### PR TITLE
Validate preview authorization and reliably finalize build checks

### DIFF
--- a/.github/workflows/build_preview_docker.yml
+++ b/.github/workflows/build_preview_docker.yml
@@ -9,15 +9,13 @@ on:
       head_branch: { description: "Fork branch", required: true }
       base_ref:    { description: "Base branch", required: true }
 
-# What appears in the Actions list
 run-name: >-
   Docker Preview • PR #${{ inputs.pr_number }}
   • ${{ inputs.head_repo }}@${{ inputs.head_branch }} → ${{ inputs.base_ref }}
   • ${{ inputs.head_sha }}
 
-# Superseding an earlier run cancels it. finalize_check still reports, because
-# always() also covers cancellation, so the stale commit's check is closed as
-# cancelled rather than left at in_progress.
+# Superseding an earlier run cancels it, and finalize_check closes the stale
+# commit's check as cancelled rather than leaving it at in_progress.
 concurrency:
   group: preview-pr-${{ inputs.pr_number }}-docker
   cancel-in-progress: true
@@ -89,7 +87,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: [create_check, build]
     permissions: {}
-    if: ${{ always() && needs.create_check.result == 'success' }}
+    # Keyed on the check id rather than on create_check's conclusion, which reads
+    # 'cancelled' or 'failure' in exactly the cases where a created check still
+    # needs closing. The id is recorded a round trip after the check exists, so a
+    # run cancelled inside that window strands its check on the superseded commit.
+    # The current commit always gets a fresh check either way.
+    if: ${{ always() && needs.create_check.outputs.check_id != '' }}
     steps:
       - name: Generate token
         id: app_token
@@ -102,13 +105,26 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           CHECK_ID: ${{ needs.create_check.outputs.check_id }}
+          CREATE_RESULT: ${{ needs.create_check.result }}
           BUILD_RESULT: ${{ needs.build.result }}
         with:
           github-token: ${{ steps.app_token.outputs.token }}
           script: |
-            const result = process.env.BUILD_RESULT;
-            const conclusion =
-              result === "success" ? "success" : result === "cancelled" ? "cancelled" : "failure";
+            const build = process.env.BUILD_RESULT;
+            const create = process.env.CREATE_RESULT;
+
+            // The build is skipped whenever create_check did not succeed, so the
+            // check reports that job's outcome instead. create_check can fail
+            // after emitting the check id, because the token action revokes the
+            // token in a post step.
+            let conclusion;
+            if (build === "success") {
+              conclusion = "success";
+            } else if (build === "cancelled" || create === "cancelled") {
+              conclusion = "cancelled";
+            } else {
+              conclusion = "failure";
+            }
 
             await github.rest.checks.update({
               owner: context.repo.owner,

--- a/.github/workflows/dispatch-preview-docker.yml
+++ b/.github/workflows/dispatch-preview-docker.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   actions: write # download artifact + create workflow dispatch
   contents: read
+  pull-requests: read # re-read the PR to confirm the preview label
 
 jobs:
   dispatch:
@@ -22,36 +23,107 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract inputs
+      # A pull_request run executes the workflow file from the PR head, so a fork
+      # authors the job that writes this artifact and controls every value in it.
+      # Only the PR number is taken from here, and the step below binds the PR it
+      # names to this run's own head before any build input is exported.
+      - name: Read the PR number from the artifact
         id: ctx
         run: |
-          cat pr_context/pr-context.json
-          {
-            echo "pr_number=$(jq -r '.pr_number' pr_context/pr-context.json)"
-            echo "head_sha=$(jq -r '.head_sha' pr_context/pr-context.json)"
-            echo "head_repo=$(jq -r '.head_repo' pr_context/pr-context.json)"
-            echo "head_branch=$(jq -r '.head_branch' pr_context/pr-context.json)"
-            echo "base_ref=$(jq -r '.base_ref' pr_context/pr-context.json)"
-          } >> "$GITHUB_OUTPUT"
+          pr_number="$(jq -r '.pr_number' pr_context/pr-context.json)"
+          if ! [[ "$pr_number" =~ ^[0-9]+$ ]]; then
+            echo "::error::pr_number in pr-context.json is not a number"
+            exit 1
+          fi
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
 
-      # The PR context comes from a fork, so every value is read from the
-      # environment. Interpolating it into the script body would let a branch
-      # name containing a quote execute arbitrary code with this token.
-      - name: Dispatch build preview docker workflow with inputs
+      # The label is the authorisation to build and publish fork-authored code
+      # with this repository's credentials, so it is confirmed against the API
+      # rather than against the artifact, which the fork wrote. Every build input
+      # is taken from the same response for the same reason.
+      - name: Resolve the PR and confirm the preview label
+        id: pr
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PR_NUMBER: ${{ steps.ctx.outputs.pr_number }}
-          HEAD_SHA: ${{ steps.ctx.outputs.head_sha }}
-          HEAD_REPO: ${{ steps.ctx.outputs.head_repo }}
-          HEAD_BRANCH: ${{ steps.ctx.outputs.head_branch }}
-          BASE_REF: ${{ steps.ctx.outputs.base_ref }}
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: Number(process.env.PR_NUMBER)
+            });
+
+            if (pr.state !== "open") {
+              core.setFailed(`PR #${pr.number} is ${pr.state}; refusing to build a preview.`);
+              return;
+            }
+            if (!pr.labels.some(label => label.name === "preview")) {
+              core.setFailed(`PR #${pr.number} does not carry the preview label; refusing to build a preview.`);
+              return;
+            }
+            // Null once the fork is deleted, which would otherwise surface as an
+            // opaque 422 from the dispatch call below.
+            if (!pr.head.repo) {
+              core.setFailed(`PR #${pr.number} has no head repository; the fork was probably deleted.`);
+              return;
+            }
+
+            // Bind the PR to the run that asked for the build. The number came from
+            // the fork-written artifact, so without this a fork could name any
+            // labelled PR and drive its builds: the concurrency group is keyed on
+            // the PR number, so repeated dispatches would cancel that PR's own
+            // preview builds. The workflow_run payload is GitHub's, not the fork's.
+            const run = context.payload.workflow_run;
+            if (pr.head.repo.full_name !== run.head_repository.full_name ||
+                pr.head.ref !== run.head_branch) {
+              core.setFailed(
+                `PR #${pr.number} is ${pr.head.repo.full_name}@${pr.head.ref}, but this run is ` +
+                `${run.head_repository.full_name}@${run.head_branch}; refusing to build another PR.`
+              );
+              return;
+            }
+
+            // The branch moved on while this relay was in flight. The push that
+            // moved it starts its own run, so this one has nothing left to do.
+            if (pr.head.sha !== run.head_sha) {
+              core.notice(
+                `PR #${pr.number} has moved from ${run.head_sha} to ${pr.head.sha}; a newer run will build it.`
+              );
+              core.setOutput("dispatch", "false");
+              return;
+            }
+
+            core.setOutput("dispatch", "true");
+            core.setOutput("pr_number", String(pr.number));
+            core.setOutput("head_sha", pr.head.sha);
+            core.setOutput("head_repo", pr.head.repo.full_name);
+            core.setOutput("head_branch", pr.head.ref);
+            core.setOutput("base_ref", pr.base.ref);
+
+      # A branch name may legally contain a quote or a backtick, so PR-derived
+      # values reach the script through the environment. Interpolating them into
+      # the body would let a crafted name execute with this token.
+      - name: Dispatch build preview docker workflow with inputs
+        if: ${{ steps.pr.outputs.dispatch == 'true' }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          HEAD_REPO: ${{ steps.pr.outputs.head_repo }}
+          HEAD_BRANCH: ${{ steps.pr.outputs.head_branch }}
+          BASE_REF: ${{ steps.pr.outputs.base_ref }}
         with:
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'build_preview_docker.yml',
-              ref: process.env.BASE_REF,
+              // The build workflow always comes from the default branch. Using the
+              // PR's base branch would run whatever branch-local copy it happens to
+              // carry, or fail outright on a release or hotfix branch that has none.
+              // base_ref stays an input, as build metadata.
+              ref: context.payload.repository.default_branch,
               inputs: {
                 pr_number: process.env.PR_NUMBER,
                 head_sha: process.env.HEAD_SHA,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,9 +212,15 @@ A preview image cannot be built on `pull_request`, because a fork PR has no acce
 credentials. Three workflows relay the context instead:
 
 1. `prepare_preview.yml` — `pull_request`, gated on the `preview` label. Writes `pr-context.json`
-   (`pr_number`, `head_sha`, `head_repo`, `head_branch`, `base_ref`) as an artifact.
-2. `dispatch-preview-docker.yml` — `workflow_run` on the above. Has secrets, reads the artifact, and
-   dispatches the build on `base_ref`.
+   (`pr_number`, `head_sha`, `head_repo`, `head_branch`, `base_ref`) as an artifact. A fork PR runs
+   this file from its own head, so the gate here is an optimisation, not the authorisation.
+2. `dispatch-preview-docker.yml` — `workflow_run` on the above. Has secrets, and carries the
+   authorisation. It accepts only `pr_number` from the artifact, then re-reads the PR through the
+   API: the PR must be open and carry the `preview` label, and its head repository and branch must
+   match the triggering run, so a forged number cannot drive another PR's builds. A head SHA that
+   has moved on skips, because the push that moved it starts its own run. Every dispatch input comes
+   from that API response, and the build is dispatched on the default branch rather than on
+   `base_ref`, so a base branch cannot supply its own copy of the build workflow.
 3. `build_preview_docker.yml` — `workflow_dispatch`. Calls the reusable workflow with
    `ref: <head_sha>`, and reports a `Docker preview build` check against that commit because a
    dispatched run does not attach to the PR on its own.


### PR DESCRIPTION
- `dispatch-preview-docker.yml` reads the pull request through the API and requires it to be open and carry the `preview` label before dispatching. The build inputs come from that response instead of from the artifact.
- `build_preview_docker.yml` guards `finalize_check` on the check id instead of on the conclusion of the job that created it, and derives the reported conclusion from both job results.