### PR TITLE
Pin the preview build's reusable workflow to a commit SHA

### DIFF
--- a/.github/workflows/build_preview_docker.yml
+++ b/.github/workflows/build_preview_docker.yml
@@ -63,9 +63,10 @@ jobs:
     needs: [create_check]
     permissions:
       contents: read
-    # Deliberately unpinned: this is a first-party OmniTrustILM reusable workflow
-    # and edits to it are meant to reach every repo without a bump here.
-    uses: OmniTrustILM/.github/.github/workflows/containers-build-and-push.yml@main
+    # Pinned to a reviewed commit of the first-party OmniTrustILM reusable
+    # workflow. The trailing comment names the branch the digest was taken from,
+    # so Renovate can bump it as that branch moves.
+    uses: OmniTrustILM/.github/.github/workflows/containers-build-and-push.yml@e876e0027156a8e84cec4d581449c78bf281d01b # main
     secrets:
       CONTAINER_REGISTRY_USERNAME: ${{ secrets.CONTAINER_REGISTRY_USERNAME }}
       CONTAINER_REGISTRY_PASSWORD: ${{ secrets.CONTAINER_REGISTRY_PASSWORD }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,8 +197,12 @@ Biome enforces linting and formatting: 4-space indent, 140-char line width, sing
 
 ## CI Workflows
 
-Container builds call first-party reusable workflows from `OmniTrustILM/.github`, referenced as
-`@main` on purpose: edits there are meant to reach every repo without a version bump here.
+Container builds call first-party reusable workflows from `OmniTrustILM/.github`. `publish_docker.yaml`
+and `test_docker_image.yaml` reference them as `@main` on purpose: edits there are meant to reach every
+repo without a version bump here. `build_preview_docker.yml` is the exception — it is pinned to a commit
+SHA with a trailing `# main` comment, because it is the only container workflow that runs against a fork
+head with registry credentials, so its reusable workflow has to be a reviewed revision rather than
+whatever `main` points at. Renovate bumps the digest.
 
 | Workflow | Trigger | Reusable workflow | Result |
 |---|---|---|---|


### PR DESCRIPTION
`build_preview_docker.yml` called `OmniTrustILM/.github/.github/workflows/containers-build-and-push.yml@main`. This pins that call to `e876e0027156a8e84cec4d581449c78bf281d01b`, the current head of `main`, with a trailing `# main` comment so Renovate can bump the digest.

This is the only container workflow that builds a fork PR head with registry credentials, so its reusable workflow now resolves to a reviewed revision rather than whatever `main` points at when the build is dispatched.

All six inputs the caller passes (`image`, `cache-scope`, `ref`, `sign`, `push-readme`, `tag-rules`) and both `CONTAINER_REGISTRY_*` secrets are present in the reusable workflow at the pinned commit.

`publish_docker.yaml` and `test_docker_image.yaml` keep their `@main` references. The CI section of `CLAUDE.md` is updated to record the split.