### PR TITLE
Keep optional custom attributes behind the selector and pre-fill defaults on opt-in

### DIFF
--- a/src/components/Attributes/AttributeEditor/Attribute/AttributeFieldInput.spec.tsx
+++ b/src/components/Attributes/AttributeEditor/Attribute/AttributeFieldInput.spec.tsx
@@ -64,8 +64,17 @@ test.describe('AttributeFieldInput', () => {
 
         const textarea = page.locator('#testField');
         await expect(textarea).toHaveValue('Filled value');
-        // --dark-gray-color (#1f2937), the shared input text color
-        await expect(textarea).toHaveCSS('color', 'rgb(31, 41, 55)');
+        // Must match the shared input text color token, whatever its current value is —
+        // and therefore not the gray inherited from the ancestor above.
+        const tokenColor = await textarea.evaluate((el) => {
+            const probe = document.createElement('span');
+            probe.style.color = 'var(--dark-gray-color)';
+            document.body.appendChild(probe);
+            const color = getComputedStyle(probe).color;
+            probe.remove();
+            return color;
+        });
+        await expect(textarea).toHaveCSS('color', tokenColor);
     });
 
     test('renders Switch for Boolean contentType', async ({ mount, page }) => {

--- a/src/components/Attributes/AttributeEditor/Attribute/AttributeFieldInput.spec.tsx
+++ b/src/components/Attributes/AttributeEditor/Attribute/AttributeFieldInput.spec.tsx
@@ -50,6 +50,24 @@ test.describe('AttributeFieldInput', () => {
         await expect(textarea).toHaveAttribute('rows', '4');
     });
 
+    test('textarea text color does not depend on the ancestor text color', async ({ mount, page }) => {
+        const descriptor = minimalDescriptor(AttributeContentType.Text, {
+            properties: { ...defaultProperties, label: 'Description' },
+        } as any);
+        // Tailwind preflight makes form controls inherit color; without an explicit class a gray
+        // ancestor turns the value into placeholder-gray text.
+        await mount(
+            <div className="text-gray-400">
+                <AttributeFieldInputTestWrapper name="testField" descriptor={descriptor} defaultValues={{ testField: 'Filled value' }} />
+            </div>,
+        );
+
+        const textarea = page.locator('#testField');
+        await expect(textarea).toHaveValue('Filled value');
+        // --dark-gray-color (#1f2937), the shared input text color
+        await expect(textarea).toHaveCSS('color', 'rgb(31, 41, 55)');
+    });
+
     test('renders Switch for Boolean contentType', async ({ mount, page }) => {
         const descriptor = minimalDescriptor(AttributeContentType.Boolean, {
             properties: { ...defaultProperties, label: 'Enable feature' },

--- a/src/components/Attributes/AttributeEditor/Attribute/AttributeFieldInput.tsx
+++ b/src/components/Attributes/AttributeEditor/Attribute/AttributeFieldInput.tsx
@@ -1,7 +1,7 @@
 import type React from 'react';
 import { Controller, type ControllerRenderProps, useFormContext, useFormState } from 'react-hook-form';
 import Label from 'components/Label';
-import TextInput from 'components/TextInput';
+import TextInput, { inputBaseClassName } from 'components/TextInput';
 import DatePicker from 'components/DatePicker';
 import Switch from 'components/Switch';
 import Editor from 'components/Input/CodeEditor/CodeEditor';
@@ -54,10 +54,10 @@ function StandardInputControl({
     const transformed = transformInputValueForDescriptor(field.value, descriptor);
     const textValue = transformed ? String(transformed) : '';
     const validationVisible = fieldState.isTouched || submitCount > 0;
-    const inputClassName = cn(
-        'py-2.5 sm:py-3 px-4 block w-full border-gray-200 rounded-lg text-sm focus:border-blue-500 focus:ring-blue-500 disabled:opacity-50 disabled:pointer-events-none dark:bg-neutral-900 dark:border-neutral-700 dark:text-neutral-400 dark:placeholder-neutral-500 dark:focus:ring-neutral-600',
-        { 'border-red-500 focus:border-red-500 focus:ring-red-500': validationVisible && fieldState.invalid },
-    );
+    const inputClassName = cn(inputBaseClassName, {
+        'border-red-500 focus:border-red-500 focus:ring-red-500': validationVisible && fieldState.invalid,
+        'bg-[#F8FAFC]': descriptor.properties.readOnly,
+    });
 
     if (descriptor.contentType === AttributeContentType.Boolean) {
         return (

--- a/src/components/Attributes/AttributeEditor/AttributeEditorTestWrapper.tsx
+++ b/src/components/Attributes/AttributeEditor/AttributeEditorTestWrapper.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import * as ReactHookForm from 'react-hook-form';
 import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router';
@@ -20,6 +20,9 @@ export type AttributeEditorTestWrapperProps = {
     withRemoveAction?: boolean;
     preloadedState?: Record<string, unknown>;
     renderFormValues?: boolean;
+    /** Renders a button that hands AttributeEditor the same descriptors under a new identity, the way a
+     *  parent re-render or a resolved group callback does. */
+    withDescriptorRefresh?: boolean;
 };
 
 function FormValuesProbe() {
@@ -61,8 +64,14 @@ export function AttributeEditorTestWrapper({
     withRemoveAction = true,
     preloadedState,
     renderFormValues = false,
+    withDescriptorRefresh = false,
 }: Readonly<AttributeEditorTestWrapperProps>) {
     const store = useMemo(() => createMockStore(preloadedState), [preloadedState]);
+    const [refreshCount, setRefreshCount] = useState(0);
+    const currentDescriptors = useMemo(
+        () => (refreshCount === 0 ? attributeDescriptors : [...attributeDescriptors]),
+        [attributeDescriptors, refreshCount],
+    );
     const defaultValues = useMemo(
         () => ({ ...buildAttributeDefaultValues(id, attributeDescriptors, attributes) }),
         [id, attributeDescriptors, attributes],
@@ -76,7 +85,7 @@ export function AttributeEditorTestWrapper({
                 <ReactHookForm.FormProvider {...methods}>
                     <AttributeEditor
                         id={id}
-                        attributeDescriptors={attributeDescriptors}
+                        attributeDescriptors={currentDescriptors}
                         attributes={attributes}
                         groupAttributesCallbackAttributes={groupAttributesCallbackAttributes}
                         setGroupAttributesCallbackAttributes={setGroupAttributesCallbackAttributes ?? (() => {})}
@@ -85,6 +94,11 @@ export function AttributeEditorTestWrapper({
                         kind={kind}
                         withRemoveAction={withRemoveAction}
                     />
+                    {withDescriptorRefresh && (
+                        <button type="button" data-testid="refresh-descriptors" onClick={() => setRefreshCount((count) => count + 1)}>
+                            Refresh descriptors
+                        </button>
+                    )}
                     {renderFormValues && <FormValuesProbe />}
                 </ReactHookForm.FormProvider>
             </MemoryRouter>

--- a/src/components/Attributes/AttributeEditor/AttributeEditorTestWrapper.tsx
+++ b/src/components/Attributes/AttributeEditor/AttributeEditorTestWrapper.tsx
@@ -19,7 +19,13 @@ export type AttributeEditorTestWrapperProps = {
     kind?: string;
     withRemoveAction?: boolean;
     preloadedState?: Record<string, unknown>;
+    renderFormValues?: boolean;
 };
+
+function FormValuesProbe() {
+    const values = ReactHookForm.useWatch();
+    return <pre data-testid="form-values">{JSON.stringify(values)}</pre>;
+}
 
 /** Build form defaultValues so Data/Custom fields exist on first paint (before AttributeEditor effects run) */
 function buildAttributeDefaultValues(
@@ -38,17 +44,23 @@ function buildAttributeDefaultValues(
     return { [key]: inner };
 }
 
+// Stable defaults: a fresh array here would change prop identity on every wrapper render, which
+// AttributeEditor's initial effect reads as "descriptors changed" and resets user-shown attributes.
+const EMPTY_ATTRIBUTES: AttributeResponseModel[] = [];
+const EMPTY_GROUP_CALLBACK_ATTRIBUTES: AttributeDescriptorModel[] = [];
+
 export function AttributeEditorTestWrapper({
     id,
     attributeDescriptors,
-    attributes = [],
-    groupAttributesCallbackAttributes = [],
+    attributes = EMPTY_ATTRIBUTES,
+    groupAttributesCallbackAttributes = EMPTY_GROUP_CALLBACK_ATTRIBUTES,
     setGroupAttributesCallbackAttributes,
     connectorUuid,
     functionGroupCode,
     kind,
     withRemoveAction = true,
     preloadedState,
+    renderFormValues = false,
 }: Readonly<AttributeEditorTestWrapperProps>) {
     const store = useMemo(() => createMockStore(preloadedState), [preloadedState]);
     const defaultValues = useMemo(
@@ -73,6 +85,7 @@ export function AttributeEditorTestWrapper({
                         kind={kind}
                         withRemoveAction={withRemoveAction}
                     />
+                    {renderFormValues && <FormValuesProbe />}
                 </ReactHookForm.FormProvider>
             </MemoryRouter>
         </Provider>

--- a/src/components/Attributes/AttributeEditor/CustomAttributeAddSelect/index.spec.tsx
+++ b/src/components/Attributes/AttributeEditor/CustomAttributeAddSelect/index.spec.tsx
@@ -48,25 +48,33 @@ test.describe('CustomAttributeAddSelect', () => {
         expect((added[0] as { uuid: string; properties: { label: string } }).properties.label).toBe('First Attr');
     });
 
-    test('calls onAdd only for newly added options when selection grows', async ({ mount, page }) => {
+    test('closes the popover after selection so the added field below stays visible', async ({ mount, page }) => {
         const descriptors = [customDescriptor('id-1', 'One'), customDescriptor('id-2', 'Two')];
         const added: unknown[] = [];
         await mount(<CustomAttributeAddSelect attributeDescriptors={descriptors} onAdd={(attr) => added.push(attr)} />);
         await page.getByTestId('select-selectAddCustomAttribute-trigger').click();
         await page.getByRole('option', { name: 'One' }).click();
         expect(added).toHaveLength(1);
-        // Multi-select keeps popover open, click second option
+        await expect(page.getByRole('option')).toHaveCount(0);
+    });
+
+    test('allows adding another attribute by reopening', async ({ mount, page }) => {
+        const descriptors = [customDescriptor('id-1', 'One'), customDescriptor('id-2', 'Two')];
+        const added: unknown[] = [];
+        await mount(<CustomAttributeAddSelect attributeDescriptors={descriptors} onAdd={(attr) => added.push(attr)} />);
+        await page.getByTestId('select-selectAddCustomAttribute-trigger').click();
+        await page.getByRole('option', { name: 'One' }).click();
+        await page.getByTestId('select-selectAddCustomAttribute-trigger').click();
         await page.getByRole('option', { name: 'Two' }).click();
         expect(added).toHaveLength(2);
         expect((added[1] as { uuid: string }).uuid).toBe('id-2');
     });
 
-    test('handles onChange with empty values (clear)', async ({ mount, page }) => {
+    test('keeps showing the placeholder instead of the picked value', async ({ mount, page }) => {
         const descriptors = [customDescriptor('x', 'Only')];
-        const added: unknown[] = [];
-        await mount(<CustomAttributeAddSelect attributeDescriptors={descriptors} onAdd={(attr) => added.push(attr)} />);
-        // Initially nothing selected — no clear button rendered. Verify no onAdd was triggered.
-        await expect(page.getByTestId('select-selectAddCustomAttribute-clear')).toHaveCount(0);
-        expect(added).toHaveLength(0);
+        await mount(<CustomAttributeAddSelect attributeDescriptors={descriptors} onAdd={() => {}} />);
+        await page.getByTestId('select-selectAddCustomAttribute-trigger').click();
+        await page.getByRole('option', { name: 'Only' }).click();
+        await expect(page.getByTestId('select-selectAddCustomAttribute-trigger')).toContainText('Show...');
     });
 });

--- a/src/components/Attributes/AttributeEditor/CustomAttributeAddSelect/index.tsx
+++ b/src/components/Attributes/AttributeEditor/CustomAttributeAddSelect/index.tsx
@@ -38,7 +38,8 @@ export default function CustomAttributeAddSelect({ attributeDescriptors, onAdd }
                 placeholder="Show..."
                 value=""
                 onChange={(value) => {
-                    const attribute = uuidToAttributeMap.get(String(value));
+                    // Every option here carries a uuid string, so anything else is not a selection.
+                    const attribute = typeof value === 'string' ? uuidToAttributeMap.get(value) : undefined;
                     if (attribute) {
                         onAdd(attribute);
                     }

--- a/src/components/Attributes/AttributeEditor/CustomAttributeAddSelect/index.tsx
+++ b/src/components/Attributes/AttributeEditor/CustomAttributeAddSelect/index.tsx
@@ -8,8 +8,6 @@ export type Props = {
     onAdd: (attribute: CustomAttributeModel) => void;
 };
 
-const EMPTY_VALUE: { value: string | number; label: string }[] = [];
-
 export default function CustomAttributeAddSelect({ attributeDescriptors, onAdd }: Readonly<Props>) {
     const { options, uuidToAttributeMap } = useMemo(() => {
         const customAttributes = attributeDescriptors?.filter<CustomAttributeModel>((el) => isCustomAttributeModel(el)) || [];
@@ -38,16 +36,12 @@ export default function CustomAttributeAddSelect({ attributeDescriptors, onAdd }
                 id="selectAddCustomAttribute"
                 options={options}
                 placeholder="Show..."
-                isClearable
-                isMulti
-                value={EMPTY_VALUE}
-                onChange={(values) => {
-                    (values || []).forEach((selected) => {
-                        const attribute = uuidToAttributeMap.get(selected.value.toString());
-                        if (attribute) {
-                            onAdd(attribute);
-                        }
-                    });
+                value=""
+                onChange={(value) => {
+                    const attribute = uuidToAttributeMap.get(String(value));
+                    if (attribute) {
+                        onAdd(attribute);
+                    }
                 }}
             />
         </>

--- a/src/components/Attributes/AttributeEditor/index.spec.tsx
+++ b/src/components/Attributes/AttributeEditor/index.spec.tsx
@@ -155,7 +155,7 @@ test.describe('AttributeEditor', () => {
         await expect(page.getByTestId('text-input-__attributes__testEditor__.toDelete')).toHaveCount(0);
     });
 
-    test.skip('add custom attribute via CustomAttributeAddSelect', async ({ mount, page }) => {
+    test('add custom attribute via CustomAttributeAddSelect', async ({ mount, page }) => {
         const descriptors: AttributeDescriptorModel[] = [
             customDescriptor({
                 name: 'addable',
@@ -165,7 +165,8 @@ test.describe('AttributeEditor', () => {
         ];
         await mount(<AttributeEditorTestWrapper id={editorId} attributeDescriptors={descriptors} />);
         await expect(page.getByText('Show custom attribute')).toBeVisible({ timeout: 10000 });
-        await page.getByTestId('select-selectAddCustomAttribute-input').selectOption('addable-uuid', { force: true });
+        await page.getByTestId('select-selectAddCustomAttribute-trigger').click();
+        await page.getByRole('option', { name: 'Addable Custom' }).click();
         await expect(page.getByTestId('text-input-__attributes__testEditor__.addable')).toBeVisible({ timeout: 5000 });
     });
 
@@ -301,7 +302,10 @@ test.describe('AttributeEditor', () => {
         await expect(input).toBeEnabled();
     });
 
-    test('optional custom attribute with a default value is shown pre-filled instead of being hidden', async ({ mount, page }) => {
+    test('optional custom attribute with a default value stays hidden until the user opts in, then is pre-filled', async ({
+        mount,
+        page,
+    }) => {
         const descriptors: AttributeDescriptorModel[] = [
             customDescriptor({
                 name: 'customDefault',
@@ -311,12 +315,55 @@ test.describe('AttributeEditor', () => {
             }),
         ];
         await mount(<AttributeEditorTestWrapper id={editorId} attributeDescriptors={descriptors} />);
+
+        // hidden by default — optional attributes join the form only when the user asks for them
+        await expect(page.getByText('Show custom attribute')).toBeVisible({ timeout: 10000 });
         const input = page.getByTestId('text-input-__attributes__testEditor__.customDefault');
+        await expect(input).toHaveCount(0);
+
+        await page.getByTestId('select-selectAddCustomAttribute-trigger').click();
+        await page.getByRole('option', { name: 'Custom Default' }).click();
+
+        // once opted in, the configured default is pre-filled and editable
         await expect(input).toBeVisible({ timeout: 10000 });
         await expect(input).toHaveValue('customDefaultValue');
         await expect(input).toBeEnabled();
-        // it is already shown, so the selector must not offer it again
-        await expect(page.getByText('Show custom attribute')).toHaveCount(0);
+    });
+
+    test('hidden optional custom attribute default is not silently seeded into the form values', async ({ mount, page }) => {
+        const descriptors: AttributeDescriptorModel[] = [
+            customDescriptor({
+                name: 'customDefault',
+                uuid: 'custom-default-uuid',
+                properties: { label: 'Custom Default', required: false, readOnly: false, list: false, multiSelect: false } as any,
+                content: [{ data: 'customDefaultValue' }] as any,
+            }),
+        ];
+        await mount(<AttributeEditorTestWrapper id={editorId} attributeDescriptors={descriptors} renderFormValues />);
+        await expect(page.getByText('Show custom attribute')).toBeVisible({ timeout: 10000 });
+
+        // While hidden, the default must not sit in the form state — it would end up in the request payload.
+        await expect(page.getByTestId('form-values')).not.toContainText('customDefaultValue');
+
+        await page.getByTestId('select-selectAddCustomAttribute-trigger').click();
+        await page.getByRole('option', { name: 'Custom Default' }).click();
+        await expect(page.getByTestId('form-values')).toContainText('customDefaultValue', { timeout: 10000 });
+    });
+
+    test('required custom attribute with a default value is shown and pre-filled from the start', async ({ mount, page }) => {
+        const descriptors: AttributeDescriptorModel[] = [
+            customDescriptor({
+                name: 'requiredDefault',
+                uuid: 'required-default-uuid',
+                properties: { label: 'Required Default', required: true, readOnly: false, list: false, multiSelect: false } as any,
+                content: [{ data: 'requiredDefaultValue' }] as any,
+            }),
+        ];
+        await mount(<AttributeEditorTestWrapper id={editorId} attributeDescriptors={descriptors} />);
+        const input = page.getByTestId('text-input-__attributes__testEditor__.requiredDefault');
+        await expect(input).toBeVisible({ timeout: 10000 });
+        await expect(input).toHaveValue('requiredDefaultValue');
+        await expect(input).toBeEnabled();
     });
 
     test('attribute value takes precedence over the descriptor default', async ({ mount, page }) => {

--- a/src/components/Attributes/AttributeEditor/index.spec.tsx
+++ b/src/components/Attributes/AttributeEditor/index.spec.tsx
@@ -316,7 +316,6 @@ test.describe('AttributeEditor', () => {
         ];
         await mount(<AttributeEditorTestWrapper id={editorId} attributeDescriptors={descriptors} />);
 
-        // hidden by default — optional attributes join the form only when the user asks for them
         await expect(page.getByText('Show custom attribute')).toBeVisible({ timeout: 10000 });
         const input = page.getByTestId('text-input-__attributes__testEditor__.customDefault');
         await expect(input).toHaveCount(0);
@@ -324,10 +323,39 @@ test.describe('AttributeEditor', () => {
         await page.getByTestId('select-selectAddCustomAttribute-trigger').click();
         await page.getByRole('option', { name: 'Custom Default' }).click();
 
-        // once opted in, the configured default is pre-filled and editable
         await expect(input).toBeVisible({ timeout: 10000 });
         await expect(input).toHaveValue('customDefaultValue');
         await expect(input).toBeEnabled();
+    });
+
+    test('an opted-in custom attribute survives a descriptor refresh', async ({ mount, page }) => {
+        const descriptors: AttributeDescriptorModel[] = [
+            customDescriptor({
+                name: 'customDefault',
+                uuid: 'custom-default-uuid',
+                properties: { label: 'Custom Default', required: false, readOnly: false, list: false, multiSelect: false } as any,
+                content: [{ data: 'customDefaultValue' }] as any,
+            }),
+        ];
+        await mount(<AttributeEditorTestWrapper id={editorId} attributeDescriptors={descriptors} withDescriptorRefresh />);
+
+        await page.getByTestId('select-selectAddCustomAttribute-trigger').click();
+        await page.getByRole('option', { name: 'Custom Default' }).click();
+
+        const input = page.getByTestId('text-input-__attributes__testEditor__.customDefault');
+        await expect(input).toBeVisible({ timeout: 10000 });
+        // TextInput starts readonly to block autofill and drops it on focus, so click before typing.
+        await input.click();
+        await input.fill('typedValue');
+
+        await page.getByTestId('refresh-descriptors').click();
+        // Let React flush the effects the refresh schedules, otherwise the assertions below pass on the
+        // pre-refresh render and the test would never see the field disappear.
+        await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve(null)))));
+
+        // The field must not vanish — its value stays in the form state and would be submitted invisibly.
+        await expect(input).toBeVisible();
+        await expect(input).toHaveValue('typedValue');
     });
 
     test('hidden optional custom attribute default is not silently seeded into the form values', async ({ mount, page }) => {

--- a/src/components/Attributes/AttributeEditor/index.tsx
+++ b/src/components/Attributes/AttributeEditor/index.tsx
@@ -80,16 +80,6 @@ const contentItemLabel = (value: { reference?: string; data?: unknown } | null |
     return String(data);
 };
 
-/**
- * A descriptor carries a configured default value when it holds content and is neither a list nor a
- * RESOURCE — for those `content` is the set of selectable options, not a value to pre-fill.
- */
-const hasDefaultValue = (descriptor: CustomAttributeModel): boolean =>
-    !descriptor.properties.list &&
-    descriptor.contentType !== AttributeContentType.Resource &&
-    Array.isArray(descriptor.content) &&
-    descriptor.content.length > 0;
-
 export type Props = {
     id: string;
     attributeDescriptors: AttributeDescriptorModel[];
@@ -398,15 +388,16 @@ function AttributeEditorInner({
     /* c8 ignore stop */
 
     /*
-     * Get non-required custom attributes, without a value assigned and without a default value.
-     * An attribute with a default value is rendered right away so its default is visible and editable.
+     * Get non-required custom attributes, without a value assigned. They stay behind the
+     * "Show custom attribute" selector even when the descriptor carries a default value — the user
+     * opts in per attribute, and only then the default is pre-filled (see Issue: #1906).
      */
     const initiallyHiddenCustomAttributeDescriptors = useMemo(
         () =>
             attributeDescriptors.filter((descriptor) => {
                 if (isCustomAttributeModel(descriptor)) {
                     const attribute = attributes.find((el) => el.name === descriptor.name);
-                    return !descriptor.properties.required && !attribute?.content && !hasDefaultValue(descriptor);
+                    return !descriptor.properties.required && !attribute?.content;
                 }
                 return false;
             }),
@@ -784,9 +775,7 @@ function AttributeEditorInner({
         setPrevAttributes(attributes);
         setShownCustomAttributes(
             attributeDescriptors.filter(
-                (descriptor) =>
-                    isCustomAttributeModel(descriptor) &&
-                    (attributes.some((attr) => attr.uuid === descriptor.uuid) || hasDefaultValue(descriptor)),
+                (descriptor) => isCustomAttributeModel(descriptor) && attributes.some((attr) => attr.uuid === descriptor.uuid),
             ),
         );
 
@@ -796,6 +785,10 @@ function AttributeEditorInner({
 
                 // Skip if this attribute was deleted
                 if (deletedAttributes.includes(descriptor.name)) {
+                    return;
+                }
+
+                if (initiallyHiddenCustomAttributeDescriptors.some((el) => el.uuid === descriptor.uuid)) {
                     return;
                 }
 
@@ -840,6 +833,7 @@ function AttributeEditorInner({
         getAttributeStaticOptions,
         deletedAttributes,
         reAddedAttributes,
+        initiallyHiddenCustomAttributeDescriptors,
     ]);
 
     /**

--- a/src/components/Attributes/AttributeEditor/index.tsx
+++ b/src/components/Attributes/AttributeEditor/index.tsx
@@ -773,11 +773,15 @@ function AttributeEditorInner({
         setPrevGroupDescriptors(groupAttributesCallbackAttributes);
         setPrevDescriptors(attributeDescriptors);
         setPrevAttributes(attributes);
-        setShownCustomAttributes(
-            attributeDescriptors.filter(
-                (descriptor) => isCustomAttributeModel(descriptor) && attributes.some((attr) => attr.uuid === descriptor.uuid),
-            ),
-        );
+        setShownCustomAttributes((prev) => {
+            const next = attributeDescriptors.filter(
+                (descriptor) =>
+                    isCustomAttributeModel(descriptor) &&
+                    (attributes.some((attr) => attr.uuid === descriptor.uuid) || prev.some((el) => el.uuid === descriptor.uuid)),
+            );
+            const unchanged = next.length === prev.length && next.every((descriptor, index) => descriptor.uuid === prev[index].uuid);
+            return unchanged ? prev : next;
+        });
 
         descriptorsToLoad.forEach((descriptor) => {
             if (isDataAttributeModel(descriptor) || isGroupAttributeModel(descriptor) || isCustomAttributeModel(descriptor)) {


### PR DESCRIPTION
Fixes #1906