### PR TITLE
Report a failed branding read-back apart from a failed save

### DIFF
--- a/src/ducks/branding-epics.spec.ts
+++ b/src/ducks/branding-epics.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { firstValueFrom, type Observable, of, throwError } from 'rxjs';
+import { firstValueFrom, lastValueFrom, type Observable, of, throwError } from 'rxjs';
 import { delay, take, toArray } from 'rxjs/operators';
 import type { PublicBrandingModel } from 'types/branding';
 import { actions as alertActions } from './alerts';
@@ -56,6 +56,11 @@ type EpicUnderTest = (action$: unknown, state$: unknown, deps: unknown) => Obser
 async function run(epic: EpicUnderTest, action: unknown, deps: unknown, expected: number) {
     const output$ = epic(of(action), of({}), deps);
     return firstValueFrom(output$.pipe(take(expected), toArray()));
+}
+
+/** Collects the whole emission, so a test asserting a failure path also asserts that nothing follows it. */
+async function runAll(epic: EpicUnderTest, action: unknown, deps: unknown) {
+    return lastValueFrom(epic(of(action), of({}), deps).pipe(toArray()));
 }
 
 describe('branding epics', () => {
@@ -137,7 +142,7 @@ describe('branding epics', () => {
             const epics = await loadEpics(true);
             const deps = createDeps({ updateBrandingSettings: () => throwError(() => err) });
 
-            const emitted = await run(epics[WRITE_BRANDING], slice.actions.updateBranding({ branding: {} }), deps, 2);
+            const emitted = await runAll(epics[WRITE_BRANDING], slice.actions.updateBranding({ branding: {} }), deps);
 
             expect(emitted).toEqual([
                 slice.actions.updateBrandingFailure({ error: 'Failed to update branding. rejected' }),
@@ -145,17 +150,21 @@ describe('branding epics', () => {
             ]);
         });
 
-        /** A failed read-back is still a failed update: the write landed, but the store must not claim a fresh value. */
-        test('updateBranding fails when the branding cannot be read back', async () => {
+        /**
+         * The write landed and only the read-back failed, so the save must not be reported as the thing that went
+         * wrong. What is actually wrong is the slice, which still holds the pre-write branding, so a read repairs it.
+         */
+        test('updateBranding reports a failed read-back apart from a failed save', async () => {
             const err = new Error('unreadable');
             const epics = await loadEpics(true);
             const deps = createDeps({ getBrandingSettings: () => throwError(() => err) });
 
-            const emitted = await run(epics[WRITE_BRANDING], slice.actions.updateBranding({ branding: {} }), deps, 2);
+            const emitted = await runAll(epics[WRITE_BRANDING], slice.actions.updateBranding({ branding: {} }), deps);
 
             expect(emitted).toEqual([
-                slice.actions.updateBrandingFailure({ error: 'Failed to update branding. unreadable' }),
-                appRedirectActions.fetchError({ error: err, message: 'Failed to update branding' }),
+                slice.actions.updateBrandingFailure({ error: 'Branding was saved but could not be read back. unreadable' }),
+                appRedirectActions.fetchError({ error: err, message: 'Branding was saved but could not be read back' }),
+                slice.actions.getBranding(),
             ]);
         });
 

--- a/src/ducks/branding-epics.ts
+++ b/src/ducks/branding-epics.ts
@@ -11,6 +11,9 @@ import { platformDefaultBranding, slice } from './branding';
 
 const BRANDING_DISABLED = 'Branding is disabled for this instance.';
 
+/** The write committed and only the read-back failed, which is not the same thing as the save having failed. */
+const READ_BACK_FAILED = 'Branding was saved but could not be read back';
+
 const getBranding: AppEpic = (action$, state$, deps) => {
     return action$.pipe(
         filter(slice.actions.getBranding.match),
@@ -58,9 +61,21 @@ const runUpdate = (deps: EpicDependencies, branding: BrandingSettingsUpdateModel
     return deps.apiClients.settings.updateBrandingSettings({ brandingSettingsUpdateDto: branding }).pipe(
         // The write answers 204 and Core rewrites SVG logos before storing them, so the stored branding is read back
         // instead of echoing the request, which would leave the store holding markup Core deliberately removed.
-        mergeMap(() => deps.apiClients.settings.getBrandingSettings()),
-        mergeMap((stored) =>
-            of(slice.actions.updateBrandingSuccess({ branding: stored }), alertActions.success('Branding updated successfully.')),
+        mergeMap(() =>
+            deps.apiClients.settings.getBrandingSettings().pipe(
+                mergeMap((stored) =>
+                    of(slice.actions.updateBrandingSuccess({ branding: stored }), alertActions.success('Branding updated successfully.')),
+                ),
+                // Reporting this as a failed save would invite a retry that changes nothing, because the write landed.
+                // The slice is what is wrong — it still holds the pre-write branding — so a fresh read repairs it.
+                catchError((err) =>
+                    of(
+                        slice.actions.updateBrandingFailure({ error: extractError(err, READ_BACK_FAILED) }),
+                        appRedirectActions.fetchError({ error: err, message: READ_BACK_FAILED }),
+                        slice.actions.getBranding(),
+                    ),
+                ),
+            ),
         ),
         catchError((err) =>
             of(

--- a/src/ducks/branding.spec.ts
+++ b/src/ducks/branding.spec.ts
@@ -113,6 +113,24 @@ describe('branding slice', () => {
             expect(state.updateSucceeded).toBe(false);
             expect(state.error).toBe('rejected');
         });
+
+        /**
+         * The sequence a failed read-back produces: the save is never reported as having succeeded, and the repair
+         * read that follows it replaces the pre-write branding the slice was left holding.
+         */
+        test('a failed read-back is repaired by the read dispatched behind it', () => {
+            const stored = { primaryColor: '#00A3E0' };
+            const failed = reducer(
+                { ...initialState, branding: { primaryColor: '#0073CF' }, isUpdatingBranding: true },
+                actions.updateBrandingFailure({ error: 'Branding was saved but could not be read back. unreadable' }),
+            );
+            const repaired = [actions.getBranding(), actions.getBrandingSuccess({ branding: stored })].reduce(reducer, failed);
+
+            expect(repaired.branding).toEqual(stored);
+            expect(repaired.updateSucceeded).toBe(false);
+            expect(repaired.isUpdatingBranding).toBe(false);
+            expect(repaired.isFetchingBranding).toBe(false);
+        });
     });
 
     describe('resetting to default', () => {


### PR DESCRIPTION
Closes #2075

Stacked on #2049 — retarget to `main` once that merges.