### PR TITLE
Build preview Docker images via the shared reusable workflow

### DIFF
--- a/.github/workflows/build_preview_docker.yml
+++ b/.github/workflows/build_preview_docker.yml
@@ -12,20 +12,21 @@ on:
 # What appears in the Actions list
 run-name: >-
   Docker Preview • PR #${{ inputs.pr_number }}
-  • ${{ inputs.head_repo }}@${{ inputs.head_branch }}
+  • ${{ inputs.head_repo }}@${{ inputs.head_branch }} → ${{ inputs.base_ref }}
   • ${{ inputs.head_sha }}
+
+# Superseding an earlier run cancels it. finalize_check still reports, because
+# always() also covers cancellation, so the stale commit's check is closed as
+# cancelled rather than left at in_progress.
+concurrency:
+  group: preview-pr-${{ inputs.pr_number }}-docker
+  cancel-in-progress: true
 
 permissions: {}
 
-env:
-  REGISTRY: harbor.3key.company
-  IMAGE: harbor.3key.company/ilm/frontend-administrator
-  PREVIEW_TAG: pr-${{ inputs.pr_number }}-${{ inputs.head_sha }}
-  # cache scope so both jobs share the same cache namespace
-  CACHE_SCOPE: ilm-fe-admin-preview
-
 jobs:
-  # Create the GitHub check once, and reuse the check_id in other jobs
+  # A dispatched run does not attach to the PR on its own, so the build reports
+  # through a check created against the head commit.
   create_check:
     name: Create GitHub Check
     runs-on: ubuntu-latest
@@ -33,22 +34,6 @@ jobs:
     outputs:
       check_id: ${{ steps.create_check.outputs.check_id }}
     steps:
-      - name: Export context
-        env:
-          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
-          INPUT_HEAD_SHA: ${{ inputs.head_sha }}
-          INPUT_HEAD_REPO: ${{ inputs.head_repo }}
-          INPUT_HEAD_BRANCH: ${{ inputs.head_branch }}
-          INPUT_BASE_REF: ${{ inputs.base_ref }}
-        run: |
-          {
-            echo "PR_NUMBER=${INPUT_PR_NUMBER}"
-            echo "HEAD_SHA=${INPUT_HEAD_SHA}"
-            echo "HEAD_REPO=${INPUT_HEAD_REPO}"
-            echo "PR_BRANCH=${INPUT_HEAD_BRANCH}"
-            echo "BASE_BRANCH=${INPUT_BASE_REF}"
-          } >> "$GITHUB_ENV"
-
       - name: Generate token
         id: app_token
         uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
@@ -59,199 +44,52 @@ jobs:
       - name: Create GitHub Check (in_progress)
         id: create_check
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          HEAD_SHA: ${{ inputs.head_sha }}
         with:
           github-token: ${{ steps.app_token.outputs.token }}
           script: |
             const check = await github.rest.checks.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              name: `Docker preview build`,
+              name: "Docker preview build",
               head_sha: process.env.HEAD_SHA,
               status: "in_progress"
             });
             core.setOutput("check_id", check.data.id);
 
-  build_amd64:
-    name: Build amd64 • PR #${{ inputs.pr_number }}
-    runs-on: ubuntu-latest
+  build:
+    name: Build & push preview image
     needs: [create_check]
     permissions:
       contents: read
-    outputs:
-      digest: ${{ steps.build.outputs.digest }}
+    # Deliberately unpinned: this is a first-party OmniTrustILM reusable workflow
+    # and edits to it are meant to reach every repo without a bump here.
+    uses: OmniTrustILM/.github/.github/workflows/containers-build-and-push.yml@main
+    secrets:
+      CONTAINER_REGISTRY_USERNAME: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
+      CONTAINER_REGISTRY_PASSWORD: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}
+    with:
+      image: ilm-preview/frontend-administrator
+      cache-scope: frontend-administrator-preview
+      # Pinning the commit rather than the branch keeps the published tag
+      # honest when a push lands mid-run. A fork commit resolves here because
+      # fork objects live in this repository's network.
+      ref: ${{ inputs.head_sha }}
+      # A preview is not a release: it carries no signature, and its checkout is
+      # a fork branch rather than the canonical README.
+      sign: false
+      push-readme: false
+      # Replaces the default rules, which would otherwise publish rolling
+      # develop-latest and develop-<sha> tags onto the preview path.
+      tag-rules: type=raw,value=pr-${{ inputs.pr_number }}-${{ inputs.head_sha }}
 
-    steps:
-      - name: Export context
-        env:
-          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
-          INPUT_HEAD_SHA: ${{ inputs.head_sha }}
-          INPUT_HEAD_REPO: ${{ inputs.head_repo }}
-          INPUT_HEAD_BRANCH: ${{ inputs.head_branch }}
-          INPUT_BASE_REF: ${{ inputs.base_ref }}
-        run: |
-          {
-            echo "PR_NUMBER=${INPUT_PR_NUMBER}"
-            echo "HEAD_SHA=${INPUT_HEAD_SHA}"
-            echo "HEAD_REPO=${INPUT_HEAD_REPO}"
-            echo "PR_BRANCH=${INPUT_HEAD_BRANCH}"
-            echo "BASE_BRANCH=${INPUT_BASE_REF}"
-          } >> "$GITHUB_ENV"
-
-      # Checkout fork PR branch + fetch base to compute diff
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
-        with:
-          repository: ${{ env.HEAD_REPO }}
-          ref: ${{ env.PR_BRANCH }}
-          fetch-depth: 0
-
-      - name: Fetch base branch
-        run: |
-          git remote add upstream ${{ github.event.repository.clone_url }}
-          git fetch upstream $BASE_BRANCH
-          git checkout -B "$BASE_BRANCH" "upstream/$BASE_BRANCH"
-          git checkout "$PR_BRANCH"
-          git clean -ffdx && git reset --hard HEAD
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
-
-      - name: Log in to Harbor
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.HARBOR_3KEY_USERNAME }}
-          password: ${{ secrets.HARBOR_3KEY_PASSWORD }}
-
-      - name: Build + push (amd64) by digest only (no tags)
-        id: build
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/amd64
-          # Push without creating an extra tag
-          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=${{ env.CACHE_SCOPE }}
-          cache-to: type=gha,mode=max,scope=${{ env.CACHE_SCOPE }}
-
-  build_arm64:
-    name: Build arm64 • PR #${{ inputs.pr_number }}
-    runs-on: ubuntu-24.04-arm
-    needs: [create_check]
-    permissions:
-      contents: read
-    outputs:
-      digest: ${{ steps.build.outputs.digest }}
-    steps:
-      - name: Export context
-        env:
-          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
-          INPUT_HEAD_SHA: ${{ inputs.head_sha }}
-          INPUT_HEAD_REPO: ${{ inputs.head_repo }}
-          INPUT_HEAD_BRANCH: ${{ inputs.head_branch }}
-          INPUT_BASE_REF: ${{ inputs.base_ref }}
-        run: |
-          {
-            echo "PR_NUMBER=${INPUT_PR_NUMBER}"
-            echo "HEAD_SHA=${INPUT_HEAD_SHA}"
-            echo "HEAD_REPO=${INPUT_HEAD_REPO}"
-            echo "PR_BRANCH=${INPUT_HEAD_BRANCH}"
-            echo "BASE_BRANCH=${INPUT_BASE_REF}"
-          } >> "$GITHUB_ENV"
-
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
-        with:
-          repository: ${{ env.HEAD_REPO }}
-          ref: ${{ env.PR_BRANCH }}
-          fetch-depth: 0
-
-      - name: Fetch base branch
-        run: |
-          git remote add upstream ${{ github.event.repository.clone_url }}
-          git fetch upstream $BASE_BRANCH
-          git checkout -B "$BASE_BRANCH" "upstream/$BASE_BRANCH"
-          git checkout "$PR_BRANCH"
-          git clean -ffdx && git reset --hard HEAD
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
-
-      - name: Log in to Harbor
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.HARBOR_3KEY_USERNAME }}
-          password: ${{ secrets.HARBOR_3KEY_PASSWORD }}
-
-      - name: Build + push (arm64) by digest only (no tags)
-        id: build
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/arm64
-          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=${{ env.CACHE_SCOPE }}
-          cache-to: type=gha,mode=max,scope=${{ env.CACHE_SCOPE }}
-
-  publish_manifest:
-    name: Publish multiarch manifest • PR #${{ inputs.pr_number }}
+  finalize_check:
+    name: Finalize GitHub Check
     runs-on: ubuntu-latest
-    needs: [create_check, build_amd64, build_arm64]
+    needs: [create_check, build]
     permissions: {}
-    steps:
-      - name: Log in to Harbor
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.HARBOR_3KEY_USERNAME }}
-          password: ${{ secrets.HARBOR_3KEY_PASSWORD }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
-
-      - name: Create + push multiarch manifest (single tag)
-        run: |
-          AMD_DIGEST="${{ needs.build_amd64.outputs.digest }}"
-          ARM_DIGEST="${{ needs.build_arm64.outputs.digest }}"
-
-          echo "amd64 digest: ${AMD_DIGEST}"
-          echo "arm64 digest: ${ARM_DIGEST}"
-
-          docker buildx imagetools create \
-            --tag "${IMAGE}:${PREVIEW_TAG}" \
-            "${IMAGE}@${AMD_DIGEST}" \
-            "${IMAGE}@${ARM_DIGEST}"
-
-          docker buildx imagetools inspect "${IMAGE}:${PREVIEW_TAG}"
-
-      - name: Generate token (for check update)
-        id: app_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
-        with:
-          app_id: ${{ secrets.SONAR_GH_APP_ID }}
-          private_key: ${{ secrets.SONAR_GH_APP_PRIVATE_KEY }}
-
-      - name: Mark GitHub Check as success
-        if: success()
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          github-token: ${{ steps.app_token.outputs.token }}
-          script: |
-            await github.rest.checks.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              check_run_id: Number("${{ needs.create_check.outputs.check_id }}"),
-              status: "completed",
-              conclusion: "success"
-            });
-
-  finalize_check_failure:
-    name: Finalize Check (failure)
-    runs-on: ubuntu-latest
-    needs: [create_check, build_amd64, build_arm64, publish_manifest]
-    permissions: {}
-    if: failure()
+    if: ${{ always() && needs.create_check.result == 'success' }}
     steps:
       - name: Generate token
         id: app_token
@@ -260,15 +98,22 @@ jobs:
           app_id: ${{ secrets.SONAR_GH_APP_ID }}
           private_key: ${{ secrets.SONAR_GH_APP_PRIVATE_KEY }}
 
-      - name: Mark GitHub Check as failure
+      - name: Report the build result on the check
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          CHECK_ID: ${{ needs.create_check.outputs.check_id }}
+          BUILD_RESULT: ${{ needs.build.result }}
         with:
           github-token: ${{ steps.app_token.outputs.token }}
           script: |
+            const result = process.env.BUILD_RESULT;
+            const conclusion =
+              result === "success" ? "success" : result === "cancelled" ? "cancelled" : "failure";
+
             await github.rest.checks.update({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              check_run_id: Number("${{ needs.create_check.outputs.check_id }}"),
+              check_run_id: Number(process.env.CHECK_ID),
               status: "completed",
-              conclusion: "failure"
+              conclusion
             });

--- a/.github/workflows/dispatch-preview-docker.yml
+++ b/.github/workflows/dispatch-preview-docker.yml
@@ -26,26 +26,37 @@ jobs:
         id: ctx
         run: |
           cat pr_context/pr-context.json
-          echo "pr_number=$(jq -r '.pr_number' pr_context/pr-context.json)" >> $GITHUB_OUTPUT
-          echo "head_sha=$(jq -r '.head_sha' pr_context/pr-context.json)" >> $GITHUB_OUTPUT
-          echo "head_repo=$(jq -r '.head_repo' pr_context/pr-context.json)" >> $GITHUB_OUTPUT
-          echo "head_branch=$(jq -r '.head_branch' pr_context/pr-context.json)" >> $GITHUB_OUTPUT
-          echo "base_ref=$(jq -r '.base_ref' pr_context/pr-context.json)" >> $GITHUB_OUTPUT
+          {
+            echo "pr_number=$(jq -r '.pr_number' pr_context/pr-context.json)"
+            echo "head_sha=$(jq -r '.head_sha' pr_context/pr-context.json)"
+            echo "head_repo=$(jq -r '.head_repo' pr_context/pr-context.json)"
+            echo "head_branch=$(jq -r '.head_branch' pr_context/pr-context.json)"
+            echo "base_ref=$(jq -r '.base_ref' pr_context/pr-context.json)"
+          } >> "$GITHUB_OUTPUT"
 
+      # The PR context comes from a fork, so every value is read from the
+      # environment. Interpolating it into the script body would let a branch
+      # name containing a quote execute arbitrary code with this token.
       - name: Dispatch build preview docker workflow with inputs
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ steps.ctx.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.ctx.outputs.head_sha }}
+          HEAD_REPO: ${{ steps.ctx.outputs.head_repo }}
+          HEAD_BRANCH: ${{ steps.ctx.outputs.head_branch }}
+          BASE_REF: ${{ steps.ctx.outputs.base_ref }}
         with:
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'build_preview_docker.yml',
-              ref: '${{ steps.ctx.outputs.base_ref }}',
+              ref: process.env.BASE_REF,
               inputs: {
-                pr_number:  '${{ steps.ctx.outputs.pr_number }}',
-                head_sha:   '${{ steps.ctx.outputs.head_sha }}',
-                head_repo:  '${{ steps.ctx.outputs.head_repo }}',
-                head_branch:'${{ steps.ctx.outputs.head_branch }}',
-                base_ref:   '${{ steps.ctx.outputs.base_ref }}'
+                pr_number: process.env.PR_NUMBER,
+                head_sha: process.env.HEAD_SHA,
+                head_repo: process.env.HEAD_REPO,
+                head_branch: process.env.HEAD_BRANCH,
+                base_ref: process.env.BASE_REF
               }
             });

--- a/.github/workflows/dispatch-sonar.yml
+++ b/.github/workflows/dispatch-sonar.yml
@@ -26,26 +26,37 @@ jobs:
         id: ctx
         run: |
           cat pr_context/pr-context.json
-          echo "pr_number=$(jq -r '.pr_number' pr_context/pr-context.json)" >> $GITHUB_OUTPUT
-          echo "head_sha=$(jq -r '.head_sha' pr_context/pr-context.json)" >> $GITHUB_OUTPUT
-          echo "head_repo=$(jq -r '.head_repo' pr_context/pr-context.json)" >> $GITHUB_OUTPUT
-          echo "head_branch=$(jq -r '.head_branch' pr_context/pr-context.json)" >> $GITHUB_OUTPUT
-          echo "base_ref=$(jq -r '.base_ref' pr_context/pr-context.json)" >> $GITHUB_OUTPUT
+          {
+            echo "pr_number=$(jq -r '.pr_number' pr_context/pr-context.json)"
+            echo "head_sha=$(jq -r '.head_sha' pr_context/pr-context.json)"
+            echo "head_repo=$(jq -r '.head_repo' pr_context/pr-context.json)"
+            echo "head_branch=$(jq -r '.head_branch' pr_context/pr-context.json)"
+            echo "base_ref=$(jq -r '.base_ref' pr_context/pr-context.json)"
+          } >> "$GITHUB_OUTPUT"
 
+      # The PR context comes from a fork, so every value is read from the
+      # environment. Interpolating it into the script body would let a branch
+      # name containing a quote execute arbitrary code with this token.
       - name: Dispatch Sonar workflow with inputs
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ steps.ctx.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.ctx.outputs.head_sha }}
+          HEAD_REPO: ${{ steps.ctx.outputs.head_repo }}
+          HEAD_BRANCH: ${{ steps.ctx.outputs.head_branch }}
+          BASE_REF: ${{ steps.ctx.outputs.base_ref }}
         with:
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'sonar.yml',
-              ref: '${{ steps.ctx.outputs.base_ref }}',
+              ref: process.env.BASE_REF,
               inputs: {
-                pr_number:  '${{ steps.ctx.outputs.pr_number }}',
-                head_sha:   '${{ steps.ctx.outputs.head_sha }}',
-                head_repo:  '${{ steps.ctx.outputs.head_repo }}',
-                head_branch:'${{ steps.ctx.outputs.head_branch }}',
-                base_ref:   '${{ steps.ctx.outputs.base_ref }}'
+                pr_number: process.env.PR_NUMBER,
+                head_sha: process.env.HEAD_SHA,
+                head_repo: process.env.HEAD_REPO,
+                head_branch: process.env.HEAD_BRANCH,
+                base_ref: process.env.BASE_REF
               }
             });

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,7 +193,48 @@ Biome enforces linting and formatting: 4-space indent, 140-char line width, sing
 ## Git & Pull Requests
 
 - Do NOT put a PR number or issue number in the PR title. Describe the change itself. (Referencing the issue in the PR body, e.g. "Closes #NNNN", is fine.)
-- Do NOT write a PR description/body — Copilot generates it automatically. Create PRs with the title only (and, if needed, a short issue reference like "Closes #NNNN"); leave the body empty otherwise.
+- DO write the PR description by hand. Describe only what the change does, factual and properly markdown formatted. No AI or assistant attribution, no follow-up/task/plan sections, and no unrelated context such as links to other pull requests. An empty body stays empty — nothing backfills it.
+
+## CI Workflows
+
+Container builds call first-party reusable workflows from `OmniTrustILM/.github`, referenced as
+`@main` on purpose: edits there are meant to reach every repo without a version bump here.
+
+| Workflow | Trigger | Reusable workflow | Result |
+|---|---|---|---|
+| `publish_docker.yaml` | push to `main`, tags | `containers-build-and-push.yml` | `ilm/frontend-administrator` |
+| `test_docker_image.yaml` | pull request | `containers-test.yml` | builds and scans, pushes nothing |
+| `build_preview_docker.yml` | `workflow_dispatch` | `containers-build-and-push.yml` | `ilm-preview/frontend-administrator` |
+
+### Preview image pipeline
+
+A preview image cannot be built on `pull_request`, because a fork PR has no access to registry
+credentials. Three workflows relay the context instead:
+
+1. `prepare_preview.yml` — `pull_request`, gated on the `preview` label. Writes `pr-context.json`
+   (`pr_number`, `head_sha`, `head_repo`, `head_branch`, `base_ref`) as an artifact.
+2. `dispatch-preview-docker.yml` — `workflow_run` on the above. Has secrets, reads the artifact, and
+   dispatches the build on `base_ref`.
+3. `build_preview_docker.yml` — `workflow_dispatch`. Calls the reusable workflow with
+   `ref: <head_sha>`, and reports a `Docker preview build` check against that commit because a
+   dispatched run does not attach to the PR on its own.
+
+`dispatch-sonar.yml` consumes the same `pr-context.json` to drive `sonar.yml`, so changing what
+`prepare_preview.yml` writes affects both paths.
+
+Passing the head SHA works for a fork PR because fork objects live in this repository's network, so
+`actions/checkout` resolves them without a `repository` override. Pinning the commit rather than the
+branch also keeps the published tag honest when a push lands mid-run.
+
+The preview call passes `sign: false` and `push-readme: false`: a preview is not a release, so it
+carries no cosign signature and must not overwrite the registry README from a fork branch. It also
+overrides `tag-rules` with a single `pr-<number>-<sha>` tag, because the default rules would publish
+rolling `develop-latest` and `develop-<sha>` tags onto the preview path.
+
+Trivy gates the preview build under the org-default policy. Per-architecture images are pushed by
+digest before the scan runs, so a PR introducing a CRITICAL or HIGH vulnerability still leaves those
+digests in the registry — but no `pr-<number>-<sha>` tag or multiarch manifest is published.
+`test_docker_image.yaml` already fails that same PR.
 
 ## Environment Variables (Runtime)
 


### PR DESCRIPTION
Replaces the hand-rolled preview build with a call to the shared
`containers-build-and-push.yml`. Preview images move to `ilm-preview/frontend-administrator` on
`hub.omnitrustregistry.com`, keeping the existing `pr-<number>-<sha>` tag shape.

The workflow drops from roughly 270 lines to three jobs: create the check, call the reusable
workflow, report the result.

- `ref: <head_sha>` pins the exact commit being built.
- `sign: false` and `push-readme: false`, so a preview carries no cosign signature and does not
  overwrite the registry README.
- `tag-rules` is overridden with a single raw tag, replacing the default rolling `develop-latest`
  and `develop-<sha>` rules.
- The `fetch-depth: 0` checkout and base-branch fetch are removed. Nothing consumed that history:
  the Dockerfile builds from copied sources and reads no git metadata.

Both dispatchers read the fork-supplied PR context from the environment instead of interpolating it
into the `github-script` body, where a branch name containing a quote could execute arbitrary code
with the workflow's token.

`CLAUDE.md` documents the container workflows and the preview pipeline, and its PR description rule
is corrected.
