### PR TITLE
Render list rows from column definitions and add the column picker

### DIFF
--- a/src/components/ColumnPicker/AvailableFields.tsx
+++ b/src/components/ColumnPicker/AvailableFields.tsx
@@ -1,0 +1,111 @@
+import { Plus, Search } from 'lucide-react';
+import type { FilterFieldSource } from 'types/openapi';
+import type { ColumnDefinition, SourcedCatalogueField } from 'types/tableColumns';
+import { groupCatalogueFields, isColumnSelected } from 'utils/columnPicker';
+import { getColumnKey } from 'utils/tableColumns';
+import SourceBadge from './SourceBadge';
+
+type Props = Readonly<{
+    fields: SourcedCatalogueField[];
+    selected: ColumnDefinition[];
+    search: string;
+    onSearchChange: (search: string) => void;
+    onAdd: (field: SourcedCatalogueField) => void;
+    /** True once the selection has reached the cap; add controls go quiet but the list stays browsable. */
+    isAtCap: boolean;
+    getSourceLabel: (source: FilterFieldSource) => string;
+}>;
+
+/**
+ * What could be shown. Splitting this from the selected columns gives search a natural home and
+ * keeps ordering, renaming and removal on the other side, where position actually means something.
+ */
+export default function AvailableFields({ fields, selected, search, onSearchChange, onAdd, isAtCap, getSourceLabel }: Props) {
+    const groups = groupCatalogueFields(fields, search);
+
+    return (
+        <section className="flex min-h-0 flex-col" aria-labelledby="available-fields-heading">
+            <h3 id="available-fields-heading" className="mb-2 text-sm font-semibold text-content">
+                Available fields
+            </h3>
+
+            <div className="relative">
+                <Search
+                    size={16}
+                    className="pointer-events-none absolute top-1/2 start-2.5 -translate-y-1/2 text-content-subtle"
+                    aria-hidden
+                />
+                <input
+                    type="search"
+                    value={search}
+                    onChange={(event) => onSearchChange(event.target.value)}
+                    placeholder={`Search ${fields.length} fields...`}
+                    aria-label="Search available fields"
+                    data-testid="available-fields-search"
+                    className="w-full rounded-md border border-divider bg-surface-raised py-1.5 ps-8 pe-2.5 text-sm text-content placeholder:text-content-subtle focus:border-brand focus:outline-hidden focus-visible:ring-2 focus-visible:ring-brand"
+                />
+            </div>
+
+            {isAtCap && (
+                <p className="mt-2 text-xs text-warning" data-testid="available-fields-cap-hint">
+                    Remove a column before adding another.
+                </p>
+            )}
+
+            <div className="mt-2 min-h-0 flex-1 overflow-y-auto" data-testid="available-fields-list">
+                {groups.length === 0 ? (
+                    <p className="px-1 py-3 text-sm text-content-subtle" data-testid="available-fields-empty">
+                        {fields.length === 0 ? 'This resource publishes no columns.' : 'No field matches your search.'}
+                    </p>
+                ) : (
+                    groups.map((group) => (
+                        <div key={group.source} className="mb-3">
+                            <h4 className="mb-1 text-xs font-semibold tracking-wide text-content-muted uppercase">
+                                {getSourceLabel(group.source)}
+                            </h4>
+                            <ul className="m-0 flex list-none flex-col p-0">
+                                {group.fields.map((field) => {
+                                    const added = isColumnSelected(selected, field);
+                                    return (
+                                        <li
+                                            key={getColumnKey(field)}
+                                            className="flex items-center gap-2 rounded-md px-1 py-1 hover:bg-surface-hover"
+                                            data-testid={`available-field-${getColumnKey(field)}`}
+                                        >
+                                            <SourceBadge source={field.fieldSource} label={getSourceLabel(field.fieldSource)} />
+                                            <span className="min-w-0 flex-1 truncate text-sm text-content">{field.fieldLabel}</span>
+                                            {field.sortable !== true && (
+                                                <span className="shrink-0 text-xs text-content-subtle" title="This field cannot be sorted">
+                                                    not sortable
+                                                </span>
+                                            )}
+                                            {added ? (
+                                                <span className="shrink-0 text-xs text-content-muted" data-testid="field-added">
+                                                    added
+                                                </span>
+                                            ) : (
+                                                <button
+                                                    type="button"
+                                                    onClick={() => onAdd(field)}
+                                                    disabled={isAtCap}
+                                                    // Kept listed and searchable at the cap: hiding what cannot
+                                                    // currently be added would make the catalogue look broken.
+                                                    className="inline-flex shrink-0 items-center gap-0.5 rounded-md px-1.5 py-0.5 text-xs font-medium text-brand hover:bg-brand-subtle disabled:cursor-not-allowed disabled:text-content-subtle disabled:hover:bg-transparent"
+                                                    data-testid={`add-field-${getColumnKey(field)}`}
+                                                >
+                                                    <Plus size={12} aria-hidden />
+                                                    add
+                                                    <span className="sr-only">{` ${field.fieldLabel} as a column`}</span>
+                                                </button>
+                                            )}
+                                        </li>
+                                    );
+                                })}
+                            </ul>
+                        </div>
+                    ))
+                )}
+            </div>
+        </section>
+    );
+}

--- a/src/components/ColumnPicker/ColumnPicker.spec.tsx
+++ b/src/components/ColumnPicker/ColumnPicker.spec.tsx
@@ -1,0 +1,359 @@
+import { expect, test } from '../../../playwright/ct-test';
+import { withProviders } from 'utils/test-helpers';
+import { AttributeContentType, FilterFieldSource, FilterFieldType, type SearchFieldDataByGroupDto } from 'types/openapi';
+import type { ColumnDefinition } from 'types/tableColumns';
+import ColumnPicker from './index';
+import ColumnPickerTestWrapper from './ColumnPickerTestWrapper';
+
+const field = (identifier: string, label: string, overrides: Record<string, unknown> = {}) => ({
+    fieldIdentifier: identifier,
+    fieldLabel: label,
+    type: FilterFieldType.String,
+    conditions: [],
+    displayable: true,
+    sortable: true,
+    ...overrides,
+});
+
+const catalogue = [
+    {
+        filterFieldSource: FilterFieldSource.Property,
+        searchFieldData: [
+            field('COMMON_NAME', 'Common Name'),
+            field('SERIAL_NUMBER', 'Serial Number'),
+            field('ISSUER_DN', 'Issuer DN'),
+            field('FINGERPRINT', 'Fingerprint', { displayable: false }),
+        ],
+    },
+    {
+        filterFieldSource: FilterFieldSource.Custom,
+        searchFieldData: [
+            field('costCentre', 'Cost centre', { sortable: false, attributeContentType: AttributeContentType.Integer }),
+            field('environment', 'Environment', { sortable: false }),
+        ],
+    },
+] as unknown as SearchFieldDataByGroupDto[];
+
+const commonName: ColumnDefinition = {
+    fieldSource: FilterFieldSource.Property,
+    fieldIdentifier: 'COMMON_NAME',
+    catalogueLabel: 'Common Name',
+};
+const serialNumber: ColumnDefinition = {
+    fieldSource: FilterFieldSource.Property,
+    fieldIdentifier: 'SERIAL_NUMBER',
+    catalogueLabel: 'Serial Number',
+};
+
+const issuerDn: ColumnDefinition = {
+    fieldSource: FilterFieldSource.Property,
+    fieldIdentifier: 'ISSUER_DN',
+    catalogueLabel: 'Issuer DN',
+};
+
+type MountOptions = {
+    columns?: ColumnDefinition[];
+    standardColumns?: ColumnDefinition[];
+    onSave?: (columns: ColumnDefinition[]) => void;
+    onClose?: () => void;
+    fieldCatalogue?: SearchFieldDataByGroupDto[];
+};
+
+const picker = ({
+    columns = [commonName],
+    standardColumns = [commonName, serialNumber],
+    onSave,
+    onClose,
+    fieldCatalogue = catalogue,
+}: MountOptions = {}) =>
+    withProviders(
+        <ColumnPicker
+            isOpen
+            onClose={onClose ?? (() => {})}
+            onSave={onSave ?? (() => {})}
+            catalogue={fieldCatalogue}
+            columns={columns}
+            standardColumns={standardColumns}
+            resourceLabel="Certificates"
+        />,
+    );
+
+test.describe('ColumnPicker', () => {
+    test('groups available fields by source with human-readable labels', async ({ mount, page }) => {
+        await mount(picker());
+
+        await expect(page.getByRole('heading', { name: 'Property' })).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Custom attribute' })).toBeVisible();
+    });
+
+    test('offers only fields the catalogue marks displayable', async ({ mount, page }) => {
+        await mount(picker());
+
+        await expect(page.getByTestId('available-fields-list')).toContainText('Serial Number');
+        await expect(page.getByTestId('available-fields-list')).not.toContainText('Fingerprint');
+    });
+
+    test('marks a non-sortable field before it is chosen', async ({ mount, page }) => {
+        await mount(picker());
+
+        await expect(page.getByTestId('available-field-custom:costCentre')).toContainText('not sortable');
+        await expect(page.getByTestId('available-field-property:SERIAL_NUMBER')).not.toContainText('not sortable');
+    });
+
+    test('shows which fields are already selected', async ({ mount, page }) => {
+        await mount(picker());
+
+        await expect(page.getByTestId('available-field-property:COMMON_NAME')).toContainText('added');
+        await expect(page.getByTestId('add-field-property:COMMON_NAME')).toHaveCount(0);
+    });
+
+    test('searches across every source and hides groups left empty', async ({ mount, page }) => {
+        await mount(picker());
+
+        await page.getByTestId('available-fields-search').fill('cost');
+
+        await expect(page.getByRole('heading', { name: 'Custom attribute' })).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Property' })).toHaveCount(0);
+    });
+
+    test('says so when nothing matches the search', async ({ mount, page }) => {
+        await mount(picker());
+
+        await page.getByTestId('available-fields-search').fill('zzzz');
+
+        await expect(page.getByTestId('available-fields-empty')).toBeVisible();
+    });
+
+    test('renders no empty group for a resource with no custom attributes', async ({ mount, page }) => {
+        await mount(picker({ fieldCatalogue: [catalogue[0]] }));
+
+        await expect(page.getByRole('heading', { name: 'Property' })).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Custom attribute' })).toHaveCount(0);
+    });
+
+    test('adds a field to the end of the selected columns', async ({ mount, page }) => {
+        await mount(picker());
+
+        await page.getByTestId('add-field-custom:environment').click();
+
+        await expect(page.getByTestId('selected-columns-list').getByRole('listitem')).toHaveCount(2);
+        await expect(page.getByTestId('column-counter')).toHaveText('2 / 12');
+    });
+
+    test('removes a selected column', async ({ mount, page }) => {
+        await mount(picker());
+
+        await page.getByTestId('selected-column-property:COMMON_NAME-remove').click();
+
+        await expect(page.getByTestId('selected-columns-empty')).toBeVisible();
+    });
+
+    test('reorders columns from the keyboard, not only by pointer drag', async ({ mount, page }) => {
+        await mount(picker({ columns: [commonName, serialNumber] }));
+
+        await page.getByTestId('selected-column-property:SERIAL_NUMBER-up').click();
+
+        await expect(page.getByTestId('header-preview')).toHaveText(/Serial Number.*Common Name/);
+    });
+
+    test('reorders columns by dragging one onto another', async ({ mount, page }) => {
+        await mount(picker({ columns: [commonName, serialNumber] }));
+
+        await page.getByTestId('selected-column-property:SERIAL_NUMBER').dragTo(page.getByTestId('selected-column-property:COMMON_NAME'));
+
+        await expect(page.getByTestId('header-preview')).toHaveText('Serial NumberCommon Name');
+    });
+
+    /**
+     * The drop indicator is a top border on the target row, i.e. "land above this row". Moving down
+     * removes the source first, which shifts the target up one, so the insertion index has to
+     * compensate or the row lands below the row the user was shown.
+     */
+    test('drops a column above the row the indicator marks when moving down', async ({ mount, page }) => {
+        await mount(picker({ columns: [commonName, serialNumber, issuerDn] }));
+
+        await page.getByTestId('selected-column-property:COMMON_NAME').dragTo(page.getByTestId('selected-column-property:ISSUER_DN'));
+
+        await expect(page.getByTestId('header-preview')).toHaveText('Serial NumberCommon NameIssuer DN');
+    });
+
+    test('drops a column above the row the indicator marks when moving up', async ({ mount, page }) => {
+        await mount(picker({ columns: [commonName, serialNumber, issuerDn] }));
+
+        await page.getByTestId('selected-column-property:ISSUER_DN').dragTo(page.getByTestId('selected-column-property:SERIAL_NUMBER'));
+
+        await expect(page.getByTestId('header-preview')).toHaveText('Common NameIssuer DNSerial Number');
+    });
+
+    test('shows where a dragged column would land', async ({ mount, page }) => {
+        await mount(picker({ columns: [commonName, serialNumber] }));
+
+        const source = page.getByTestId('selected-column-property:SERIAL_NUMBER');
+        const target = page.getByTestId('selected-column-property:COMMON_NAME');
+
+        // The drag events are dispatched rather than mimed with the mouse: a completed dragTo
+        // cannot show the mid-drag state, and raw mouse events never start an HTML5 drag at all.
+        await source.dispatchEvent('dragstart');
+        await target.dispatchEvent('dragover');
+
+        await expect(target).toHaveClass(/border-t-brand/);
+        await expect(source).toHaveClass(/opacity-50/);
+
+        await target.dispatchEvent('drop');
+        await expect(target).not.toHaveClass(/border-t-brand/);
+    });
+
+    test('disables the move controls at the ends of the order', async ({ mount, page }) => {
+        await mount(picker({ columns: [commonName, serialNumber] }));
+
+        await expect(page.getByTestId('selected-column-property:COMMON_NAME-up')).toBeDisabled();
+        await expect(page.getByTestId('selected-column-property:SERIAL_NUMBER-down')).toBeDisabled();
+    });
+
+    test('renames a column heading and keeps the catalogue label visible', async ({ mount, page }) => {
+        await mount(picker());
+
+        await page.getByTestId('selected-column-property:COMMON_NAME-rename').click();
+        await page.getByTestId('selected-column-property:COMMON_NAME-rename-input').fill('Host');
+        await page.keyboard.press('Enter');
+
+        const row = page.getByTestId('selected-column-property:COMMON_NAME');
+        await expect(row).toContainText('Host');
+        await expect(row).toContainText('← Common Name');
+    });
+
+    test('reverting a heading restores the catalogue label rather than a remembered string', async ({ mount, page }) => {
+        await mount(picker());
+
+        await page.getByTestId('selected-column-property:COMMON_NAME-rename').click();
+        await page.getByTestId('selected-column-property:COMMON_NAME-rename-input').fill('Host');
+        await page.keyboard.press('Enter');
+        await page.getByTestId('selected-column-property:COMMON_NAME-revert').click();
+
+        await expect(page.getByTestId('header-preview')).toHaveText('Common Name');
+        await expect(page.getByTestId('selected-column-property:COMMON_NAME-revert')).toHaveCount(0);
+    });
+
+    test('renaming a column back to its catalogue label clears the override', async ({ mount, page }) => {
+        await mount(picker());
+
+        await page.getByTestId('selected-column-property:COMMON_NAME-rename').click();
+        await page.getByTestId('selected-column-property:COMMON_NAME-rename-input').fill('Common Name');
+        await page.keyboard.press('Enter');
+
+        await expect(page.getByTestId('selected-column-property:COMMON_NAME-revert')).toHaveCount(0);
+    });
+
+    test('the header preview follows the current selection and order live', async ({ mount, page }) => {
+        await mount(picker());
+
+        await expect(page.getByTestId('header-preview')).toHaveText('Common Name');
+        await page.getByTestId('add-field-custom:environment').click();
+
+        await expect(page.getByTestId('header-preview')).toHaveText(/Common Name.*Environment/);
+    });
+
+    /**
+     * A platform default column can be absent from the filter-field catalogue and still renderable —
+     * the keys inventory ships three such columns. Resetting used to mark them unavailable, and the
+     * next Save then silently removed them from the view.
+     */
+    test('reset keeps a platform column the catalogue does not publish, and saves it', async ({ mount, page }) => {
+        const uncatalogued: ColumnDefinition = {
+            fieldSource: FilterFieldSource.Property,
+            fieldIdentifier: 'CKI_ENABLED',
+            catalogueLabel: 'Status',
+        };
+        const saved: ColumnDefinition[][] = [];
+        await mount(picker({ columns: [], standardColumns: [commonName, uncatalogued], onSave: (columns) => saved.push(columns) }));
+
+        await page.getByTestId('reset-to-standard').click();
+
+        await expect(page.getByTestId('selected-column-property:CKI_ENABLED')).not.toContainText('Unavailable');
+
+        await page.getByRole('button', { name: 'Save' }).click();
+
+        await expect.poll(() => saved.length).toBe(1);
+        expect(saved[0].map((column) => column.fieldIdentifier)).toEqual(['COMMON_NAME', 'CKI_ENABLED']);
+    });
+
+    test('refills the selected columns from the platform set', async ({ mount, page }) => {
+        await mount(picker({ columns: [], standardColumns: [commonName, serialNumber] }));
+
+        await page.getByTestId('reset-to-standard').click();
+
+        await expect(page.getByTestId('selected-columns-list').getByRole('listitem')).toHaveCount(2);
+    });
+
+    /**
+     * The dialog holds a working copy, so a re-render with new prop references must not restart the
+     * edit. The catalogue can also land after the dialog opened, which is reconciled onto the working
+     * copy rather than re-seeded from the view.
+     */
+    test('keeps an edited draft when the caller re-renders with new prop references', async ({ mount, page }) => {
+        await mount(
+            withProviders(
+                <ColumnPickerTestWrapper columns={[commonName, serialNumber]} standardColumns={[commonName]} catalogue={catalogue} />,
+            ),
+        );
+
+        await page.getByTestId('selected-column-property:SERIAL_NUMBER-remove').click();
+        await page.getByTestId('available-fields-search').fill('cost');
+        await expect(page.getByTestId('selected-columns-list').getByRole('listitem')).toHaveCount(1);
+
+        // The dialog is modal, so its overlay intercepts a real click on a control outside it.
+        await page.getByTestId('wrapper-rerender').dispatchEvent('click');
+
+        await expect(page.getByTestId('wrapper-rerender')).toHaveText('rerender 1');
+        await expect(page.getByTestId('selected-columns-list').getByRole('listitem')).toHaveCount(1);
+        await expect(page.getByTestId('available-fields-search')).toHaveValue('cost');
+    });
+
+    test('resolves a catalogue that only lands after the dialog is open', async ({ mount, page }) => {
+        await mount(
+            withProviders(<ColumnPickerTestWrapper columns={[issuerDn]} standardColumns={[]} catalogue={catalogue} withheldCatalogue />),
+        );
+
+        await expect(page.getByTestId('selected-column-property:ISSUER_DN')).toContainText('Unavailable');
+        await expect(page.getByRole('button', { name: 'Save' })).toBeDisabled();
+
+        await page.getByTestId('wrapper-release-catalogue').dispatchEvent('click');
+
+        await expect(page.getByTestId('selected-column-property:ISSUER_DN')).not.toContainText('Unavailable');
+        await expect(page.getByRole('button', { name: 'Save' })).toBeEnabled();
+    });
+
+    test('blocks saving with no columns, because the API rejects an empty set', async ({ mount, page }) => {
+        await mount(picker({ columns: [] }));
+
+        await expect(page.getByTestId('selected-columns-empty')).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Save' })).toBeDisabled();
+    });
+
+    test('saves the columns in the arranged order, with the heading override', async ({ mount, page }) => {
+        const saved: ColumnDefinition[][] = [];
+        await mount(picker({ columns: [commonName, serialNumber], onSave: (columns) => saved.push(columns) }));
+
+        await page.getByTestId('selected-column-property:SERIAL_NUMBER-rename').click();
+        await page.getByTestId('selected-column-property:SERIAL_NUMBER-rename-input').fill('Serial');
+        await page.keyboard.press('Enter');
+        await page.getByTestId('selected-column-property:SERIAL_NUMBER-up').click();
+        await page.getByRole('button', { name: 'Save' }).click();
+
+        await expect.poll(() => saved.length).toBe(1);
+        expect(saved[0].map((column) => column.fieldIdentifier)).toEqual(['SERIAL_NUMBER', 'COMMON_NAME']);
+        expect(saved[0][0].label).toBe('Serial');
+    });
+
+    test('cancel reports no columns at all', async ({ mount, page }) => {
+        const saved: ColumnDefinition[][] = [];
+        let closed = 0;
+        await mount(picker({ onSave: (columns) => saved.push(columns), onClose: () => (closed += 1) }));
+
+        await page.getByTestId('add-field-custom:environment').click();
+        await page.getByRole('button', { name: 'Cancel' }).click();
+
+        await expect.poll(() => closed).toBe(1);
+        expect(saved).toEqual([]);
+    });
+});

--- a/src/components/ColumnPicker/ColumnPickerEdges.spec.tsx
+++ b/src/components/ColumnPicker/ColumnPickerEdges.spec.tsx
@@ -1,0 +1,169 @@
+import { expect, test } from '../../../playwright/ct-test';
+import { withProviders } from 'utils/test-helpers';
+import { FilterFieldSource, FilterFieldType, type SearchFieldDataByGroupDto } from 'types/openapi';
+import type { ColumnDefinition } from 'types/tableColumns';
+import ColumnPicker from './index';
+
+/** Enough fields to reach the cap and still have some left over to prove they stay browsable. */
+const PROPERTY_FIELDS = Array.from({ length: 16 }, (_value, index) => ({
+    fieldIdentifier: `FIELD_${index}`,
+    fieldLabel: `Field ${index}`,
+    type: FilterFieldType.String,
+    conditions: [],
+    displayable: true,
+    sortable: true,
+}));
+
+const catalogue = [
+    { filterFieldSource: FilterFieldSource.Property, searchFieldData: PROPERTY_FIELDS },
+] as unknown as SearchFieldDataByGroupDto[];
+
+const columnsOf = (count: number): ColumnDefinition[] =>
+    PROPERTY_FIELDS.slice(0, count).map((field) => ({
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: field.fieldIdentifier,
+        catalogueLabel: field.fieldLabel,
+    }));
+
+const picker = (columns: ColumnDefinition[], onSave?: (columns: ColumnDefinition[]) => void) =>
+    withProviders(
+        <ColumnPicker
+            isOpen
+            onClose={() => {}}
+            onSave={onSave ?? (() => {})}
+            catalogue={catalogue}
+            columns={columns}
+            standardColumns={columnsOf(2)}
+        />,
+    );
+
+test.describe('ColumnPicker · at the cap', () => {
+    test('counts up to the cap and warns before it binds', async ({ mount, page }) => {
+        await mount(picker(columnsOf(10)));
+
+        await expect(page.getByTestId('column-counter')).toHaveText('10 / 12');
+        await expect(page.getByTestId('column-counter-warning')).toBeVisible();
+    });
+
+    test('does not warn below the threshold', async ({ mount, page }) => {
+        await mount(picker(columnsOf(9)));
+
+        await expect(page.getByTestId('column-counter-warning')).toHaveCount(0);
+    });
+
+    test('stops selection at the cap rather than silently ignoring further additions', async ({ mount, page }) => {
+        await mount(picker(columnsOf(12)));
+
+        await expect(page.getByTestId('column-counter')).toHaveText('12 / 12');
+        await expect(page.getByTestId('add-field-property:FIELD_12')).toBeDisabled();
+        await expect(page.getByTestId('available-fields-cap-hint')).toBeVisible();
+    });
+
+    test('keeps unselected fields listed and searchable at the cap, so the catalogue never looks broken', async ({ mount, page }) => {
+        await mount(picker(columnsOf(12)));
+
+        await expect(page.getByTestId('available-field-property:FIELD_15')).toBeVisible();
+        await page.getByTestId('available-fields-search').fill('Field 14');
+        await expect(page.getByTestId('available-field-property:FIELD_14')).toBeVisible();
+    });
+
+    test('lets a column be removed and another added again', async ({ mount, page }) => {
+        await mount(picker(columnsOf(12)));
+
+        await page.getByTestId('selected-column-property:FIELD_0-remove').click();
+
+        await expect(page.getByTestId('column-counter')).toHaveText('11 / 12');
+        await expect(page.getByTestId('add-field-property:FIELD_12')).toBeEnabled();
+    });
+
+    test('renders a stored view that is already above the cap rather than truncating it', async ({ mount, page }) => {
+        await mount(picker(columnsOf(14)));
+
+        await expect(page.getByTestId('column-counter')).toHaveText('14 / 12');
+        await expect(page.getByTestId('selected-columns-list').getByRole('listitem')).toHaveCount(14);
+    });
+});
+
+test.describe('ColumnPicker · a column whose field is gone', () => {
+    const gone: ColumnDefinition = {
+        fieldSource: FilterFieldSource.Custom,
+        fieldIdentifier: 'cost_centre',
+        catalogueLabel: 'Cost centre',
+    };
+    const withGone = [columnsOf(1)[0], gone, columnsOf(2)[1]];
+
+    test('keeps the column in its stored position and badges it unavailable', async ({ mount, page }) => {
+        await mount(picker(withGone));
+
+        const rows = page.getByTestId('selected-columns-list').getByRole('listitem');
+        await expect(rows).toHaveCount(3);
+        await expect(rows.nth(1)).toContainText('Unavailable');
+    });
+
+    test('shows the stored identifier, so an administrator can tell what the column was', async ({ mount, page }) => {
+        await mount(picker(withGone));
+
+        await expect(page.getByTestId('selected-column-custom:cost_centre')).toContainText('custom / cost_centre');
+    });
+
+    test('offers removal as the only action on it', async ({ mount, page }) => {
+        await mount(picker(withGone));
+
+        const row = page.getByTestId('selected-column-custom:cost_centre');
+        await expect(row.getByRole('button')).toHaveCount(1);
+        await expect(page.getByTestId('selected-column-custom:cost_centre-remove')).toBeVisible();
+    });
+
+    test('leaves it out of the header preview, which is what the table would render', async ({ mount, page }) => {
+        await mount(picker(withGone));
+
+        await expect(page.getByTestId('header-preview')).not.toContainText('Cost centre');
+    });
+
+    test('drops it on save', async ({ mount, page }) => {
+        const saved: ColumnDefinition[][] = [];
+        await mount(picker(withGone, (columns) => saved.push(columns)));
+
+        await page.getByRole('button', { name: 'Save' }).click();
+
+        await expect.poll(() => saved.length).toBe(1);
+        expect(saved[0].map((column) => column.fieldIdentifier)).toEqual(['FIELD_0', 'FIELD_1']);
+    });
+
+    /**
+     * Save sends only the available columns, so a draft of nothing but unavailable rows resolves to
+     * the empty set the API rejects — even though the draft itself is not empty.
+     */
+    test('blocks saving a draft of nothing but unavailable columns', async ({ mount, page }) => {
+        await mount(picker([gone]));
+
+        await expect(page.getByTestId('selected-columns-list').getByRole('listitem')).toHaveCount(1);
+        await expect(page.getByRole('button', { name: 'Save' })).toBeDisabled();
+    });
+
+    /** It is not draggable, but it holds a position, so a column has to be placeable above it. */
+    test('accepts a drop, so a column can be placed immediately above it', async ({ mount, page }) => {
+        await mount(picker(withGone));
+        const rows = page.getByTestId('selected-columns-list').getByRole('listitem');
+
+        await page.getByTestId('selected-column-property:FIELD_1').dragTo(page.getByTestId('selected-column-custom:cost_centre'));
+
+        await expect(rows.nth(1)).toContainText('Field 1');
+        await expect(rows.nth(2)).toContainText('Unavailable');
+    });
+
+    test('still lets the rest of the view be arranged around it', async ({ mount, page }) => {
+        await mount(picker(withGone));
+        const rows = page.getByTestId('selected-columns-list').getByRole('listitem');
+
+        // The unavailable column holds a real position, so moving past it is a real move even
+        // though the preview — which shows what the table would render — does not change yet.
+        await page.getByTestId('selected-column-property:FIELD_1-up').click();
+        await expect(rows.nth(1)).toContainText('Field 1');
+        await expect(rows.nth(2)).toContainText('Unavailable');
+        await expect(page.getByTestId('header-preview')).toHaveText('Field 0Field 1');
+
+        await page.getByTestId('selected-column-property:FIELD_1-up').click();
+        await expect(page.getByTestId('header-preview')).toHaveText('Field 1Field 0');
+    });
+});

--- a/src/components/ColumnPicker/ColumnPickerTestWrapper.tsx
+++ b/src/components/ColumnPicker/ColumnPickerTestWrapper.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import type { SearchFieldDataByGroupDto } from 'types/openapi';
+import type { ColumnDefinition } from 'types/tableColumns';
+import ColumnPicker from './index';
+
+type Props = Readonly<{
+    columns: ColumnDefinition[];
+    standardColumns?: ColumnDefinition[];
+    catalogue: SearchFieldDataByGroupDto[];
+    /** Withholds the catalogue until released, so a test can make it land after the dialog opened. */
+    withheldCatalogue?: boolean;
+    onSave?: (columns: ColumnDefinition[]) => void;
+}>;
+
+const clone = <T,>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+
+/**
+ * Drives {@link ColumnPicker} through prop changes that a component test cannot produce with
+ * `component.update()`, because the dialog renders into a portal and updating unmounts it.
+ *
+ * Every render hands the picker freshly cloned props, which is what a caller re-rendering from a
+ * selector does. The dialog is expected to keep the working copy across that.
+ */
+export default function ColumnPickerTestWrapper({ columns, standardColumns = [], catalogue, withheldCatalogue = false, onSave }: Props) {
+    const [isReleased, setIsReleased] = useState(!withheldCatalogue);
+    const [nonce, setNonce] = useState(0);
+
+    return (
+        <div>
+            <button type="button" data-testid="wrapper-rerender" onClick={() => setNonce((current) => current + 1)}>
+                {`rerender ${nonce}`}
+            </button>
+            <button type="button" data-testid="wrapper-release-catalogue" onClick={() => setIsReleased(true)}>
+                release catalogue
+            </button>
+            <ColumnPicker
+                isOpen
+                onClose={() => {}}
+                onSave={onSave ?? (() => {})}
+                catalogue={isReleased ? clone(catalogue) : []}
+                columns={clone(columns)}
+                standardColumns={clone(standardColumns)}
+                resourceLabel="Certificates"
+            />
+        </div>
+    );
+}

--- a/src/components/ColumnPicker/HeaderPreview.tsx
+++ b/src/components/ColumnPicker/HeaderPreview.tsx
@@ -1,0 +1,36 @@
+import type { PickerColumn } from 'types/tableColumns';
+import { getColumnHeading, getColumnKey } from 'utils/tableColumns';
+
+type Props = Readonly<{
+    columns: PickerColumn[];
+}>;
+
+/**
+ * The header row the current selection would produce, rendered live inside the dialog so a reorder
+ * or a rename can be judged without closing anything. Unavailable columns are left out, because
+ * they are what the table will not render either.
+ */
+export default function HeaderPreview({ columns }: Props) {
+    const rendered = columns.filter((column) => column.available);
+
+    return (
+        <section className="mt-4" aria-labelledby="column-header-preview-label">
+            <h3 className="mb-1.5 text-xs font-medium text-content-muted" id="column-header-preview-label">
+                Header preview
+            </h3>
+            <div className="overflow-x-auto rounded-md border border-divider bg-surface-sunken" data-testid="header-preview">
+                {rendered.length === 0 ? (
+                    <p className="px-3 py-2 text-xs text-content-subtle">No columns to preview.</p>
+                ) : (
+                    <ul className="m-0 flex list-none items-center gap-4 px-3 py-2">
+                        {rendered.map((column) => (
+                            <li key={getColumnKey(column)} className="text-xs font-medium whitespace-nowrap text-content">
+                                {getColumnHeading(column)}
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </div>
+        </section>
+    );
+}

--- a/src/components/ColumnPicker/SelectedColumnRow.tsx
+++ b/src/components/ColumnPicker/SelectedColumnRow.tsx
@@ -1,0 +1,204 @@
+import cn from 'classnames';
+import { ChevronDown, ChevronUp, GripVertical, RotateCcw, X } from 'lucide-react';
+import { useState } from 'react';
+import Badge from 'components/Badge';
+import type { FilterFieldSource } from 'types/openapi';
+import type { PickerColumn } from 'types/tableColumns';
+import { getColumnHeading } from 'utils/tableColumns';
+import SourceBadge from './SourceBadge';
+
+type Props = Readonly<{
+    column: PickerColumn;
+    index: number;
+    total: number;
+    getSourceLabel: (source: FilterFieldSource) => string;
+    onRename: (index: number, label: string) => void;
+    onRevert: (index: number) => void;
+    onRemove: (index: number) => void;
+    onMove: (from: number, to: number) => void;
+    onDragStart: (index: number) => void;
+    onDragOver: (index: number) => void;
+    onDrop: () => void;
+    onDragEnd: () => void;
+    isDragging: boolean;
+    /** True when a dragged row would land immediately above this one. */
+    isDropTarget: boolean;
+    dataTestId: string;
+}>;
+
+/**
+ * One selected column. Position is display order — top is leftmost — so the row carries both the
+ * pointer affordance (a drag handle) and explicit move controls: reordering has to be reachable
+ * from the keyboard, and a drag handle alone never is.
+ */
+export default function SelectedColumnRow({
+    column,
+    index,
+    total,
+    getSourceLabel,
+    onRename,
+    onRevert,
+    onRemove,
+    onMove,
+    onDragStart,
+    onDragOver,
+    onDrop,
+    onDragEnd,
+    isDragging,
+    isDropTarget,
+    dataTestId,
+}: Props) {
+    const [isRenaming, setIsRenaming] = useState(false);
+    const [draft, setDraft] = useState('');
+
+    const heading = getColumnHeading(column);
+    const isRenamed = Boolean(column.label);
+
+    const commitRename = () => {
+        setIsRenaming(false);
+        onRename(index, draft);
+    };
+
+    // A column whose field the catalogue no longer publishes cannot be renamed or reordered into
+    // meaning — it can only be taken out. It keeps its position and shows the stored identifier, so
+    // an administrator can tell what it was. It is not draggable, but it does accept a drop, or no
+    // column could be placed immediately above it.
+    if (!column.available) {
+        return (
+            <li
+                onDragOver={(event) => {
+                    event.preventDefault();
+                    onDragOver(index);
+                }}
+                onDrop={(event) => {
+                    event.preventDefault();
+                    onDrop();
+                }}
+                onDragEnd={onDragEnd}
+                className={cn('flex items-center gap-2 rounded-md border border-dashed border-outline px-2 py-1.5', {
+                    'border-t-2 border-t-brand': isDropTarget,
+                })}
+                data-testid={dataTestId}
+            >
+                <span className="w-4 shrink-0" aria-hidden />
+                <Badge color="warning" size="small" className="shrink-0">
+                    Unavailable
+                </Badge>
+                <span className="min-w-0 flex-1 truncate text-sm text-content-muted">
+                    {column.catalogueLabel}
+                    <span className="ms-1.5 text-xs text-content-subtle">{`${column.fieldSource} / ${column.fieldIdentifier}`}</span>
+                </span>
+                <button
+                    type="button"
+                    onClick={() => onRemove(index)}
+                    aria-label={`Remove unavailable column ${column.catalogueLabel}`}
+                    className="shrink-0 rounded-md p-1 text-content-subtle hover:bg-surface-hover hover:text-danger focus:outline-hidden focus-visible:ring-2 focus-visible:ring-brand"
+                    data-testid={`${dataTestId}-remove`}
+                >
+                    <X size={14} aria-hidden />
+                </button>
+            </li>
+        );
+    }
+
+    return (
+        <li
+            draggable
+            onDragStart={() => onDragStart(index)}
+            onDragOver={(event) => {
+                event.preventDefault();
+                onDragOver(index);
+            }}
+            onDrop={(event) => {
+                event.preventDefault();
+                onDrop();
+            }}
+            onDragEnd={onDragEnd}
+            className={cn('flex items-center gap-2 rounded-md border border-transparent px-2 py-1.5 hover:bg-surface-hover', {
+                'opacity-50': isDragging,
+                'border-t-2 border-t-brand': isDropTarget,
+            })}
+            data-testid={dataTestId}
+        >
+            <GripVertical size={16} className="shrink-0 cursor-grab text-content-subtle" aria-hidden data-testid={`${dataTestId}-handle`} />
+            <SourceBadge source={column.fieldSource} label={getSourceLabel(column.fieldSource)} />
+
+            {isRenaming ? (
+                <input
+                    // biome-ignore lint/a11y/noAutofocus: the field replaces the heading the user just chose to edit
+                    autoFocus
+                    value={draft}
+                    onChange={(event) => setDraft(event.target.value)}
+                    onBlur={commitRename}
+                    onKeyDown={(event) => {
+                        if (event.key === 'Enter') commitRename();
+                        if (event.key === 'Escape') setIsRenaming(false);
+                    }}
+                    aria-label={`Heading for ${column.catalogueLabel}`}
+                    className="min-w-0 flex-1 rounded-md border border-brand bg-surface-raised px-1.5 py-0.5 text-sm text-content focus:outline-hidden"
+                    data-testid={`${dataTestId}-rename-input`}
+                />
+            ) : (
+                <button
+                    type="button"
+                    onClick={() => {
+                        setDraft(heading);
+                        setIsRenaming(true);
+                    }}
+                    className="min-w-0 flex-1 truncate rounded-md px-1 text-start text-sm text-content hover:bg-surface-active focus:outline-hidden focus-visible:ring-2 focus-visible:ring-brand"
+                    data-testid={`${dataTestId}-rename`}
+                >
+                    {heading}
+                    {isRenamed && (
+                        // The catalogue label stays visible behind the override, so it is clear what
+                        // reverting would restore.
+                        <span className="ms-1.5 text-xs text-content-subtle">{`← ${column.catalogueLabel}`}</span>
+                    )}
+                    <span className="sr-only"> — rename this column heading</span>
+                </button>
+            )}
+
+            {isRenamed && !isRenaming && (
+                <button
+                    type="button"
+                    onClick={() => onRevert(index)}
+                    aria-label={`Revert ${heading} to the catalogue label ${column.catalogueLabel}`}
+                    className="shrink-0 rounded-md p-1 text-content-subtle hover:bg-surface-hover hover:text-content focus:outline-hidden focus-visible:ring-2 focus-visible:ring-brand"
+                    data-testid={`${dataTestId}-revert`}
+                >
+                    <RotateCcw size={13} aria-hidden />
+                </button>
+            )}
+
+            <button
+                type="button"
+                onClick={() => onMove(index, index - 1)}
+                disabled={index === 0}
+                aria-label={`Move ${heading} earlier`}
+                className="shrink-0 rounded-md p-1 text-content-subtle hover:bg-surface-hover hover:text-content disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent focus:outline-hidden focus-visible:ring-2 focus-visible:ring-brand"
+                data-testid={`${dataTestId}-up`}
+            >
+                <ChevronUp size={14} aria-hidden />
+            </button>
+            <button
+                type="button"
+                onClick={() => onMove(index, index + 1)}
+                disabled={index === total - 1}
+                aria-label={`Move ${heading} later`}
+                className="shrink-0 rounded-md p-1 text-content-subtle hover:bg-surface-hover hover:text-content disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent focus:outline-hidden focus-visible:ring-2 focus-visible:ring-brand"
+                data-testid={`${dataTestId}-down`}
+            >
+                <ChevronDown size={14} aria-hidden />
+            </button>
+            <button
+                type="button"
+                onClick={() => onRemove(index)}
+                aria-label={`Remove column ${heading}`}
+                className="shrink-0 rounded-md p-1 text-content-subtle hover:bg-surface-hover hover:text-danger focus:outline-hidden focus-visible:ring-2 focus-visible:ring-brand"
+                data-testid={`${dataTestId}-remove`}
+            >
+                <X size={14} aria-hidden />
+            </button>
+        </li>
+    );
+}

--- a/src/components/ColumnPicker/SelectedColumns.tsx
+++ b/src/components/ColumnPicker/SelectedColumns.tsx
@@ -1,0 +1,119 @@
+import cn from 'classnames';
+import { useState } from 'react';
+import type { FilterFieldSource } from 'types/openapi';
+import type { PickerColumn } from 'types/tableColumns';
+import { COLUMN_COUNT_WARNING_FROM, getCounterState, MAX_COLUMNS } from 'utils/columnPicker';
+import { getColumnKey } from 'utils/tableColumns';
+import SelectedColumnRow from './SelectedColumnRow';
+
+type Props = Readonly<{
+    columns: PickerColumn[];
+    getSourceLabel: (source: FilterFieldSource) => string;
+    onRename: (index: number, label: string) => void;
+    onRevert: (index: number) => void;
+    onRemove: (index: number) => void;
+    onMove: (from: number, to: number) => void;
+    onResetToStandard: () => void;
+}>;
+
+const COUNTER_CLASSES = {
+    ok: 'text-content-muted',
+    warning: 'text-warning',
+    full: 'text-danger',
+} as const;
+
+/**
+ * The selected columns, in display order, with the count against the cap and the reset control.
+ * Reordering is available by drag and by the per-row move buttons, because a drag handle alone is
+ * not reachable from the keyboard.
+ */
+export default function SelectedColumns({ columns, getSourceLabel, onRename, onRevert, onRemove, onMove, onResetToStandard }: Props) {
+    const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
+    const [dropIndex, setDropIndex] = useState<number | null>(null);
+
+    const counterState = getCounterState(columns.length);
+
+    const finishDrag = () => {
+        setDraggingIndex(null);
+        setDropIndex(null);
+    };
+
+    const handleDrop = () => {
+        if (draggingIndex !== null && dropIndex !== null) {
+            // The indicator is a top border on the target row, i.e. "land above this row". The move
+            // takes the source out before inserting, which shifts a target below it up by one, so a
+            // downward move has to compensate or the row lands below the highlighted one.
+            onMove(draggingIndex, draggingIndex < dropIndex ? dropIndex - 1 : dropIndex);
+        }
+        finishDrag();
+    };
+
+    return (
+        <section className="flex min-h-0 flex-col" aria-labelledby="selected-columns-heading">
+            <div className="mb-2 flex items-center justify-between gap-2">
+                <h3 id="selected-columns-heading" className="text-sm font-semibold text-content">
+                    Columns shown
+                </h3>
+                <span
+                    className={cn('text-xs font-medium', COUNTER_CLASSES[counterState])}
+                    // The count is announced when it changes, so the cap is not something a
+                    // keyboard user discovers only by an add control going quiet.
+                    aria-live="polite"
+                    data-testid="column-counter"
+                >
+                    {`${columns.length} / ${MAX_COLUMNS}`}
+                </span>
+            </div>
+
+            {columns.length === 0 ? (
+                <p
+                    className="rounded-md border border-dashed border-outline px-3 py-6 text-center text-sm text-content-muted"
+                    data-testid="selected-columns-empty"
+                >
+                    A view needs at least one column.
+                </p>
+            ) : (
+                <ul className="m-0 min-h-0 flex-1 list-none overflow-y-auto p-0" data-testid="selected-columns-list">
+                    {columns.map((column, index) => (
+                        <SelectedColumnRow
+                            key={getColumnKey(column)}
+                            column={column}
+                            index={index}
+                            total={columns.length}
+                            getSourceLabel={getSourceLabel}
+                            onRename={onRename}
+                            onRevert={onRevert}
+                            onRemove={onRemove}
+                            onMove={onMove}
+                            onDragStart={setDraggingIndex}
+                            onDragOver={setDropIndex}
+                            onDrop={handleDrop}
+                            onDragEnd={finishDrag}
+                            isDragging={draggingIndex === index}
+                            isDropTarget={draggingIndex !== null && dropIndex === index && draggingIndex !== index}
+                            dataTestId={`selected-column-${getColumnKey(column)}`}
+                        />
+                    ))}
+                </ul>
+            )}
+
+            {counterState === 'warning' && (
+                <p className="mt-2 text-xs text-warning" data-testid="column-counter-warning">
+                    {`A table stays readable up to ${MAX_COLUMNS} columns; you are past ${COLUMN_COUNT_WARNING_FROM - 1}.`}
+                </p>
+            )}
+
+            <button
+                type="button"
+                onClick={onResetToStandard}
+                // Refills the pane as an edit the user can still cancel. Getting back to the
+                // platform columns outright is the Standard tab, which is why the table itself
+                // carries no reset control.
+                className="mt-3 self-start rounded-md px-1 text-xs font-medium text-brand hover:text-brand-hover focus:outline-hidden focus-visible:ring-2 focus-visible:ring-brand"
+                data-testid="reset-to-standard"
+            >
+                Reset to Standard columns
+            </button>
+        </section>
+    );
+}

--- a/src/components/ColumnPicker/SourceBadge.tsx
+++ b/src/components/ColumnPicker/SourceBadge.tsx
@@ -1,0 +1,45 @@
+import Badge, { type BadgeColor } from 'components/Badge';
+import { FilterFieldSource } from 'types/openapi';
+
+/**
+ * Default labels for the four field sources. The platform publishes its own through
+ * `PlatformEnum.FilterFieldSource`; a caller that has them passes `getSourceLabel` and these are
+ * only what the picker falls back to before the enums have loaded.
+ */
+export const DEFAULT_SOURCE_LABELS: Readonly<Record<FilterFieldSource, string>> = {
+    [FilterFieldSource.Property]: 'Property',
+    [FilterFieldSource.Custom]: 'Custom attribute',
+    [FilterFieldSource.Meta]: 'Metadata',
+    [FilterFieldSource.Data]: 'Data attribute',
+};
+
+/** One colour per source, so a field's origin is readable at a glance down a long list. */
+const SOURCE_COLORS: Readonly<Record<FilterFieldSource, BadgeColor>> = {
+    [FilterFieldSource.Property]: 'secondary',
+    [FilterFieldSource.Custom]: 'info',
+    [FilterFieldSource.Meta]: 'success',
+    [FilterFieldSource.Data]: 'warning',
+};
+
+/** Short forms, because the badge sits before every field label and the full names crowd the row. */
+const SOURCE_ABBREVIATIONS: Readonly<Record<FilterFieldSource, string>> = {
+    [FilterFieldSource.Property]: 'Prop',
+    [FilterFieldSource.Custom]: 'Custom',
+    [FilterFieldSource.Meta]: 'Meta',
+    [FilterFieldSource.Data]: 'Data',
+};
+
+type Props = Readonly<{
+    source: FilterFieldSource;
+    /** The full source name, announced to screen readers in place of the abbreviation. */
+    label: string;
+}>;
+
+export default function SourceBadge({ source, label }: Props) {
+    return (
+        <Badge color={SOURCE_COLORS[source]} size="small" className="shrink-0">
+            <span aria-hidden="true">{SOURCE_ABBREVIATIONS[source]}</span>
+            <span className="sr-only">{label}</span>
+        </Badge>
+    );
+}

--- a/src/components/ColumnPicker/index.tsx
+++ b/src/components/ColumnPicker/index.tsx
@@ -1,0 +1,198 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Dialog from 'components/Dialog';
+import type { FilterFieldSource, SearchFieldDataByGroupDto } from 'types/openapi';
+import type { ColumnDefinition, PickerColumn, SourcedCatalogueField } from 'types/tableColumns';
+import {
+    MAX_COLUMNS,
+    isColumnSelected,
+    isSameResolution,
+    moveColumn,
+    resolveColumns,
+    toCatalogueFields,
+    toColumnDefinition,
+} from 'utils/columnPicker';
+import AvailableFields from './AvailableFields';
+import HeaderPreview from './HeaderPreview';
+import SelectedColumns from './SelectedColumns';
+import { DEFAULT_SOURCE_LABELS } from './SourceBadge';
+
+const NO_STANDARD_COLUMNS: ColumnDefinition[] = [];
+
+export type ColumnPickerProps = Readonly<{
+    isOpen: boolean;
+    /** Closes without applying anything, discarding every change made in the dialog. */
+    onClose: () => void;
+    /** Receives the arranged columns. Unavailable ones are already dropped. */
+    onSave: (columns: ColumnDefinition[]) => void;
+    /** The column catalogue for the resource, i.e. `GET /v1/{resource}/search`. */
+    catalogue: SearchFieldDataByGroupDto[];
+    /** The columns the view currently holds. */
+    columns: ColumnDefinition[];
+    /** The platform default set, offered inside the dialog as "Reset to Standard columns". */
+    standardColumns?: ColumnDefinition[];
+    /** Named in the dialog caption, e.g. "Certificates". */
+    resourceLabel?: string;
+    /** Resolves a source to its platform label; falls back to the picker's own names. */
+    getSourceLabel?: (source: FilterFieldSource) => string;
+    dataTestId?: string;
+}>;
+
+/**
+ * The dialog where a user arranges the columns of a view: what could be shown on the left, what is
+ * shown on the right. Two panes rather than one combined list, because an organisation with thirty
+ * custom attributes makes "what have I already got?" unanswerable. Nothing reaches the API until
+ * Save, so a half-arranged view never hits the network.
+ */
+export default function ColumnPicker({
+    isOpen,
+    onClose,
+    onSave,
+    catalogue,
+    columns,
+    standardColumns = NO_STANDARD_COLUMNS,
+    resourceLabel,
+    getSourceLabel,
+    dataTestId = 'column-picker',
+}: ColumnPickerProps) {
+    const fields = useMemo(() => toCatalogueFields(catalogue), [catalogue]);
+    const [draft, setDraft] = useState<PickerColumn[]>([]);
+    const [search, setSearch] = useState('');
+
+    const hasSeeded = useRef(false);
+
+    // Seeded once per open, so the dialog holds a working copy and Cancel is simply never reading it
+    // back. A later change to `columns` or to the catalogue must not restart the user's edit, but the
+    // catalogue can also land after the dialog opened — so that case is reconciled onto the working
+    // copy, refreshing labels and availability without discarding anything the user has done.
+    useEffect(() => {
+        if (!isOpen) {
+            hasSeeded.current = false;
+            return;
+        }
+
+        if (hasSeeded.current) {
+            setDraft((current) => {
+                const reconciled = resolveColumns(current, fields, standardColumns);
+                return isSameResolution(current, reconciled) ? current : reconciled;
+            });
+            return;
+        }
+
+        hasSeeded.current = true;
+        setDraft(resolveColumns(columns, fields, standardColumns));
+        setSearch('');
+    }, [isOpen, columns, fields, standardColumns]);
+
+    const resolveSourceLabel = useCallback(
+        (source: FilterFieldSource) => getSourceLabel?.(source) ?? DEFAULT_SOURCE_LABELS[source],
+        [getSourceLabel],
+    );
+
+    const handleAdd = useCallback((field: SourcedCatalogueField) => {
+        setDraft((current) => {
+            // Selection stops at the cap rather than silently ignoring further additions, and a
+            // field already shown is never added twice.
+            if (current.length >= MAX_COLUMNS || isColumnSelected(current, field)) return current;
+            return [...current, { ...toColumnDefinition(field), available: true }];
+        });
+    }, []);
+
+    const handleRename = useCallback((index: number, label: string) => {
+        setDraft((current) =>
+            current.map((column, position) => {
+                if (position !== index) return column;
+                const trimmed = label.trim();
+                // An empty or unchanged heading is not an override: clearing it puts the column back
+                // to following the catalogue, which is what `label: null` means in the stored shape.
+                const { label: _previous, ...rest } = column;
+                return trimmed && trimmed !== column.catalogueLabel ? { ...rest, label: trimmed } : rest;
+            }),
+        );
+    }, []);
+
+    const handleRevert = useCallback((index: number) => {
+        setDraft((current) =>
+            current.map((column, position) => {
+                if (position !== index) return column;
+                const { label: _removed, ...rest } = column;
+                return rest;
+            }),
+        );
+    }, []);
+
+    const handleRemove = useCallback((index: number) => {
+        setDraft((current) => current.filter((_column, position) => position !== index));
+    }, []);
+
+    const handleMove = useCallback((from: number, to: number) => {
+        setDraft((current) => moveColumn(current, from, to));
+    }, []);
+
+    const handleResetToStandard = useCallback(() => {
+        setDraft(resolveColumns(standardColumns, fields, standardColumns));
+    }, [standardColumns, fields]);
+
+    // What Save would actually send: an unresolved column is dropped, having stayed visible until
+    // then so the user could see what had gone rather than watch a heading disappear.
+    const savableColumns = useMemo(
+        () => draft.filter((column) => column.available).map(({ available: _available, ...column }) => column),
+        [draft],
+    );
+
+    const handleSave = useCallback(() => {
+        // Guarded as well as disabled: the API rejects an empty column set.
+        if (savableColumns.length === 0) return;
+        onSave(savableColumns);
+    }, [savableColumns, onSave]);
+
+    const isAtCap = draft.length >= MAX_COLUMNS;
+
+    return (
+        <Dialog
+            isOpen={isOpen}
+            toggle={onClose}
+            size="xl"
+            dataTestId={dataTestId}
+            caption={
+                <span className="flex flex-col">
+                    <span>Edit columns</span>
+                    {resourceLabel && (
+                        <span className="text-xs font-normal text-content-muted">{`${resourceLabel} · visible only to you`}</span>
+                    )}
+                </span>
+            }
+            body={
+                <div>
+                    <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+                        <AvailableFields
+                            fields={fields}
+                            selected={draft}
+                            search={search}
+                            onSearchChange={setSearch}
+                            onAdd={handleAdd}
+                            isAtCap={isAtCap}
+                            getSourceLabel={resolveSourceLabel}
+                        />
+                        <SelectedColumns
+                            columns={draft}
+                            getSourceLabel={resolveSourceLabel}
+                            onRename={handleRename}
+                            onRevert={handleRevert}
+                            onRemove={handleRemove}
+                            onMove={handleMove}
+                            onResetToStandard={handleResetToStandard}
+                        />
+                    </div>
+                    <HeaderPreview columns={draft} />
+                </div>
+            }
+            buttons={[
+                { key: 'cancel', color: 'secondary', variant: 'outline', body: 'Cancel', onClick: onClose },
+                // The API rejects an empty column set, so this is the one place the dialog blocks
+                // outright rather than warning. Counted over what would be sent, not over the draft:
+                // a draft of nothing but unavailable rows resolves to an empty request.
+                { key: 'save', color: 'primary', body: 'Save', onClick: handleSave, disabled: savableColumns.length === 0 },
+            ]}
+        />
+    );
+}

--- a/src/components/CustomTable/columns/AttributeCell.spec.tsx
+++ b/src/components/CustomTable/columns/AttributeCell.spec.tsx
@@ -1,0 +1,143 @@
+import { expect, test } from '../../../../playwright/ct-test';
+import { withProviders } from 'utils/test-helpers';
+import { AttributeContentType } from 'types/openapi';
+import AttributeCell from './AttributeCell';
+
+/** A cell is only comparable down a column if every row is the same height. */
+const CELL_WIDTH = 200;
+
+const inCell = (component: React.ReactElement) => (
+    <div style={{ width: `${CELL_WIDTH}px` }} data-testid="cell-box">
+        {component}
+    </div>
+);
+
+test.describe('AttributeCell', () => {
+    test('renders the empty state when the row has no value for the column', async ({ mount, page }) => {
+        await mount(withProviders(inCell(<AttributeCell contentType={AttributeContentType.String} content={undefined} />)));
+
+        await expect(page.getByTestId('empty-cell')).toBeVisible();
+        await expect(page.getByText('No value')).toHaveCount(1);
+    });
+
+    test('renders the empty state for content that is present but empty', async ({ mount, page }) => {
+        await mount(withProviders(inCell(<AttributeCell contentType={AttributeContentType.String} content={[]} />)));
+
+        await expect(page.getByTestId('empty-cell')).toBeVisible();
+    });
+
+    test('renders the empty state when the catalogue reports no content type', async ({ mount, page }) => {
+        await mount(withProviders(inCell(<AttributeCell contentType={undefined} content={[{ data: 'ignored' }]} />)));
+
+        await expect(page.getByTestId('empty-cell')).toBeVisible();
+    });
+
+    test('renders a single value as text', async ({ mount, page }) => {
+        await mount(withProviders(inCell(<AttributeCell contentType={AttributeContentType.String} content={[{ data: 'production' }]} />)));
+
+        await expect(page.getByText('production')).toBeVisible();
+        await expect(page.getByTestId('empty-cell')).toHaveCount(0);
+    });
+
+    test('renders a boolean as Yes rather than as true', async ({ mount, page }) => {
+        await mount(withProviders(inCell(<AttributeCell contentType={AttributeContentType.Boolean} content={[{ data: true }]} />)));
+
+        await expect(page.getByText('Yes')).toBeVisible();
+    });
+
+    test('shows the first value and a count for a multi-valued attribute', async ({ mount, page }) => {
+        await mount(
+            withProviders(
+                inCell(
+                    <AttributeCell
+                        contentType={AttributeContentType.String}
+                        content={[{ data: 'production' }, { data: 'staging' }, { data: 'dr-site' }]}
+                    />,
+                ),
+            ),
+        );
+
+        await expect(page.getByText('production')).toBeVisible();
+        await expect(page.getByText('+2')).toBeVisible();
+        await expect(page.getByText('staging')).toHaveCount(0);
+    });
+
+    test('reveals every value of a multi-valued attribute, in item order', async ({ mount, page }) => {
+        await mount(
+            withProviders(
+                inCell(
+                    <AttributeCell
+                        contentType={AttributeContentType.String}
+                        content={[{ data: 'production' }, { data: 'staging' }, { data: 'dr-site' }]}
+                    />,
+                ),
+            ),
+        );
+
+        await page.getByRole('button', { name: 'Show all 3 values' }).click();
+
+        await expect(page.getByRole('listitem')).toHaveText(['production', 'staging', 'dr-site']);
+    });
+
+    test('keeps a multi-valued cell exactly as tall as a single-valued one', async ({ mount, page }) => {
+        // Rendered together so the two are measured in one layout: a `+N` pill that made its row a
+        // fraction taller would be invisible on one row and obvious down a column of twenty-five.
+        await mount(
+            withProviders(
+                <div style={{ width: `${CELL_WIDTH}px` }}>
+                    <div data-testid="one">
+                        <AttributeCell contentType={AttributeContentType.String} content={[{ data: 'production' }]} />
+                    </div>
+                    <div data-testid="many">
+                        <AttributeCell
+                            contentType={AttributeContentType.String}
+                            content={[{ data: 'a-very-long-value-that-would-wrap-if-it-could' }, { data: 'b' }, { data: 'c' }]}
+                        />
+                    </div>
+                    <div data-testid="none">
+                        <AttributeCell contentType={AttributeContentType.String} content={undefined} />
+                    </div>
+                </div>,
+            ),
+        );
+
+        const heights = await page.evaluate(() =>
+            ['one', 'many', 'none'].map((id) =>
+                Math.round(document.querySelector(`[data-testid="${id}"]`)?.getBoundingClientRect().height ?? 0),
+            ),
+        );
+
+        expect(new Set(heights).size).toBe(1);
+    });
+
+    test('links a resource value to the referenced object', async ({ mount, page }) => {
+        await mount(
+            withProviders(
+                inCell(
+                    <AttributeCell
+                        contentType={AttributeContentType.Resource}
+                        content={[{ data: { resource: 'certificates', uuid: 'u-1', name: 'api.acme.test' } }]}
+                    />,
+                ),
+            ),
+        );
+
+        await expect(page.getByRole('link', { name: 'api.acme.test' })).toHaveAttribute('href', '/certificates/detail/u-1');
+    });
+
+    test('shows a file by name only and keeps the mime type off the column', async ({ mount, page }) => {
+        await mount(
+            withProviders(
+                inCell(
+                    <AttributeCell
+                        contentType={AttributeContentType.File}
+                        content={[{ data: { fileName: 'chain.pem', mimeType: 'application/x-pem-file', content: 'x' } }]}
+                    />,
+                ),
+            ),
+        );
+
+        await expect(page.getByText('chain.pem')).toBeVisible();
+        await expect(page.getByText('application/x-pem-file')).toHaveCount(0);
+    });
+});

--- a/src/components/CustomTable/columns/AttributeCell.spec.tsx
+++ b/src/components/CustomTable/columns/AttributeCell.spec.tsx
@@ -125,6 +125,43 @@ test.describe('AttributeCell', () => {
         await expect(page.getByRole('link', { name: 'api.acme.test' })).toHaveAttribute('href', '/certificates/detail/u-1');
     });
 
+    /** Its detail route also takes the parent entity, which a projected value does not carry. */
+    test('leaves a location unlinked rather than pointing at a route that cannot resolve', async ({ mount, page }) => {
+        await mount(
+            withProviders(
+                inCell(
+                    <AttributeCell
+                        contentType={AttributeContentType.Resource}
+                        content={[{ data: { resource: 'locations', uuid: 'u-1', name: 'Rack 4' } }]}
+                    />,
+                ),
+            ),
+        );
+
+        await expect(page.getByText('Rack 4')).toBeVisible();
+        await expect(page.getByRole('link')).toHaveCount(0);
+    });
+
+    test('keeps the overflow values navigable when they were navigable in the cell', async ({ mount, page }) => {
+        await mount(
+            withProviders(
+                inCell(
+                    <AttributeCell
+                        contentType={AttributeContentType.Resource}
+                        content={[
+                            { data: { resource: 'certificates', uuid: 'u-1', name: 'api.acme.test' } },
+                            { data: { resource: 'certificates', uuid: 'u-2', name: 'web.acme.test' } },
+                        ]}
+                    />,
+                ),
+            ),
+        );
+
+        await page.getByTestId('multi-value-overflow').click();
+
+        await expect(page.getByRole('link', { name: 'web.acme.test' })).toHaveAttribute('href', '/certificates/detail/u-2');
+    });
+
     test('shows a file by name only and keeps the mime type off the column', async ({ mount, page }) => {
         await mount(
             withProviders(

--- a/src/components/CustomTable/columns/AttributeCell.tsx
+++ b/src/components/CustomTable/columns/AttributeCell.tsx
@@ -1,0 +1,41 @@
+import cn from 'classnames';
+import type { BaseAttributeContentModel } from 'types/attributes';
+import { AttributeContentType } from 'types/openapi';
+import { getListCellValues } from 'utils/attributes/listCellValues';
+import EmptyCell from './EmptyCell';
+import MultiValueCell from './MultiValueCell';
+
+type Props = Readonly<{
+    contentType: AttributeContentType | undefined;
+    content: BaseAttributeContentModel[] | undefined;
+    dataTestId?: string;
+}>;
+
+/** Content types whose digits should line up down the column. */
+const TABULAR_CONTENT_TYPES: ReadonlySet<AttributeContentType> = new Set([
+    AttributeContentType.Integer,
+    AttributeContentType.Float,
+    AttributeContentType.Date,
+    AttributeContentType.Time,
+    AttributeContentType.Datetime,
+]);
+
+/**
+ * An attribute-sourced cell. Absence is answered first — a row simply may not have the attribute —
+ * and only then does the content type decide how the values are rendered.
+ */
+export default function AttributeCell({ contentType, content, dataTestId }: Props) {
+    // A column whose catalogue entry carries no content type cannot be interpreted; that is a
+    // missing value as far as the row is concerned, not a reason to render something arbitrary.
+    const values = contentType ? getListCellValues(contentType, content) : [];
+
+    if (values.length === 0) return <EmptyCell />;
+
+    const isTabular = contentType !== undefined && TABULAR_CONTENT_TYPES.has(contentType);
+
+    return (
+        <span className={cn('block min-w-0', { 'tabular-nums': isTabular })}>
+            <MultiValueCell values={values} dataTestId={dataTestId} />
+        </span>
+    );
+}

--- a/src/components/CustomTable/columns/EmptyCell.tsx
+++ b/src/components/CustomTable/columns/EmptyCell.tsx
@@ -1,0 +1,13 @@
+/**
+ * The cell of a row that has no value for a column. An em dash rather than a blank cell, which
+ * reads as a rendering fault, and rather than the attribute fallback's `'Not set'`, which is
+ * detail-page copy. Empty is one state, not one per content type, so every column uses this.
+ */
+export default function EmptyCell() {
+    return (
+        <span className="text-content-subtle" data-testid="empty-cell">
+            <span aria-hidden="true">&mdash;</span>
+            <span className="sr-only">No value</span>
+        </span>
+    );
+}

--- a/src/components/CustomTable/columns/MultiValueCell.tsx
+++ b/src/components/CustomTable/columns/MultiValueCell.tsx
@@ -1,0 +1,49 @@
+import Badge from 'components/Badge';
+import Toggletip from 'components/Toggletip';
+import type { ListCellValue } from 'utils/attributes/listCellValues';
+import ValueCell from './ValueCell';
+
+type Props = Readonly<{
+    /** Every value the attribute holds, in `item_order`. */
+    values: ListCellValue[];
+    dataTestId?: string;
+}>;
+
+/**
+ * A multi-valued attribute in a list cell: the first value plus a `+N` pill that reveals the rest.
+ * Joining values with `', '` — which the certificates Groups cell does today — turns five values
+ * into one ever-widening line, and that does not survive a user adding ten more columns. The `+N`
+ * treatment is the connector capability cell's, adopted rather than reinvented.
+ */
+export default function MultiValueCell({ values, dataTestId }: Props) {
+    const [first, ...rest] = values;
+
+    if (rest.length === 0) return <ValueCell value={first} dataTestId={dataTestId} />;
+
+    return (
+        // `items-center` on a nowrap flex row keeps the pill inside the cell's own line box, so a
+        // row carrying several values is exactly as tall as one carrying a single value.
+        <span className="flex min-w-0 items-center gap-1 whitespace-nowrap" data-testid={dataTestId}>
+            <ValueCell value={first} />
+            <Toggletip
+                ariaLabel={`Show all ${values.length} values`}
+                triggerClassName="shrink-0"
+                dataTestId={dataTestId ? `${dataTestId}-overflow` : 'multi-value-overflow'}
+                triggerContent={
+                    <Badge color="secondary" size="small">
+                        {`+${rest.length}`}
+                    </Badge>
+                }
+                content={
+                    <ul className="m-0 flex list-none flex-col gap-1 p-0">
+                        {values.map((value, index) => (
+                            // Values are free text and may repeat, so a value's position in
+                            // item_order is the only stable identity it has here.
+                            <li key={`${value.label}-${index}`}>{value.detail ? `${value.label} (${value.detail})` : value.label}</li>
+                        ))}
+                    </ul>
+                }
+            />
+        </span>
+    );
+}

--- a/src/components/CustomTable/columns/MultiValueCell.tsx
+++ b/src/components/CustomTable/columns/MultiValueCell.tsx
@@ -1,6 +1,7 @@
+import { Link } from 'react-router';
 import Badge from 'components/Badge';
 import Toggletip from 'components/Toggletip';
-import type { ListCellValue } from 'utils/attributes/listCellValues';
+import { listCellLinkPath, type ListCellValue } from 'utils/attributes/listCellValues';
 import ValueCell from './ValueCell';
 
 type Props = Readonly<{
@@ -10,10 +11,9 @@ type Props = Readonly<{
 }>;
 
 /**
- * A multi-valued attribute in a list cell: the first value plus a `+N` pill that reveals the rest.
- * Joining values with `', '` — which the certificates Groups cell does today — turns five values
- * into one ever-widening line, and that does not survive a user adding ten more columns. The `+N`
- * treatment is the connector capability cell's, adopted rather than reinvented.
+ * A multi-valued attribute in a list cell: the first value on the cell's single line, with the rest
+ * behind a `+N` pill. Every value is repeated inside the reveal, so the first one does not have to
+ * be read twice, and a value that was navigable in the cell stays navigable there.
  */
 export default function MultiValueCell({ values, dataTestId }: Props) {
     const [first, ...rest] = values;
@@ -39,7 +39,15 @@ export default function MultiValueCell({ values, dataTestId }: Props) {
                         {values.map((value, index) => (
                             // Values are free text and may repeat, so a value's position in
                             // item_order is the only stable identity it has here.
-                            <li key={`${value.label}-${index}`}>{value.detail ? `${value.label} (${value.detail})` : value.label}</li>
+                            <li key={`${value.label}-${index}`}>
+                                {value.link ? (
+                                    <Link to={listCellLinkPath(value.link)}>{value.label}</Link>
+                                ) : value.detail ? (
+                                    `${value.label} (${value.detail})`
+                                ) : (
+                                    value.label
+                                )}
+                            </li>
                         ))}
                     </ul>
                 }

--- a/src/components/CustomTable/columns/TruncatedCell.spec.tsx
+++ b/src/components/CustomTable/columns/TruncatedCell.spec.tsx
@@ -10,6 +10,12 @@ const inBox = (width: number, value: string) => (
     </div>
 );
 
+const linkInBox = (width: number, value: string) => (
+    <div style={{ width: `${width}px` }} data-testid="box">
+        <TruncatedCell value={value} to="/certificates/detail/u-1" dataTestId="cell" />
+    </div>
+);
+
 test.describe('TruncatedCell', () => {
     test('shows the value on one line when the column is wide enough', async ({ mount, page }) => {
         await mount(withProviders(inBox(600, 'api.acme.test')));
@@ -42,5 +48,23 @@ test.describe('TruncatedCell', () => {
         await page.getByTestId('cell').hover();
 
         await expect(page.getByRole('tooltip')).toHaveText(LONG_VALUE);
+    });
+
+    test('measures a link the same way, so a linked value is not cut off unreadably', async ({ mount, page }) => {
+        await mount(withProviders(linkInBox(120, LONG_VALUE)));
+
+        await expect(page.getByTestId('cell')).toHaveAttribute('href', '/certificates/detail/u-1');
+
+        await page.getByTestId('cell').hover();
+
+        await expect(page.getByRole('tooltip')).toHaveText(LONG_VALUE);
+    });
+
+    test('leaves a linked value that fits without a tooltip', async ({ mount, page }) => {
+        await mount(withProviders(linkInBox(600, 'api.acme.test')));
+
+        await page.getByTestId('cell').hover();
+
+        await expect(page.getByRole('tooltip')).toHaveCount(0);
     });
 });

--- a/src/components/CustomTable/columns/TruncatedCell.spec.tsx
+++ b/src/components/CustomTable/columns/TruncatedCell.spec.tsx
@@ -1,0 +1,46 @@
+import { expect, test } from '../../../../playwright/ct-test';
+import { withProviders } from 'utils/test-helpers';
+import TruncatedCell from './TruncatedCell';
+
+const LONG_VALUE = 'CN=api.internal.acme.test, OU=Platform Engineering, O=Acme Corporation, L=Prague, C=CZ';
+
+const inBox = (width: number, value: string) => (
+    <div style={{ width: `${width}px` }} data-testid="box">
+        <TruncatedCell value={value} dataTestId="cell" />
+    </div>
+);
+
+test.describe('TruncatedCell', () => {
+    test('shows the value on one line when the column is wide enough', async ({ mount, page }) => {
+        await mount(withProviders(inBox(600, 'api.acme.test')));
+
+        await expect(page.getByTestId('cell')).toHaveText('api.acme.test');
+        // No tooltip wrapper at all: repeating a value that is already fully visible would be
+        // noise on every cell of every row.
+        await page.getByTestId('cell').hover();
+        await expect(page.getByRole('tooltip')).toHaveCount(0);
+    });
+
+    test('keeps a value that does not fit on one line and cuts it off', async ({ mount, page }) => {
+        await mount(withProviders(inBox(120, LONG_VALUE)));
+
+        const metrics = await page.getByTestId('cell').evaluate((element) => ({
+            scrollWidth: element.scrollWidth,
+            clientWidth: element.clientWidth,
+            whiteSpace: getComputedStyle(element).whiteSpace,
+            textOverflow: getComputedStyle(element).textOverflow,
+        }));
+
+        expect(metrics.scrollWidth).toBeGreaterThan(metrics.clientWidth);
+        expect(metrics.whiteSpace).toBe('nowrap');
+        expect(metrics.textOverflow).toBe('ellipsis');
+    });
+
+    test('reveals the full value when it has been cut off', async ({ mount, page }) => {
+        await mount(withProviders(inBox(120, LONG_VALUE)));
+
+        await page.getByTestId('cell').hover();
+
+        await expect(page.getByRole('tooltip')).toHaveText(LONG_VALUE);
+    });
+});

--- a/src/components/CustomTable/columns/TruncatedCell.tsx
+++ b/src/components/CustomTable/columns/TruncatedCell.tsx
@@ -1,28 +1,35 @@
+import { Link } from 'react-router';
 import Tooltip from 'components/Tooltip';
 import { useIsTruncated } from 'utils/common-hooks';
 
 type Props = Readonly<{
     /** The value the cell shows, and the full value revealed when it does not fit. */
     value: string;
+    /** When set, the measured element is a link to this route rather than plain text. */
+    to?: string;
     dataTestId?: string;
 }>;
 
 /**
- * A single-line cell that reveals its full value only when the column is too narrow to show it.
- * Twenty-five rows stay comparable only if every row is the same height, so a long value truncates
- * rather than wraps — and a truncated value the user cannot read back is worse than no column, so
- * the overflow goes into a tooltip. An untruncated value gets none, because a tooltip repeating
- * what is already on screen is noise on every cell of every row.
+ * A single-line cell that reveals its full value only when the column is too narrow to show it. Rows
+ * stay comparable only if they are all one line high, so a long value truncates rather than wraps,
+ * and the overflow goes into a tooltip so it stays readable. An untruncated value gets none, or
+ * every cell of every row would carry a tooltip repeating what is already on screen.
  *
- * The tooltip wrapper is forced to full width. It is inline-block by default, which would shrink to
- * its content, narrow the span that was just measured, and flip the truncation back off — the
- * measurement would undo the thing it triggered.
+ * The tooltip wrapper is forced to full width: inline-block would shrink to its content, narrowing
+ * the element that was just measured and flipping the truncation back off.
  */
-export default function TruncatedCell({ value, dataTestId }: Props) {
-    const [ref, isTruncated] = useIsTruncated<HTMLSpanElement>(value);
+export default function TruncatedCell({ value, to, dataTestId }: Props) {
+    const [ref, isTruncated] = useIsTruncated<HTMLElement>(value);
 
-    const text = (
-        <span ref={ref} className="block max-w-full overflow-hidden text-ellipsis whitespace-nowrap" data-testid={dataTestId}>
+    const className = 'block max-w-full overflow-hidden text-ellipsis whitespace-nowrap';
+
+    const text = to ? (
+        <Link ref={ref} className={className} to={to} data-testid={dataTestId}>
+            {value}
+        </Link>
+    ) : (
+        <span ref={ref} className={className} data-testid={dataTestId}>
             {value}
         </span>
     );

--- a/src/components/CustomTable/columns/TruncatedCell.tsx
+++ b/src/components/CustomTable/columns/TruncatedCell.tsx
@@ -1,0 +1,37 @@
+import Tooltip from 'components/Tooltip';
+import { useIsTruncated } from 'utils/common-hooks';
+
+type Props = Readonly<{
+    /** The value the cell shows, and the full value revealed when it does not fit. */
+    value: string;
+    dataTestId?: string;
+}>;
+
+/**
+ * A single-line cell that reveals its full value only when the column is too narrow to show it.
+ * Twenty-five rows stay comparable only if every row is the same height, so a long value truncates
+ * rather than wraps — and a truncated value the user cannot read back is worse than no column, so
+ * the overflow goes into a tooltip. An untruncated value gets none, because a tooltip repeating
+ * what is already on screen is noise on every cell of every row.
+ *
+ * The tooltip wrapper is forced to full width. It is inline-block by default, which would shrink to
+ * its content, narrow the span that was just measured, and flip the truncation back off — the
+ * measurement would undo the thing it triggered.
+ */
+export default function TruncatedCell({ value, dataTestId }: Props) {
+    const [ref, isTruncated] = useIsTruncated<HTMLSpanElement>(value);
+
+    const text = (
+        <span ref={ref} className="block max-w-full overflow-hidden text-ellipsis whitespace-nowrap" data-testid={dataTestId}>
+            {value}
+        </span>
+    );
+
+    if (!isTruncated) return text;
+
+    return (
+        <Tooltip content={value} className="w-full align-bottom" triggerClassName="block w-full">
+            {text}
+        </Tooltip>
+    );
+}

--- a/src/components/CustomTable/columns/ValueCell.tsx
+++ b/src/components/CustomTable/columns/ValueCell.tsx
@@ -1,6 +1,5 @@
-import { Link } from 'react-router';
 import Tooltip from 'components/Tooltip';
-import type { ListCellValue } from 'utils/attributes/listCellValues';
+import { listCellLinkPath, type ListCellValue } from 'utils/attributes/listCellValues';
 import TruncatedCell from './TruncatedCell';
 
 type Props = Readonly<{
@@ -15,15 +14,7 @@ type Props = Readonly<{
  */
 export default function ValueCell({ value, dataTestId }: Props) {
     if (value.link) {
-        return (
-            <Link
-                className="block max-w-full overflow-hidden text-ellipsis whitespace-nowrap"
-                to={`/${value.link.resource}/detail/${value.link.uuid}`}
-                data-testid={dataTestId}
-            >
-                {value.label}
-            </Link>
-        );
+        return <TruncatedCell value={value.label} to={listCellLinkPath(value.link)} dataTestId={dataTestId} />;
     }
 
     if (value.detail) {

--- a/src/components/CustomTable/columns/ValueCell.tsx
+++ b/src/components/CustomTable/columns/ValueCell.tsx
@@ -1,0 +1,40 @@
+import { Link } from 'react-router';
+import Tooltip from 'components/Tooltip';
+import type { ListCellValue } from 'utils/attributes/listCellValues';
+import TruncatedCell from './TruncatedCell';
+
+type Props = Readonly<{
+    value: ListCellValue;
+    dataTestId?: string;
+}>;
+
+/**
+ * One attribute value in a list cell: its label on a single line, linked when it points at an
+ * addressable object, and with anything that does not fit the column — the value itself, or a
+ * detail such as a file's mime type — reachable without leaving the row.
+ */
+export default function ValueCell({ value, dataTestId }: Props) {
+    if (value.link) {
+        return (
+            <Link
+                className="block max-w-full overflow-hidden text-ellipsis whitespace-nowrap"
+                to={`/${value.link.resource}/detail/${value.link.uuid}`}
+                data-testid={dataTestId}
+            >
+                {value.label}
+            </Link>
+        );
+    }
+
+    if (value.detail) {
+        return (
+            <Tooltip content={`${value.label} (${value.detail})`} className="max-w-full align-bottom" triggerClassName="max-w-full">
+                <span className="block max-w-full overflow-hidden text-ellipsis whitespace-nowrap" data-testid={dataTestId}>
+                    {value.label}
+                </span>
+            </Tooltip>
+        );
+    }
+
+    return <TruncatedCell value={value.label} dataTestId={dataTestId} />;
+}

--- a/src/components/CustomTable/columns/buildTableRows.spec.tsx
+++ b/src/components/CustomTable/columns/buildTableRows.spec.tsx
@@ -1,0 +1,140 @@
+import { expect, test } from '../../../../playwright/ct-test';
+import { withProviders } from 'utils/test-helpers';
+import { AttributeContentType, FilterFieldSource } from 'types/openapi';
+import type { AttributeProjectable, ColumnDefinition } from 'types/tableColumns';
+import CustomTable from '..';
+import { buildColumnHeaders } from 'utils/tableColumns';
+import { buildTableRows } from './buildTableRows';
+import type { CellRegistry } from './registry';
+
+interface Row extends AttributeProjectable {
+    uuid: string;
+    commonName: string;
+}
+
+const commonName: ColumnDefinition = {
+    fieldSource: FilterFieldSource.Property,
+    fieldIdentifier: 'COMMON_NAME',
+    catalogueLabel: 'Common Name',
+};
+
+const costCentre: ColumnDefinition = {
+    fieldSource: FilterFieldSource.Custom,
+    fieldIdentifier: 'costCentre',
+    catalogueLabel: 'Cost centre',
+    attributeContentType: AttributeContentType.Integer,
+};
+
+const environment: ColumnDefinition = {
+    fieldSource: FilterFieldSource.Custom,
+    fieldIdentifier: 'environment',
+    catalogueLabel: 'Environment',
+    attributeContentType: AttributeContentType.String,
+};
+
+const rows: Row[] = [
+    {
+        uuid: 'u-1',
+        commonName: 'api.acme.test',
+        attributeValues: {
+            [FilterFieldSource.Custom]: { costCentre: [{ data: 4820 }], environment: [{ data: 'production' }, { data: 'staging' }] },
+        },
+    },
+    { uuid: 'u-2', commonName: 'vpn.acme.test', attributeValues: { [FilterFieldSource.Custom]: { environment: [{ data: 'dmz' }] } } },
+];
+
+const registry: CellRegistry<Row> = {
+    'property:COMMON_NAME': (row) => <a href={`/certificates/detail/${row.uuid}`}>{row.commonName}</a>,
+};
+
+const renderTable = (columns: ColumnDefinition[]) =>
+    withProviders(
+        <CustomTable
+            headers={buildColumnHeaders(columns)}
+            data={buildTableRows(rows, columns, { getRowId: (row) => row.uuid, registry })}
+        />,
+    );
+
+test.describe('buildTableRows', () => {
+    test('renders a row from the column definitions it is given', async ({ mount, page }) => {
+        await mount(renderTable([commonName, costCentre, environment]));
+
+        await expect(page.getByRole('columnheader')).toHaveText(['Common Name', 'Cost centre', 'Environment']);
+        await expect(page.getByRole('row').nth(1).getByRole('cell')).toHaveText(['api.acme.test', '4820', /production/]);
+    });
+
+    test('renders the same row in a different column order without touching the row data', async ({ mount, page }) => {
+        await mount(renderTable([environment, commonName, costCentre]));
+
+        await expect(page.getByRole('columnheader')).toHaveText(['Environment', 'Common Name', 'Cost centre']);
+        await expect(page.getByRole('row').nth(1).getByRole('cell')).toHaveText([/production/, 'api.acme.test', '4820']);
+    });
+
+    test('uses the registry entry for a rich property column', async ({ mount, page }) => {
+        await mount(renderTable([commonName]));
+
+        await expect(page.getByRole('link', { name: 'api.acme.test' })).toBeVisible();
+        await expect(page.getByRole('link', { name: 'vpn.acme.test' })).toBeVisible();
+    });
+
+    test('falls back to the attribute renderer for a column with no registry entry', async ({ mount, page }) => {
+        await mount(renderTable([costCentre]));
+
+        await expect(page.getByRole('row').nth(1).getByRole('cell')).toHaveText(['4820']);
+    });
+
+    test('renders the empty state for a row missing a value, without dropping the cell', async ({ mount, page }) => {
+        await mount(renderTable([commonName, costCentre]));
+
+        // The second row has no cost centre, so its cell is the shared empty state rather than absent.
+        await expect(page.getByRole('row').nth(2).getByRole('cell')).toHaveCount(2);
+        await expect(page.getByRole('row').nth(2).getByTestId('empty-cell')).toBeVisible();
+    });
+
+    test('holds every cell to one text line, whatever state it is in', async ({ mount, page }) => {
+        await mount(renderTable([commonName, costCentre, environment]));
+
+        // Row 1 carries a link, a number and a multi-valued attribute; row 2 carries a link, an
+        // empty cell and a single value. Every one of those is one line high, which is what keeps
+        // twenty-five rows comparable. Row boxes themselves differ by the table's own half-pixel
+        // divider, so the promise is asserted on the cell content rather than on the row.
+        const heights = await page.evaluate(() =>
+            [...document.querySelectorAll('tbody td')].map((cell) => Math.round(cell.getBoundingClientRect().height)),
+        );
+
+        expect(new Set(heights).size).toBe(1);
+    });
+
+    test('renders no rows for no data', async ({ mount }) => {
+        const columns = [commonName];
+        expect(buildTableRows([], columns, { getRowId: (row: Row) => row.uuid })).toEqual([]);
+    });
+
+    test('renders a row with no columns as a row with no cells', async ({ mount }) => {
+        expect(buildTableRows(rows, [], { getRowId: (row) => row.uuid })[0]).toMatchObject({ id: 'u-1', columns: [] });
+    });
+
+    test('carries row options through when the caller supplies them', async ({ mount }) => {
+        const built = buildTableRows(rows, [commonName], {
+            getRowId: (row) => row.uuid,
+            rowOptions: (row) => (row.uuid === 'u-1' ? { rowClassName: 'accent' } : undefined),
+        });
+
+        expect(built[0].options).toEqual({ rowClassName: 'accent' });
+        expect(built[1].options).toBeUndefined();
+    });
+
+    test('treats a registry entry that returns nothing as a missing value', async ({ mount, page }) => {
+        const blankRegistry: CellRegistry<Row> = { 'property:COMMON_NAME': () => '' };
+        await mount(
+            withProviders(
+                <CustomTable
+                    headers={buildColumnHeaders([commonName])}
+                    data={buildTableRows(rows, [commonName], { getRowId: (row) => row.uuid, registry: blankRegistry })}
+                />,
+            ),
+        );
+
+        await expect(page.getByTestId('empty-cell')).toHaveCount(2);
+    });
+});

--- a/src/components/CustomTable/columns/buildTableRows.tsx
+++ b/src/components/CustomTable/columns/buildTableRows.tsx
@@ -1,0 +1,61 @@
+import type { ReactNode } from 'react';
+import type { ColumnDefinition } from 'types/tableColumns';
+import { getColumnKey, getProjectedContent } from 'utils/tableColumns';
+import type { TableDataRow } from '../types';
+import AttributeCell from './AttributeCell';
+import EmptyCell from './EmptyCell';
+import type { CellRegistry } from './registry';
+
+/** A registry result that carries nothing to show. */
+function isBlank(rendered: ReactNode): boolean {
+    return rendered === null || rendered === undefined || rendered === '';
+}
+
+/**
+ * The cell for one column of one row. Resolution runs in a fixed order:
+ *
+ * 1. the registry entry for the column, which owns the rich property cells;
+ * 2. otherwise the projected attribute values, rendered by content type;
+ * 3. and in either case the shared empty state when that produced nothing.
+ */
+export function renderCell<TRow extends object>(row: TRow, column: ColumnDefinition, registry?: CellRegistry<TRow>): ReactNode {
+    const renderer = registry?.[getColumnKey(column)];
+    if (renderer) {
+        const rendered = renderer(row, column);
+        return isBlank(rendered) ? <EmptyCell /> : rendered;
+    }
+
+    return (
+        <AttributeCell
+            contentType={column.attributeContentType}
+            content={getProjectedContent(row, column)}
+            dataTestId={`cell-${getColumnKey(column)}`}
+        />
+    );
+}
+
+export interface BuildTableRowsOptions<TRow> {
+    getRowId: (row: TRow) => string | number;
+    registry?: CellRegistry<TRow>;
+    rowOptions?: (row: TRow) => TableDataRow['options'];
+}
+
+/**
+ * Table rows for a column definition list. A row is rendered from the definitions it is given, in
+ * the order it is given them, rather than from a positional cell array a page assembles — which is
+ * what lets a column set chosen at runtime render at all.
+ */
+export function buildTableRows<TRow extends object>(
+    rows: TRow[],
+    columns: ColumnDefinition[],
+    { getRowId, registry, rowOptions }: BuildTableRowsOptions<TRow>,
+): TableDataRow[] {
+    return rows.map((row) => {
+        const options = rowOptions?.(row);
+        return {
+            id: getRowId(row),
+            columns: columns.map((column) => renderCell(row, column, registry)),
+            ...(options ? { options } : {}),
+        };
+    });
+}

--- a/src/components/CustomTable/columns/buildTableRows.unit.spec.tsx
+++ b/src/components/CustomTable/columns/buildTableRows.unit.spec.tsx
@@ -1,0 +1,145 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AttributeContentType, FilterFieldSource } from 'types/openapi';
+import type { ColumnDefinition } from 'types/tableColumns';
+import type { CellRegistry } from './registry';
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// The cell primitives are exercised in the browser by the component tests; here the subject is the
+// resolution order, so they are stubbed down to something the assertions can read.
+vi.mock('./EmptyCell', () => ({ default: () => <span data-testid="empty">empty</span> }));
+vi.mock('./AttributeCell', () => ({
+    default: ({ contentType, content }: { contentType?: string; content?: { data: unknown }[] }) => (
+        <span data-testid="attribute">{`${contentType}:${content?.map((item) => String(item.data)).join('|') ?? 'none'}`}</span>
+    ),
+}));
+
+const { buildTableRows, renderCell } = await import('./buildTableRows');
+
+interface Row {
+    uuid: string;
+    commonName?: string;
+    attributeValues?: Record<string, Record<string, { data: unknown }[]>>;
+}
+
+const commonName: ColumnDefinition = {
+    fieldSource: FilterFieldSource.Property,
+    fieldIdentifier: 'COMMON_NAME',
+    catalogueLabel: 'Common Name',
+};
+
+const costCentre: ColumnDefinition = {
+    fieldSource: FilterFieldSource.Custom,
+    fieldIdentifier: 'costCentre',
+    catalogueLabel: 'Cost centre',
+    attributeContentType: AttributeContentType.Integer,
+};
+
+const registry: CellRegistry<Row> = {
+    'property:COMMON_NAME': (row) => row.commonName,
+};
+
+describe('renderCell', () => {
+    let container: HTMLDivElement;
+    let root: Root;
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        root = createRoot(container);
+    });
+
+    afterEach(() => {
+        act(() => root.unmount());
+        container.remove();
+    });
+
+    const render = async (row: Row, column: ColumnDefinition, cellRegistry?: CellRegistry<Row>) => {
+        await act(async () => {
+            root.render(<>{renderCell(row, column, cellRegistry)}</>);
+        });
+    };
+
+    it('prefers the registry entry over the attribute renderer', async () => {
+        await render({ uuid: 'u-1', commonName: 'api.acme.test' }, commonName, registry);
+
+        expect(container.textContent).toBe('api.acme.test');
+        expect(container.querySelector('[data-testid="attribute"]')).toBeNull();
+    });
+
+    it('falls through to the attribute renderer when no entry is registered', async () => {
+        await render({ uuid: 'u-1', attributeValues: { custom: { costCentre: [{ data: 4820 }] } } }, costCentre, registry);
+
+        expect(container.querySelector('[data-testid="attribute"]')?.textContent).toBe('integer:4820');
+    });
+
+    it('falls through when no registry is supplied at all', async () => {
+        await render({ uuid: 'u-1', commonName: 'api.acme.test' }, commonName);
+
+        expect(container.querySelector('[data-testid="attribute"]')?.textContent).toBe('undefined:none');
+    });
+
+    it('renders the empty state when the registry entry has nothing to show', async () => {
+        for (const blank of [undefined, null, '']) {
+            await render({ uuid: 'u-1' }, commonName, { 'property:COMMON_NAME': () => blank });
+            expect(container.querySelector('[data-testid="empty"]')).not.toBeNull();
+        }
+    });
+
+    it('keeps a registry entry that renders a falsy but meaningful value', async () => {
+        await render({ uuid: 'u-1' }, commonName, { 'property:COMMON_NAME': () => 0 });
+
+        expect(container.textContent).toBe('0');
+        expect(container.querySelector('[data-testid="empty"]')).toBeNull();
+    });
+
+    it('passes the column to the registry entry, so one entry can serve several columns', async () => {
+        await render({ uuid: 'u-1' }, commonName, { 'property:COMMON_NAME': (_row, column) => column.catalogueLabel });
+
+        expect(container.textContent).toBe('Common Name');
+    });
+});
+
+describe('buildTableRows', () => {
+    const rows: Row[] = [
+        { uuid: 'u-1', commonName: 'api.acme.test', attributeValues: { custom: { costCentre: [{ data: 4820 }] } } },
+        { uuid: 'u-2', commonName: 'vpn.acme.test' },
+    ];
+
+    it('builds one row per entry, keyed by the id the caller derives', () => {
+        const built = buildTableRows(rows, [commonName], { getRowId: (row) => row.uuid, registry });
+
+        expect(built.map((row) => row.id)).toEqual(['u-1', 'u-2']);
+    });
+
+    it('builds one cell per column, in the order the columns are given', () => {
+        const built = buildTableRows(rows, [costCentre, commonName], { getRowId: (row) => row.uuid, registry });
+
+        expect(built[0].columns).toHaveLength(2);
+    });
+
+    it('returns no rows for no entries', () => {
+        expect(buildTableRows([], [commonName], { getRowId: (row: Row) => row.uuid })).toEqual([]);
+    });
+
+    it('returns a cell-less row for no columns', () => {
+        expect(buildTableRows(rows, [], { getRowId: (row) => row.uuid })).toEqual([
+            { id: 'u-1', columns: [] },
+            { id: 'u-2', columns: [] },
+        ]);
+    });
+
+    it('attaches row options only where the caller produced them', () => {
+        const built = buildTableRows(rows, [commonName], {
+            getRowId: (row) => row.uuid,
+            registry,
+            rowOptions: (row) => (row.uuid === 'u-1' ? { useAccentBottomBorder: true } : undefined),
+        });
+
+        expect(built[0].options).toEqual({ useAccentBottomBorder: true });
+        expect(built[1]).not.toHaveProperty('options');
+    });
+});

--- a/src/components/CustomTable/columns/index.ts
+++ b/src/components/CustomTable/columns/index.ts
@@ -1,0 +1,7 @@
+export { default as AttributeCell } from './AttributeCell';
+export { buildTableRows, renderCell, type BuildTableRowsOptions } from './buildTableRows';
+export { default as EmptyCell } from './EmptyCell';
+export { default as MultiValueCell } from './MultiValueCell';
+export type { CellRegistry, CellRenderer } from './registry';
+export { default as TruncatedCell } from './TruncatedCell';
+export { default as ValueCell } from './ValueCell';

--- a/src/components/CustomTable/columns/registry.ts
+++ b/src/components/CustomTable/columns/registry.ts
@@ -1,0 +1,18 @@
+import type { ReactNode } from 'react';
+import type { ColumnDefinition } from 'types/tableColumns';
+
+/**
+ * Renders the cell of one column from the listing entry itself. A registry entry exists for the
+ * property columns that are rich today — a status badge, a link to a detail page, an owner chip —
+ * where the value lives on the entry rather than in the projected attribute map.
+ *
+ * Returning `null`, `undefined` or `''` means the entry has no value for this column, and the row
+ * renders the shared empty state; a renderer never has to spell that out.
+ */
+export type CellRenderer<TRow> = (row: TRow, column: ColumnDefinition) => ReactNode;
+
+/**
+ * Cell renderers keyed by the column key — `property:COMMON_NAME`, for example. A field identifier
+ * is unique only within its source, so the key carries the source too.
+ */
+export type CellRegistry<TRow> = Readonly<Record<string, CellRenderer<TRow>>>;

--- a/src/components/Toggletip/index.tsx
+++ b/src/components/Toggletip/index.tsx
@@ -6,6 +6,12 @@ import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
 type Props = {
     content: ReactNode;
     ariaLabel?: string;
+    /**
+     * What the trigger button shows. Defaults to the info icon. A caller supplies this when the
+     * affordance is part of the content itself — a `+N` overflow pill, for example — so the
+     * trigger's hover, pinning and focus behaviour is not reimplemented alongside it.
+     */
+    triggerContent?: ReactNode;
     iconSize?: number;
     placement?: 'top' | 'bottom';
     triggerClassName?: string;
@@ -20,6 +26,7 @@ const HOVER_CLOSE_DELAY = 150;
 function Toggletip({
     content,
     ariaLabel = 'More information',
+    triggerContent,
     iconSize = 16,
     placement = 'bottom',
     triggerClassName,
@@ -83,7 +90,7 @@ function Toggletip({
                     onMouseEnter={hoverOpen}
                     onMouseLeave={hoverClose}
                 >
-                    <Info size={iconSize} className="block" aria-hidden />
+                    {triggerContent ?? <Info size={iconSize} className="block" aria-hidden />}
                 </button>
             </Popover.Trigger>
             <Popover.Portal>

--- a/src/components/_pages/certificates/certificateTableHelpers.spec.tsx
+++ b/src/components/_pages/certificates/certificateTableHelpers.spec.tsx
@@ -56,7 +56,7 @@ test.describe('certificateTableHelpers', () => {
             getEnumLabel: mockGetEnumLabel,
         };
 
-        test('returns array of 17 columns for minimal certificate', () => {
+        test('returns one column per entry in CERTIFICATE_COLUMNS for a minimal certificate', () => {
             const cert = buildListCertificate({
                 uuid: 'uuid-1',
                 commonName: 'cn.example.com',
@@ -73,7 +73,7 @@ test.describe('certificateTableHelpers', () => {
 
             const result = buildCertificateRowColumns(cert, baseOpts);
             expect(Array.isArray(result)).toBe(true);
-            expect(result).toHaveLength(16);
+            expect(result).toHaveLength(CERTIFICATE_COLUMNS.length);
         });
 
         test('with isLinkDisabled true commonName is plain text', () => {
@@ -89,9 +89,7 @@ test.describe('certificateTableHelpers', () => {
             const cert = buildListCertificate();
             const columns = buildCertificateRowColumns(cert, baseOpts);
 
-            // Groups is the 8th column: state, validation, compliance, key, common name, valid from,
-            // expires at, groups. An unset value is the em dash every column uses, not the
-            // per-column 'Unassigned' copy this cell used to invent.
+            // Groups is the eighth entry in CERTIFICATE_COLUMNS.
             await mount(<div>{columns[7]}</div>);
 
             await expect(page.getByTestId('empty-cell')).toBeVisible();
@@ -111,7 +109,7 @@ test.describe('certificateTableHelpers', () => {
 
             await expect(page.getByText('Production')).toBeVisible();
             await expect(page.getByText('+2')).toBeVisible();
-            // Joining every group into the cell is what made this column grow without bound.
+            // Joining every group would let the cell grow without bound.
             await expect(page.getByText('Production, PCI, EU')).toHaveCount(0);
         });
 

--- a/src/components/_pages/certificates/certificateTableHelpers.spec.tsx
+++ b/src/components/_pages/certificates/certificateTableHelpers.spec.tsx
@@ -1,7 +1,12 @@
 import { test, expect } from '../../../../playwright/ct-test';
-import { buildCertificateRowColumns, buildCertificateDetailBaseRows, buildCertificateProtocolRows } from './certificateTableHelpers';
+import {
+    buildCertificateRowColumns,
+    buildCertificateDetailBaseRows,
+    buildCertificateProtocolRows,
+    CERTIFICATE_COLUMNS,
+} from './certificateTableHelpers';
 import type { CertificateListResponseModel, CertificateDetailResponseModel } from 'types/certificate';
-import { CertificateProtocol, type CertificateProtocolDto, CertificateType } from 'types/openapi';
+import { AttributeContentType, CertificateProtocol, type CertificateProtocolDto, CertificateType, FilterFieldSource } from 'types/openapi';
 
 const mockDateFormatter = (d: Date) => d.toISOString().slice(0, 10);
 const mockGetEnumLabel = (_e: any, key: string) => key;
@@ -80,13 +85,62 @@ test.describe('certificateTableHelpers', () => {
             expect(commonNameColumn).toBe('test.example.com');
         });
 
-        test('groups Unassigned when no groups', () => {
+        test('renders the shared empty state for a certificate with no groups', async ({ mount, page }) => {
             const cert = buildListCertificate();
+            const columns = buildCertificateRowColumns(cert, baseOpts);
 
-            const result = buildCertificateRowColumns(cert, baseOpts);
-            // groups is 8th column (index 7): state, validationStatus, compliance, key, commonName, notBefore, notAfter, groups
-            const groupsColumn = result[7];
-            expect(groupsColumn).toBe('Unassigned');
+            // Groups is the 8th column: state, validation, compliance, key, common name, valid from,
+            // expires at, groups. An unset value is the em dash every column uses, not the
+            // per-column 'Unassigned' copy this cell used to invent.
+            await mount(<div>{columns[7]}</div>);
+
+            await expect(page.getByTestId('empty-cell')).toBeVisible();
+            await expect(page.getByText('Unassigned')).toHaveCount(0);
+        });
+
+        test('renders one group as a plain value and the rest behind a count', async ({ mount, page }) => {
+            const cert = buildListCertificate({
+                groups: [
+                    { uuid: 'g-1', name: 'Production' },
+                    { uuid: 'g-2', name: 'PCI' },
+                    { uuid: 'g-3', name: 'EU' },
+                ],
+            } as Partial<CertificateListResponseModel>);
+
+            await mount(<div>{buildCertificateRowColumns(cert, baseOpts)[7]}</div>);
+
+            await expect(page.getByText('Production')).toBeVisible();
+            await expect(page.getByText('+2')).toBeVisible();
+            // Joining every group into the cell is what made this column grow without bound.
+            await expect(page.getByText('Production, PCI, EU')).toHaveCount(0);
+        });
+
+        test('renders a row for a column set given in a different order', () => {
+            const cert = buildListCertificate({ commonName: 'cn.example.com', serialNumber: 'SN123' });
+            const reordered = [CERTIFICATE_COLUMNS[10], CERTIFICATE_COLUMNS[4]];
+
+            const result = buildCertificateRowColumns(cert, baseOpts, reordered);
+
+            expect(result).toHaveLength(2);
+            expect(result[0]).toBe('SN123');
+            expect(result[1]).toBe('cn.example.com');
+        });
+
+        test('renders an attribute-sourced column the registry knows nothing about', async ({ mount, page }) => {
+            const cert = buildListCertificate({
+                attributeValues: { custom: { costCentre: [{ data: 4820 }] } },
+            } as Partial<CertificateListResponseModel>);
+
+            const column = {
+                fieldSource: FilterFieldSource.Custom,
+                fieldIdentifier: 'costCentre',
+                catalogueLabel: 'Cost centre',
+                attributeContentType: AttributeContentType.Integer,
+            };
+
+            await mount(<div>{buildCertificateRowColumns(cert, baseOpts, [column])[0]}</div>);
+
+            await expect(page.getByText('4820')).toBeVisible();
         });
     });
 

--- a/src/components/_pages/certificates/certificateTableHelpers.tsx
+++ b/src/components/_pages/certificates/certificateTableHelpers.tsx
@@ -11,12 +11,18 @@ import {
     type CertificateValidationResultDto,
     CertificateValidationStatus,
     ComplianceStatus,
+    FilterFieldSource,
+    FilterFieldType,
     PlatformEnum,
 } from 'types/openapi';
 import type { CertificateListResponseModel, CertificateDetailResponseModel, SearchFilterModel } from 'types/certificate';
 import type { EnumItemModel } from 'types/enums';
 import type { Dispatch } from 'redux';
 import type { TableDataRow } from 'components/CustomTable';
+import { renderCell, type CellRegistry } from 'components/CustomTable/columns';
+import MultiValueCell from 'components/CustomTable/columns/MultiValueCell';
+import type { ColumnDefinition } from 'types/tableColumns';
+import type { ListCellValue } from 'utils/attributes/listCellValues';
 import { EnumValueDescription } from 'components/EnumDescription';
 import Tooltip from 'components/Tooltip';
 import CertificateStatus from './CertificateStatus';
@@ -99,64 +105,174 @@ function buildCertTypeCell(
     );
 }
 
+/**
+ * Renders the Groups cell. Joining group names with `', '` — which this cell used to do — turns five
+ * groups into one ever-widening line, and that does not survive a user adding more columns beside
+ * it, so the extra groups move behind a `+N` reveal.
+ */
+function buildGroupsValues(certificate: CertificateListResponseModel, isLinkDisabled: boolean): ListCellValue[] {
+    return (certificate.groups ?? []).map((group) => ({
+        label: group.name,
+        ...(isLinkDisabled ? {} : { link: { resource: 'groups', uuid: group.uuid } }),
+    }));
+}
+
+/**
+ * The platform default column set for the certificates inventory — the "Standard" tab. Field
+ * identifiers are the catalogue's own (`FilterField` enum names), so a saved view referring to the
+ * same field resolves to the same registry entry.
+ *
+ * The labels here are the headings the page ships today; the wiring ticket resolves them from the
+ * live catalogue instead, which is also where the set stops being hardcoded.
+ */
+export const CERTIFICATE_COLUMNS: ColumnDefinition[] = [
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'CERTIFICATE_STATE',
+        catalogueLabel: 'State',
+        type: FilterFieldType.List,
+        align: 'center',
+    },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'CERTIFICATE_VALIDATION_STATUS',
+        catalogueLabel: 'Validation',
+        type: FilterFieldType.List,
+        align: 'center',
+    },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'COMPLIANCE_STATUS',
+        catalogueLabel: 'Compliance',
+        type: FilterFieldType.List,
+        align: 'center',
+    },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'PRIVATE_KEY',
+        catalogueLabel: 'Has private key',
+        type: FilterFieldType.Boolean,
+        align: 'center',
+    },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'COMMON_NAME',
+        catalogueLabel: 'Common Name',
+        type: FilterFieldType.String,
+    },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'NOT_BEFORE',
+        catalogueLabel: 'Valid From',
+        type: FilterFieldType.Datetime,
+    },
+    { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'NOT_AFTER', catalogueLabel: 'Expires At', type: FilterFieldType.Datetime },
+    { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'GROUP_NAME', catalogueLabel: 'Groups', type: FilterFieldType.List },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'RA_PROFILE_NAME',
+        catalogueLabel: 'RA Profile',
+        type: FilterFieldType.List,
+    },
+    { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'OWNER', catalogueLabel: 'Owner', type: FilterFieldType.List },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'SERIAL_NUMBER',
+        catalogueLabel: 'Serial number',
+        type: FilterFieldType.String,
+    },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'SIGNATURE_ALGORITHM',
+        catalogueLabel: 'Signature Algorithm',
+        type: FilterFieldType.List,
+    },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'PUBLIC_KEY_ALGORITHM',
+        catalogueLabel: 'Public Key Algorithm',
+        type: FilterFieldType.List,
+    },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'ISSUER_COMMON_NAME',
+        catalogueLabel: 'Issuer Common Name',
+        type: FilterFieldType.String,
+    },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'CERTIFICATE_TYPE',
+        catalogueLabel: 'Certificate Type',
+        type: FilterFieldType.List,
+    },
+    { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'ARCHIVED', catalogueLabel: 'Archived', type: FilterFieldType.Boolean },
+];
+
+/**
+ * Cell renderers for the certificate property columns that are rich today — statuses, links, dates.
+ * Anything not registered here falls through to the attribute renderer, which is how a custom or
+ * metadata column the user picks renders without this file knowing about it.
+ */
+export function buildCertificateCellRegistry(opts: BuildCertificateRowColumnsOpts): CellRegistry<CertificateListResponseModel> {
+    const { isLinkDisabled, dateFormatter, certificateTypeEnum, getEnumLabel, onPendingAction } = opts;
+
+    return {
+        'property:CERTIFICATE_STATE': (certificate) => (
+            <>
+                <CertificateStatus status={certificate.state} asIcon={true} />
+                <PendingActionButtons certificate={certificate} compact onAction={onPendingAction} />
+            </>
+        ),
+        'property:CERTIFICATE_VALIDATION_STATUS': (certificate) => (
+            <CertificateStatus status={certificate.validationStatus} asIcon={true} />
+        ),
+        'property:COMPLIANCE_STATUS': (certificate) =>
+            certificate.complianceStatus ? <CertificateStatus status={certificate.complianceStatus} asIcon={true} /> : null,
+        'property:PRIVATE_KEY': (certificate) =>
+            certificate.privateKeyAvailability ? (
+                <Tooltip content="Private key is available for this certificate">
+                    <span>
+                        <KeyRound aria-hidden size={16} strokeWidth={1.5} />
+                        <span className="sr-only">Private key available</span>
+                    </span>
+                </Tooltip>
+            ) : null,
+        'property:COMMON_NAME': (certificate) => buildCommonNameCell(certificate, opts),
+        'property:NOT_BEFORE': (certificate) =>
+            certificate.notBefore ? <span className="whitespace-nowrap">{dateFormatter(new Date(certificate.notBefore))}</span> : null,
+        'property:NOT_AFTER': (certificate) =>
+            certificate.notAfter ? <span className="whitespace-nowrap">{dateFormatter(new Date(certificate.notAfter))}</span> : null,
+        'property:GROUP_NAME': (certificate) => {
+            const groups = buildGroupsValues(certificate, isLinkDisabled);
+            return groups.length > 0 ? <MultiValueCell values={groups} dataTestId="cell-groups" /> : null;
+        },
+        'property:RA_PROFILE_NAME': (certificate) =>
+            certificate.raProfile ? <span className="whitespace-nowrap">{buildRaProfileCell(certificate, isLinkDisabled)}</span> : null,
+        'property:OWNER': (certificate) => (certificate.owner ? buildOwnerCell(certificate, isLinkDisabled) : null),
+        'property:SERIAL_NUMBER': (certificate) => certificate.serialNumber,
+        'property:SIGNATURE_ALGORITHM': (certificate) => certificate.signatureAlgorithm,
+        'property:PUBLIC_KEY_ALGORITHM': (certificate) => certificate.publicKeyAlgorithm,
+        'property:ISSUER_COMMON_NAME': (certificate) => buildIssuerCell(certificate, isLinkDisabled),
+        'property:CERTIFICATE_TYPE': (certificate) => buildCertTypeCell(certificate, certificateTypeEnum, getEnumLabel),
+        'property:ARCHIVED': (certificate) => (
+            <Badge color={certificate.archived ? 'gray' : 'success'} size="small">
+                {certificate.archived ? 'Yes' : 'No'}
+            </Badge>
+        ),
+    };
+}
+
+/**
+ * The cells of one certificate row, rendered from the column definitions rather than assembled as a
+ * positional array — which is what lets a column set chosen at runtime render at all.
+ */
 export function buildCertificateRowColumns(
     certificate: CertificateListResponseModel,
     opts: BuildCertificateRowColumnsOpts,
-): (string | React.ReactNode)[] {
-    const { isLinkDisabled, dateFormatter, certificateTypeEnum, getEnumLabel, onPendingAction } = opts;
-    const commonNameCell = buildCommonNameCell(certificate, opts);
-    const groupsCell = buildGroupsCell(certificate, isLinkDisabled);
-    const raProfileCell = buildRaProfileCell(certificate, isLinkDisabled);
-    const ownerCell = buildOwnerCell(certificate, isLinkDisabled);
-    const issuerCell = buildIssuerCell(certificate, isLinkDisabled);
-    const certTypeCell = buildCertTypeCell(certificate, certificateTypeEnum, getEnumLabel);
-
-    return [
-        <React.Fragment key="state">
-            <CertificateStatus status={certificate.state} asIcon={true} />
-            <PendingActionButtons certificate={certificate} compact onAction={onPendingAction} />
-        </React.Fragment>,
-        <CertificateStatus key="validationStatus" status={certificate.validationStatus} asIcon={true} />,
-        certificate.complianceStatus ? <CertificateStatus key="compliance" status={certificate.complianceStatus} asIcon={true} /> : '',
-        certificate.privateKeyAvailability ? (
-            <Tooltip key="key" content="Private key is available for this certificate">
-                <span>
-                    <KeyRound aria-hidden size={16} strokeWidth={1.5} />
-                    <span className="sr-only">Private key available</span>
-                </span>
-            </Tooltip>
-        ) : (
-            ''
-        ),
-        commonNameCell,
-        certificate.notBefore ? (
-            <span key="notBefore" style={{ whiteSpace: 'nowrap' }}>
-                {dateFormatter(new Date(certificate.notBefore))}
-            </span>
-        ) : (
-            ''
-        ),
-        certificate.notAfter ? (
-            <span key="notAfter" style={{ whiteSpace: 'nowrap' }}>
-                {dateFormatter(new Date(certificate.notAfter))}
-            </span>
-        ) : (
-            ''
-        ),
-        groupsCell,
-        <span key="raProfile" style={{ whiteSpace: 'nowrap' }}>
-            {raProfileCell}
-        </span>,
-        ownerCell,
-        certificate.serialNumber || '',
-        certificate.signatureAlgorithm || '',
-        certificate.publicKeyAlgorithm || '',
-        issuerCell,
-        certTypeCell,
-        <Badge key="archivationStatus" color={certificate.archived ? 'gray' : 'success'} size="small">
-            {certificate.archived ? 'Yes' : 'No'}
-        </Badge>,
-    ];
+    columns: ColumnDefinition[] = CERTIFICATE_COLUMNS,
+): React.ReactNode[] {
+    const registry = buildCertificateCellRegistry(opts);
+    return columns.map((column) => renderCell(certificate, column, registry));
 }
 
 function buildQcStatementRows(

--- a/src/components/_pages/certificates/certificateTableHelpers.tsx
+++ b/src/components/_pages/certificates/certificateTableHelpers.tsx
@@ -105,11 +105,7 @@ function buildCertTypeCell(
     );
 }
 
-/**
- * Renders the Groups cell. Joining group names with `', '` — which this cell used to do — turns five
- * groups into one ever-widening line, and that does not survive a user adding more columns beside
- * it, so the extra groups move behind a `+N` reveal.
- */
+/** Prepares a certificate's groups for a single-line cell: the first name, the rest behind a `+N` reveal. */
 function buildGroupsValues(certificate: CertificateListResponseModel, isLinkDisabled: boolean): ListCellValue[] {
     return (certificate.groups ?? []).map((group) => ({
         label: group.name,
@@ -120,10 +116,8 @@ function buildGroupsValues(certificate: CertificateListResponseModel, isLinkDisa
 /**
  * The platform default column set for the certificates inventory — the "Standard" tab. Field
  * identifiers are the catalogue's own (`FilterField` enum names), so a saved view referring to the
- * same field resolves to the same registry entry.
- *
- * The labels here are the headings the page ships today; the wiring ticket resolves them from the
- * live catalogue instead, which is also where the set stops being hardcoded.
+ * same field resolves to the same registry entry. The labels are the headings the page ships with,
+ * standing in until the set is resolved from the live catalogue.
  */
 export const CERTIFICATE_COLUMNS: ColumnDefinition[] = [
     {

--- a/src/components/_pages/cryptographic-keys/keyTableHelpers.spec.tsx
+++ b/src/components/_pages/cryptographic-keys/keyTableHelpers.spec.tsx
@@ -1,0 +1,98 @@
+import { expect, test } from '../../../../playwright/ct-test';
+import { withProviders } from 'utils/test-helpers';
+import { AttributeContentType, FilterFieldSource } from 'types/openapi';
+import type { CryptographicKeyResponseModel } from 'types/cryptographic-keys';
+import type { ColumnDefinition } from 'types/tableColumns';
+import { buildKeyRowColumns, KEY_COLUMNS } from './keyTableHelpers';
+
+const opts = {
+    keyTypeEnum: {},
+    getEnumLabel: (_enumMap: unknown, key: string) => key,
+    dateFormatter: (date: string | Date) => new Date(date).toISOString().slice(0, 10),
+};
+
+function buildKey(overrides: Partial<CryptographicKeyResponseModel> = {}): CryptographicKeyResponseModel {
+    return {
+        uuid: 'k-1',
+        keyWrapperUuid: 'w-1',
+        name: 'signing-key',
+        enabled: true,
+        length: 2048,
+        format: 'RAW',
+        keyAlgorithm: 'RSA',
+        groups: [],
+        associations: 3,
+        ...overrides,
+    } as unknown as CryptographicKeyResponseModel;
+}
+
+const columnAt = (identifier: string) => {
+    const index = KEY_COLUMNS.findIndex((column) => column.fieldIdentifier === identifier);
+    if (index < 0) throw new Error(`No default key column ${identifier}`);
+    return index;
+};
+
+test.describe('keyTableHelpers', () => {
+    test('renders one cell per column of the default set', () => {
+        expect(buildKeyRowColumns(buildKey(), opts)).toHaveLength(KEY_COLUMNS.length);
+    });
+
+    test('renders the key name as a link to its detail page', async ({ mount, page }) => {
+        const cells = buildKeyRowColumns(buildKey(), opts);
+        await mount(withProviders(<div>{cells[columnAt('CKI_NAME')]}</div>));
+
+        await expect(page.getByRole('link', { name: 'signing-key' })).toBeVisible();
+    });
+
+    test('renders the shared empty state for a key with no groups', async ({ mount, page }) => {
+        const cells = buildKeyRowColumns(buildKey(), opts);
+        await mount(withProviders(<div>{cells[columnAt('CK_GROUP')]}</div>));
+
+        await expect(page.getByTestId('empty-cell')).toBeVisible();
+        await expect(page.getByText('Unassigned')).toHaveCount(0);
+    });
+
+    test('renders the shared empty state rather than the literal "unknown" for an unset size', async ({ mount, page }) => {
+        const cells = buildKeyRowColumns(buildKey({ length: undefined }), opts);
+        await mount(withProviders(<div>{cells[columnAt('CKI_LENGTH')]}</div>));
+
+        await expect(page.getByTestId('empty-cell')).toBeVisible();
+        await expect(page.getByText('unknown')).toHaveCount(0);
+    });
+
+    test('shows the first group and a count for a key in several groups', async ({ mount, page }) => {
+        const key = buildKey({
+            groups: [
+                { uuid: 'g-1', name: 'Production' },
+                { uuid: 'g-2', name: 'HSM' },
+            ],
+        } as Partial<CryptographicKeyResponseModel>);
+
+        await mount(withProviders(<div>{buildKeyRowColumns(key, opts)[columnAt('CK_GROUP')]}</div>));
+
+        await expect(page.getByText('Production')).toBeVisible();
+        await expect(page.getByText('+1')).toBeVisible();
+    });
+
+    test('renders a column set given in a different order', () => {
+        const reordered = [KEY_COLUMNS[columnAt('CK_ASSOCIATIONS')], KEY_COLUMNS[columnAt('CKI_CRYPTOGRAPHIC_ALGORITHM')]];
+
+        expect(buildKeyRowColumns(buildKey(), opts, reordered)).toEqual(['3', 'RSA']);
+    });
+
+    test('renders an attribute-sourced column the registry knows nothing about', async ({ mount, page }) => {
+        const key = buildKey({
+            attributeValues: { custom: { rotationDue: [{ data: '2026-09-01' }] } },
+        } as Partial<CryptographicKeyResponseModel>);
+        const column: ColumnDefinition = {
+            fieldSource: FilterFieldSource.Custom,
+            fieldIdentifier: 'rotationDue',
+            catalogueLabel: 'Rotation due',
+            attributeContentType: AttributeContentType.Date,
+        };
+
+        await mount(withProviders(<div>{buildKeyRowColumns(key, opts, [column])[0]}</div>));
+
+        await expect(page.getByText('2026-09-01')).toBeVisible();
+    });
+});

--- a/src/components/_pages/cryptographic-keys/keyTableHelpers.tsx
+++ b/src/components/_pages/cryptographic-keys/keyTableHelpers.tsx
@@ -127,8 +127,7 @@ export function buildKeyCellRegistry({
         ),
         'property:CKI_TYPE': (item) => (item.type ? <Badge color="secondary">{getEnumLabel(keyTypeEnum, item.type)}</Badge> : null),
         'property:CKI_CRYPTOGRAPHIC_ALGORITHM': (item) => item.keyAlgorithm,
-        // An unset size or format is the shared empty state rather than the literal 'unknown' this
-        // cell used to print, which claimed a value the platform does not have.
+        // An unset size or format resolves to the shared empty state.
         'property:CKI_LENGTH': (item) => item.length?.toString(),
         'property:CKI_FORMAT': (item) => item.format,
         'property:CKI_CREATED': (item) =>

--- a/src/components/_pages/cryptographic-keys/keyTableHelpers.tsx
+++ b/src/components/_pages/cryptographic-keys/keyTableHelpers.tsx
@@ -1,0 +1,165 @@
+import type React from 'react';
+import { Link } from 'react-router';
+import Badge from 'components/Badge';
+import { renderCell, type CellRegistry } from 'components/CustomTable/columns';
+import MultiValueCell from 'components/CustomTable/columns/MultiValueCell';
+import type { CryptographicKeyResponseModel } from 'types/cryptographic-keys';
+import type { EnumItemModel } from 'types/enums';
+import { FilterFieldSource, FilterFieldType } from 'types/openapi';
+import type { ColumnDefinition } from 'types/tableColumns';
+import type { ListCellValue } from 'utils/attributes/listCellValues';
+import KeyStateCircle from './KeyStateCircle';
+import KeyStatusCircle from './KeyStatusCircle';
+
+type PlatformEnumMap = { [key: string]: EnumItemModel } | undefined;
+
+export interface BuildKeyRowColumnsOpts {
+    keyTypeEnum: PlatformEnumMap;
+    getEnumLabel: (enumMap: PlatformEnumMap, key: string) => string;
+    dateFormatter: (date: string | Date) => string;
+}
+
+/**
+ * The platform default column set for the cryptographic keys inventory.
+ *
+ * Three of these are not in the filter-field catalogue today — `CKI_ENABLED`, `CKI_CREATED` and
+ * `CK_ASSOCIATIONS` have no `FilterField` entry — so they are shown by the default set but cannot
+ * be picked, renamed or sorted until the catalogue carries them. They keep their natural
+ * identifiers here so that adding the fields is the only change needed.
+ */
+export const KEY_COLUMNS: ColumnDefinition[] = [
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'CKI_ENABLED',
+        catalogueLabel: 'Status',
+        type: FilterFieldType.Boolean,
+        align: 'center',
+    },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'CKI_STATE',
+        catalogueLabel: 'State',
+        type: FilterFieldType.List,
+        align: 'center',
+    },
+    { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'CKI_NAME', catalogueLabel: 'Name', type: FilterFieldType.String },
+    { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'CKI_TYPE', catalogueLabel: 'Type', type: FilterFieldType.List },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'CKI_CRYPTOGRAPHIC_ALGORITHM',
+        catalogueLabel: 'Algorithm',
+        type: FilterFieldType.List,
+        align: 'center',
+    },
+    { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'CKI_LENGTH', catalogueLabel: 'Size', type: FilterFieldType.Number },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'CKI_FORMAT',
+        catalogueLabel: 'Format',
+        type: FilterFieldType.List,
+        align: 'center',
+    },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'CKI_CREATED',
+        catalogueLabel: 'Creation Date',
+        type: FilterFieldType.Datetime,
+        align: 'center',
+    },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'CK_GROUP',
+        catalogueLabel: 'Group',
+        type: FilterFieldType.List,
+        align: 'center',
+    },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'CK_OWNER',
+        catalogueLabel: 'Owner',
+        type: FilterFieldType.List,
+        align: 'center',
+    },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'CK_TOKEN_PROFILE',
+        catalogueLabel: 'Token Profile',
+        type: FilterFieldType.List,
+        align: 'center',
+    },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'CK_TOKEN_INSTANCE',
+        catalogueLabel: 'Token Instance',
+        type: FilterFieldType.List,
+        align: 'center',
+    },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'CK_ASSOCIATIONS',
+        catalogueLabel: 'Associations',
+        type: FilterFieldType.Number,
+        align: 'center',
+    },
+];
+
+function buildGroupValues(item: CryptographicKeyResponseModel): ListCellValue[] {
+    return (item.groups ?? []).map((group) => ({ label: group.name, link: { resource: 'groups', uuid: group.uuid } }));
+}
+
+/**
+ * Cell renderers for the key property columns that are rich today. Anything not registered here
+ * falls through to the attribute renderer, which is how a custom or metadata column renders without
+ * this file knowing about it.
+ */
+export function buildKeyCellRegistry({
+    keyTypeEnum,
+    getEnumLabel,
+    dateFormatter,
+}: BuildKeyRowColumnsOpts): CellRegistry<CryptographicKeyResponseModel> {
+    return {
+        'property:CKI_ENABLED': (item) => <KeyStatusCircle status={item.enabled} />,
+        'property:CKI_STATE': (item) => <KeyStateCircle state={item.state} />,
+        'property:CKI_NAME': (item) => (
+            <span className="whitespace-nowrap">
+                <Link to={`./detail/${item.keyWrapperUuid}/${item.uuid}`}>{item.name}</Link>
+            </span>
+        ),
+        'property:CKI_TYPE': (item) => (item.type ? <Badge color="secondary">{getEnumLabel(keyTypeEnum, item.type)}</Badge> : null),
+        'property:CKI_CRYPTOGRAPHIC_ALGORITHM': (item) => item.keyAlgorithm,
+        // An unset size or format is the shared empty state rather than the literal 'unknown' this
+        // cell used to print, which claimed a value the platform does not have.
+        'property:CKI_LENGTH': (item) => item.length?.toString(),
+        'property:CKI_FORMAT': (item) => item.format,
+        'property:CKI_CREATED': (item) =>
+            item.creationTime ? <span className="whitespace-nowrap">{dateFormatter(item.creationTime)}</span> : null,
+        'property:CK_GROUP': (item) => {
+            const groups = buildGroupValues(item);
+            return groups.length > 0 ? <MultiValueCell values={groups} dataTestId="cell-key-groups" /> : null;
+        },
+        'property:CK_OWNER': (item) => {
+            if (!item.owner) return null;
+            return item.ownerUuid ? <Link to={`../users/detail/${item.ownerUuid}`}>{item.owner}</Link> : item.owner;
+        },
+        'property:CK_TOKEN_PROFILE': (item) =>
+            item.tokenProfileName ? (
+                <Link to={`../tokenprofiles/detail/${item.tokenInstanceUuid}/${item.tokenProfileUuid}`}>{item.tokenProfileName}</Link>
+            ) : null,
+        'property:CK_TOKEN_INSTANCE': (item) =>
+            item.tokenInstanceName ? <Link to={`../tokens/detail/${item.tokenInstanceUuid}`}>{item.tokenInstanceName}</Link> : null,
+        'property:CK_ASSOCIATIONS': (item) => item.associations?.toString(),
+    };
+}
+
+/**
+ * The cells of one key row, rendered from the column definitions rather than assembled as a
+ * positional array — which is what lets a column set chosen at runtime render at all.
+ */
+export function buildKeyRowColumns(
+    item: CryptographicKeyResponseModel,
+    opts: BuildKeyRowColumnsOpts,
+    columns: ColumnDefinition[] = KEY_COLUMNS,
+): React.ReactNode[] {
+    const registry = buildKeyCellRegistry(opts);
+    return columns.map((column) => renderCell(item, column, registry));
+}

--- a/src/components/_pages/cryptographic-keys/list/index.tsx
+++ b/src/components/_pages/cryptographic-keys/list/index.tsx
@@ -9,18 +9,16 @@ import { actions, selectors } from 'ducks/cryptographic-keys';
 import { selectors as enumSelectors, getEnumLabel } from 'ducks/enums';
 import { EntityType } from 'ducks/filters';
 import { selectors as pagingSelectors } from 'ducks/paging';
-import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Link } from 'react-router';
 import Select from 'components/Select';
 import type { SearchRequestModel } from 'types/certificate';
 import { KeyCompromiseReason, type KeyUsage, PlatformEnum } from 'types/openapi';
 import { LockWidgetNameEnum } from 'types/user-interface';
 import { dateFormatter } from 'utils/dateUtil';
-import KeyStateCircle from '../KeyStateCircle';
-import KeyStatusCircle from '../KeyStatusCircle';
 import KeyUsageSelect from '../KeyUsageSelect';
-import Badge from 'components/Badge';
+import { buildKeyCellRegistry, KEY_COLUMNS } from '../keyTableHelpers';
+import { buildTableRows } from 'components/CustomTable/columns';
 import { EnumColumnDescription } from 'components/EnumDescription';
 import CryptographicKeyForm from '../form';
 
@@ -231,54 +229,9 @@ function CryptographicKeyList() {
 
     const cryptographicKeysList: TableDataRow[] = useMemo(
         () =>
-            cryptographicKeys.map((cryptographicKey) => {
-                return {
-                    id: cryptographicKey.uuid,
-                    columns: [
-                        <KeyStatusCircle key="status" status={cryptographicKey.enabled} />,
-                        <KeyStateCircle key="state" state={cryptographicKey.state} />,
-                        <span key="name" style={{ whiteSpace: 'nowrap' }}>
-                            <Link to={`./detail/${cryptographicKey.keyWrapperUuid}/${cryptographicKey.uuid}`}>{cryptographicKey.name}</Link>
-                        </span>,
-                        <Badge key="type" color="secondary">
-                            {getEnumLabel(keyTypeEnum, cryptographicKey.type)}
-                        </Badge>,
-                        cryptographicKey.keyAlgorithm,
-                        cryptographicKey.length?.toString() || 'unknown',
-                        cryptographicKey.format || 'unknown',
-                        <span key="created" style={{ whiteSpace: 'nowrap' }}>
-                            {dateFormatter(cryptographicKey.creationTime) || ''}
-                        </span>,
-                        cryptographicKey?.groups?.length
-                            ? cryptographicKey?.groups.map((group, i) => (
-                                  <Fragment key={group.uuid}>
-                                      <Link to={`../../groups/detail/${group.uuid}`}>{group.name}</Link>
-                                      {cryptographicKey?.groups?.length && i !== cryptographicKey.groups.length - 1 ? `, ` : ``}
-                                  </Fragment>
-                              ))
-                            : 'Unassigned',
-                        cryptographicKey.ownerUuid ? (
-                            <Link to={`../users/detail/${cryptographicKey.ownerUuid}`}>{cryptographicKey.owner ?? 'Unassigned'}</Link>
-                        ) : (
-                            (cryptographicKey.owner ?? 'Unassigned')
-                        ),
-                        cryptographicKey.tokenProfileName ? (
-                            <Link to={`../tokenprofiles/detail/${cryptographicKey.tokenInstanceUuid}/${cryptographicKey.tokenProfileUuid}`}>
-                                {cryptographicKey.tokenProfileName ?? 'Unassigned'}
-                            </Link>
-                        ) : (
-                            (cryptographicKey.tokenProfileName ?? 'Unassigned')
-                        ),
-                        cryptographicKey.tokenInstanceName ? (
-                            <Link to={`../tokens/detail/${cryptographicKey.tokenInstanceUuid}`}>
-                                {cryptographicKey.tokenInstanceName ?? 'Unassigned'}
-                            </Link>
-                        ) : (
-                            (cryptographicKey.tokenInstanceName ?? 'Unassigned')
-                        ),
-                        cryptographicKey.associations?.toString() || '',
-                    ],
-                };
+            buildTableRows(cryptographicKeys, KEY_COLUMNS, {
+                getRowId: (cryptographicKey) => cryptographicKey.uuid,
+                registry: buildKeyCellRegistry({ keyTypeEnum, getEnumLabel, dateFormatter }),
             }),
         [cryptographicKeys, keyTypeEnum],
     );

--- a/src/types/tableColumns.ts
+++ b/src/types/tableColumns.ts
@@ -1,5 +1,5 @@
 import type { BaseAttributeContentModel } from './attributes';
-import type { AttributeContentType, FilterFieldSource, FilterFieldType } from './openapi';
+import type { AttributeContentType, FilterFieldSource, FilterFieldType, SearchFieldDataDto } from './openapi';
 
 /**
  * Attribute values a listing entry carries for the columns that were requested, nested by field
@@ -30,4 +30,29 @@ export interface ColumnDefinition {
     sortable?: boolean;
     multiValue?: boolean;
     align?: 'left' | 'center' | 'right';
+}
+
+/**
+ * A field the column catalogue offers, i.e. `GET /v1/{resource}/search` extended with the two flags
+ * the list contract added. Both mirror the contract exactly, and stand in until the generated DTO in
+ * `src/types/openapi` carries them.
+ */
+export interface ColumnCatalogueField extends SearchFieldDataDto {
+    /** Whether the field may be requested as a column of the listing. */
+    displayable?: boolean;
+    /** Whether the listing may be ordered by the field. */
+    sortable?: boolean;
+}
+
+/** A catalogue field paired with the source it was published under. */
+export interface SourcedCatalogueField extends ColumnCatalogueField {
+    fieldSource: FilterFieldSource;
+}
+
+/**
+ * A column in the picker's selected list. `available: false` marks a stored column whose field the
+ * catalogue no longer publishes — a deleted custom attribute, or a renamed metadata identifier.
+ */
+export interface PickerColumn extends ColumnDefinition {
+    available: boolean;
 }

--- a/src/types/tableColumns.ts
+++ b/src/types/tableColumns.ts
@@ -1,0 +1,33 @@
+import type { BaseAttributeContentModel } from './attributes';
+import type { AttributeContentType, FilterFieldSource, FilterFieldType } from './openapi';
+
+/**
+ * Attribute values a listing entry carries for the columns that were requested, nested by field
+ * source and then by field identifier. Mirrors `AttributeProjectable` from the list API contract:
+ * an identifier is unique only within its source, so the map is nested rather than keyed by a
+ * composite `"source:identifier"` string.
+ */
+export type ProjectedAttributeValues = Partial<Record<FilterFieldSource, Record<string, BaseAttributeContentModel[]>>>;
+
+/** A listing entry that can carry projected attribute values. */
+export interface AttributeProjectable {
+    attributeValues?: ProjectedAttributeValues;
+}
+
+/**
+ * One column of a listing table, resolved from the filter-field catalogue and, for a saved view,
+ * from the stored column list.
+ */
+export interface ColumnDefinition {
+    fieldSource: FilterFieldSource;
+    fieldIdentifier: string;
+    /** Label the catalogue reports for the field. */
+    catalogueLabel: string;
+    /** Per-view heading override. Absent means the column follows the catalogue. */
+    label?: string;
+    type?: FilterFieldType;
+    attributeContentType?: AttributeContentType;
+    sortable?: boolean;
+    multiValue?: boolean;
+    align?: 'left' | 'center' | 'right';
+}

--- a/src/utils/attributes/listCellValues.spec.ts
+++ b/src/utils/attributes/listCellValues.spec.ts
@@ -61,6 +61,21 @@ describe('getListCellValues', () => {
             expect(values(AttributeContentType.Time, [{ data: '22:22:02' }])).toEqual(['22:22:02']);
         });
 
+        /**
+         * A date-only value has no time zone. Formatting it would parse `yyyy-MM-dd` as UTC midnight
+         * and read it back with local getters, which lands on the previous day west of UTC.
+         */
+        it('renders a date-only value as the contract carries it, in any time zone', () => {
+            const original = process.env.TZ;
+
+            for (const zone of ['UTC', 'America/Los_Angeles', 'Pacific/Kiritimati']) {
+                process.env.TZ = zone;
+                expect(values(AttributeContentType.Date, [{ data: '2026-03-04' }])).toEqual(['2026-03-04']);
+            }
+
+            process.env.TZ = original;
+        });
+
         it('leaves an unparseable date alone rather than rendering Invalid Date', () => {
             expect(values(AttributeContentType.Date, [{ data: 'not a date' }])).toEqual(['not a date']);
         });
@@ -94,6 +109,20 @@ describe('getListCellValues', () => {
         it('carries no link when the resource or the uuid is missing', () => {
             expect(getListCellValues(AttributeContentType.Resource, [{ data: { name: 'orphan' } }])[0].link).toBeUndefined();
             expect(getListCellValues(AttributeContentType.Resource, [{ data: { uuid: 'u-1' } }])[0].link).toBeUndefined();
+        });
+
+        /** Its detail route also takes the parent entity, which a projected value does not carry. */
+        it('carries no link for a location, whose route needs more than the uuid', () => {
+            const location = [{ data: { resource: 'locations', uuid: 'u-1', name: 'Rack 4' } }];
+
+            expect(values(AttributeContentType.Resource, location)).toEqual(['Rack 4']);
+            expect(getListCellValues(AttributeContentType.Resource, location)[0].link).toBeUndefined();
+        });
+
+        it('carries no link for a resource the contract adds later', () => {
+            const unknown = [{ data: { resource: 'somethingNew', uuid: 'u-1', name: 'New' } }];
+
+            expect(getListCellValues(AttributeContentType.Resource, unknown)[0].link).toBeUndefined();
         });
     });
 

--- a/src/utils/attributes/listCellValues.spec.ts
+++ b/src/utils/attributes/listCellValues.spec.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import type { BaseAttributeContentModel } from 'types/attributes';
+import { AttributeContentType } from 'types/openapi';
+import { getListCellValues } from './listCellValues';
+
+const values = (contentType: AttributeContentType, content: BaseAttributeContentModel[] | undefined) =>
+    getListCellValues(contentType, content).map((value) => value.label);
+
+describe('getListCellValues', () => {
+    it('returns nothing for absent content, so the cell resolves to the empty state', () => {
+        expect(getListCellValues(AttributeContentType.String, undefined)).toEqual([]);
+        expect(getListCellValues(AttributeContentType.String, [])).toEqual([]);
+    });
+
+    it('returns one value per content item, preserving item_order', () => {
+        const content = [{ data: 'production' }, { data: 'staging' }, { data: 'dr-site' }];
+        expect(values(AttributeContentType.String, content)).toEqual(['production', 'staging', 'dr-site']);
+    });
+
+    describe('string and text', () => {
+        it('prefers the human-readable reference over the stored data', () => {
+            expect(values(AttributeContentType.String, [{ data: 'ACME_1', reference: 'Acme Corp' }])).toEqual(['Acme Corp']);
+            expect(values(AttributeContentType.Text, [{ data: 'ACME_1', reference: 'Acme Corp' }])).toEqual(['Acme Corp']);
+        });
+
+        it('falls back to the data when there is no reference', () => {
+            expect(values(AttributeContentType.String, [{ data: 'ACME_1' }])).toEqual(['ACME_1']);
+        });
+    });
+
+    describe('numbers', () => {
+        it('renders integers and floats as plain numerals', () => {
+            expect(values(AttributeContentType.Integer, [{ data: 4820 }])).toEqual(['4820']);
+            expect(values(AttributeContentType.Float, [{ data: 12.5 }])).toEqual(['12.5']);
+        });
+
+        it('keeps a zero rather than treating it as absent', () => {
+            expect(values(AttributeContentType.Integer, [{ data: 0 }])).toEqual(['0']);
+        });
+    });
+
+    describe('boolean', () => {
+        it('renders Yes and No, not the developer-facing true and false', () => {
+            expect(values(AttributeContentType.Boolean, [{ data: true }])).toEqual(['Yes']);
+            expect(values(AttributeContentType.Boolean, [{ data: false }])).toEqual(['No']);
+        });
+    });
+
+    describe('dates and times', () => {
+        it('renders a date in the platform date format', () => {
+            expect(values(AttributeContentType.Date, [{ data: '2026-03-04' }])).toEqual(['2026-03-04']);
+        });
+
+        it('renders a datetime through the platform datetime format', () => {
+            expect(values(AttributeContentType.Datetime, [{ data: '2026-03-04T10:20:30Z' }])[0]).toMatch(
+                /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/,
+            );
+        });
+
+        it('renders a time verbatim', () => {
+            expect(values(AttributeContentType.Time, [{ data: '22:22:02' }])).toEqual(['22:22:02']);
+        });
+
+        it('leaves an unparseable date alone rather than rendering Invalid Date', () => {
+            expect(values(AttributeContentType.Date, [{ data: 'not a date' }])).toEqual(['not a date']);
+        });
+    });
+
+    describe('credential and object', () => {
+        it('renders the human label and never the raw object', () => {
+            const content = [{ data: { id: 7, secretish: 'x' }, reference: 'Vault credential' }];
+            expect(values(AttributeContentType.Credential, content)).toEqual(['Vault credential']);
+            expect(values(AttributeContentType.Object, content)).toEqual(['Vault credential']);
+        });
+
+        it('renders nothing rather than JSON when there is no reference', () => {
+            expect(getListCellValues(AttributeContentType.Object, [{ data: { id: 7 } }])).toEqual([]);
+        });
+    });
+
+    describe('resource', () => {
+        const content = [{ data: { resource: 'certificates', uuid: 'u-1', name: 'api.acme.test' } }];
+
+        it('prefers the reference, then the name, then the uuid', () => {
+            expect(values(AttributeContentType.Resource, [{ ...content[0], reference: 'Referenced' }])).toEqual(['Referenced']);
+            expect(values(AttributeContentType.Resource, content)).toEqual(['api.acme.test']);
+            expect(values(AttributeContentType.Resource, [{ data: { resource: 'certificates', uuid: 'u-1' } }])).toEqual(['u-1']);
+        });
+
+        it('carries the link target when the referenced object is addressable', () => {
+            expect(getListCellValues(AttributeContentType.Resource, content)[0].link).toEqual({ resource: 'certificates', uuid: 'u-1' });
+        });
+
+        it('carries no link when the resource or the uuid is missing', () => {
+            expect(getListCellValues(AttributeContentType.Resource, [{ data: { name: 'orphan' } }])[0].link).toBeUndefined();
+            expect(getListCellValues(AttributeContentType.Resource, [{ data: { uuid: 'u-1' } }])[0].link).toBeUndefined();
+        });
+    });
+
+    describe('file', () => {
+        const content = [{ data: { fileName: 'chain.pem', mimeType: 'application/x-pem-file', content: 'base64' } }];
+
+        it('shows the file name only, because name plus mime type is too wide for a column', () => {
+            expect(values(AttributeContentType.File, content)).toEqual(['chain.pem']);
+        });
+
+        it('moves the mime type into the detail the overflow reveals', () => {
+            expect(getListCellValues(AttributeContentType.File, content)[0].detail).toBe('application/x-pem-file');
+        });
+
+        it('falls back to the reference when the data is not a file payload', () => {
+            expect(values(AttributeContentType.File, [{ data: 'raw', reference: 'chain.pem' }])).toEqual(['chain.pem']);
+        });
+    });
+
+    describe('content types the catalogue must never offer as a column', () => {
+        it('masks a secret rather than revealing it', () => {
+            expect(values(AttributeContentType.Secret, [{ data: 'hunter2' }])).toEqual(['*****']);
+        });
+
+        it('names a code block rather than rendering it, which would be multi-line', () => {
+            expect(values(AttributeContentType.Codeblock, [{ data: { code: 'YQ==', language: 'javascript' } }])).toEqual(['Code block']);
+        });
+    });
+});

--- a/src/utils/attributes/listCellValues.ts
+++ b/src/utils/attributes/listCellValues.ts
@@ -1,6 +1,6 @@
 import type { BaseAttributeContentModel } from 'types/attributes';
-import { AttributeContentType, type FileAttributeContentData } from 'types/openapi';
-import { getFormattedDate, getFormattedDateTime } from 'utils/dateUtil';
+import { AttributeContentType, AttributeResource, type FileAttributeContentData } from 'types/openapi';
+import { getFormattedDateTime } from 'utils/dateUtil';
 
 /** One value of an attribute, prepared for a list cell. */
 export interface ListCellValue {
@@ -14,6 +14,23 @@ export interface ListCellValue {
 
 type ResourceContentData = { resource?: string; uuid?: string; name?: string };
 
+/**
+ * The attribute resources whose detail route is `/<resource>/detail/<uuid>`. An allow-list rather
+ * than an exclusion, so a resource added to the contract later is unlinked until its route is known
+ * to fit. `Locations` is the one that does not: its route also takes the parent entity, which a
+ * projected value does not carry.
+ */
+const LINKABLE_RESOURCES: ReadonlySet<string> = new Set([
+    AttributeResource.Certificates,
+    AttributeResource.Credentials,
+    AttributeResource.Authorities,
+    AttributeResource.Entities,
+    AttributeResource.Secrets,
+]);
+
+/** The detail route of a linked value. */
+export const listCellLinkPath = (link: NonNullable<ListCellValue['link']>): string => `/${link.resource}/detail/${link.uuid}`;
+
 function isFileContentData(data: unknown): data is FileAttributeContentData {
     return typeof data === 'object' && data !== null && 'fileName' in data && 'mimeType' in data;
 }
@@ -22,7 +39,8 @@ function toResourceValue(item: BaseAttributeContentModel): ListCellValue | undef
     const data = (item.data ?? {}) as ResourceContentData;
     const label = item.reference ?? data.name ?? data.uuid;
     if (!label) return undefined;
-    const link = data.resource && data.uuid ? { resource: data.resource, uuid: data.uuid } : undefined;
+    const link =
+        data.resource && data.uuid && LINKABLE_RESOURCES.has(data.resource) ? { resource: data.resource, uuid: data.uuid } : undefined;
     return { label, ...(link ? { link } : {}) };
 }
 
@@ -44,7 +62,10 @@ function toLabel(contentType: AttributeContentType, item: BaseAttributeContentMo
             // 'true' / 'false' is developer-facing copy; a column reads as a table of answers.
             return item.data ? 'Yes' : 'No';
         case AttributeContentType.Date:
-            return getFormattedDate(String(item.data));
+            // Date-only, and passed through as the contract carries it. Formatting it would parse
+            // `yyyy-MM-dd` as UTC midnight and read it back with local getters, which shows the
+            // previous day west of UTC.
+            return String(item.data);
         case AttributeContentType.Datetime:
             return getFormattedDateTime(String(item.data));
         case AttributeContentType.Time:

--- a/src/utils/attributes/listCellValues.ts
+++ b/src/utils/attributes/listCellValues.ts
@@ -1,0 +1,91 @@
+import type { BaseAttributeContentModel } from 'types/attributes';
+import { AttributeContentType, type FileAttributeContentData } from 'types/openapi';
+import { getFormattedDate, getFormattedDateTime } from 'utils/dateUtil';
+
+/** One value of an attribute, prepared for a list cell. */
+export interface ListCellValue {
+    /** What the cell shows. */
+    label: string;
+    /** Information that belongs in the overflow reveal rather than in the column itself. */
+    detail?: string;
+    /** Set when the value points at another object that has a detail route. */
+    link?: { resource: string; uuid: string };
+}
+
+type ResourceContentData = { resource?: string; uuid?: string; name?: string };
+
+function isFileContentData(data: unknown): data is FileAttributeContentData {
+    return typeof data === 'object' && data !== null && 'fileName' in data && 'mimeType' in data;
+}
+
+function toResourceValue(item: BaseAttributeContentModel): ListCellValue | undefined {
+    const data = (item.data ?? {}) as ResourceContentData;
+    const label = item.reference ?? data.name ?? data.uuid;
+    if (!label) return undefined;
+    const link = data.resource && data.uuid ? { resource: data.resource, uuid: data.uuid } : undefined;
+    return { label, ...(link ? { link } : {}) };
+}
+
+function toFileValue(item: BaseAttributeContentModel): ListCellValue | undefined {
+    if (!isFileContentData(item.data)) return item.reference ? { label: item.reference } : undefined;
+    return { label: item.data.fileName, detail: item.data.mimeType };
+}
+
+function toLabel(contentType: AttributeContentType, item: BaseAttributeContentModel): string | undefined {
+    switch (contentType) {
+        case AttributeContentType.String:
+        case AttributeContentType.Text:
+            // The reference is the human-readable form; the data is the stored code behind it.
+            return item.reference ?? String(item.data);
+        case AttributeContentType.Integer:
+        case AttributeContentType.Float:
+            return String(item.data);
+        case AttributeContentType.Boolean:
+            // 'true' / 'false' is developer-facing copy; a column reads as a table of answers.
+            return item.data ? 'Yes' : 'No';
+        case AttributeContentType.Date:
+            return getFormattedDate(String(item.data));
+        case AttributeContentType.Datetime:
+            return getFormattedDateTime(String(item.data));
+        case AttributeContentType.Time:
+            return String(item.data);
+        case AttributeContentType.Credential:
+        case AttributeContentType.Object:
+            // Never the raw object: it is unbounded, and a column has one line.
+            return item.reference;
+        case AttributeContentType.Secret:
+            // Unreachable through the picker — the catalogue marks secrets displayable=false — but
+            // masked rather than rendered, so no path can put one on screen.
+            return '*****';
+        case AttributeContentType.Codeblock:
+            // Also unreachable, and deliberately not rendered: getAttributeContent returns a
+            // <CodeBlock> for these, which is multi-line by construction and breaks the row rule.
+            return 'Code block';
+        default:
+            return undefined;
+    }
+}
+
+/**
+ * The values an attribute contributes to a list cell, one entry per content item in `item_order`.
+ * A detail page and a table column want different things from the same content, so this deviates
+ * from `getAttributeContent` where the column needs it to — notably files, booleans and objects.
+ *
+ * An item that has nothing presentable is dropped rather than rendered blank, so a cell left with
+ * no values resolves to the empty state.
+ */
+export function getListCellValues(contentType: AttributeContentType, content: BaseAttributeContentModel[] | undefined): ListCellValue[] {
+    if (!content || content.length === 0) return [];
+
+    return content.reduce<ListCellValue[]>((values, item) => {
+        let value: ListCellValue | undefined;
+        if (contentType === AttributeContentType.Resource) value = toResourceValue(item);
+        else if (contentType === AttributeContentType.File) value = toFileValue(item);
+        else {
+            const label = toLabel(contentType, item);
+            value = label ? { label } : undefined;
+        }
+        if (value) values.push(value);
+        return values;
+    }, []);
+}

--- a/src/utils/columnPicker.spec.ts
+++ b/src/utils/columnPicker.spec.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it } from 'vitest';
+import { AttributeContentType, FilterFieldSource, FilterFieldType, type SearchFieldDataByGroupDto } from 'types/openapi';
+import type { ColumnDefinition, SourcedCatalogueField } from 'types/tableColumns';
+import {
+    COLUMN_COUNT_WARNING_FROM,
+    MAX_COLUMNS,
+    getCounterState,
+    groupCatalogueFields,
+    isColumnSelected,
+    isSameResolution,
+    moveColumn,
+    resolveColumns,
+    toCatalogueFields,
+    toColumnDefinition,
+} from './columnPicker';
+
+const field = (overrides: Partial<SourcedCatalogueField> = {}): SourcedCatalogueField =>
+    ({
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'COMMON_NAME',
+        fieldLabel: 'Common Name',
+        type: FilterFieldType.String,
+        conditions: [],
+        displayable: true,
+        sortable: true,
+        ...overrides,
+    }) as SourcedCatalogueField;
+
+const catalogue: SearchFieldDataByGroupDto[] = [
+    {
+        filterFieldSource: FilterFieldSource.Property,
+        searchFieldData: [
+            {
+                fieldIdentifier: 'COMMON_NAME',
+                fieldLabel: 'Common Name',
+                type: FilterFieldType.String,
+                conditions: [],
+                displayable: true,
+                sortable: true,
+            },
+            {
+                fieldIdentifier: 'FINGERPRINT',
+                fieldLabel: 'Fingerprint',
+                type: FilterFieldType.String,
+                conditions: [],
+                displayable: false,
+                sortable: true,
+            },
+        ] as SearchFieldDataByGroupDto['searchFieldData'],
+    },
+    {
+        filterFieldSource: FilterFieldSource.Custom,
+        searchFieldData: [
+            {
+                fieldIdentifier: 'costCentre',
+                fieldLabel: 'Cost centre',
+                type: FilterFieldType.Number,
+                conditions: [],
+                attributeContentType: AttributeContentType.Integer,
+                displayable: true,
+                sortable: false,
+            },
+        ] as SearchFieldDataByGroupDto['searchFieldData'],
+    },
+    { filterFieldSource: FilterFieldSource.Meta, searchFieldData: undefined },
+];
+
+describe('toCatalogueFields', () => {
+    it('flattens the catalogue and stamps each field with the source it was published under', () => {
+        expect(toCatalogueFields(catalogue).map((f) => [f.fieldSource, f.fieldIdentifier])).toEqual([
+            [FilterFieldSource.Property, 'COMMON_NAME'],
+            [FilterFieldSource.Custom, 'costCentre'],
+        ]);
+    });
+
+    it('offers only fields the catalogue marks displayable', () => {
+        expect(toCatalogueFields(catalogue).some((f) => f.fieldIdentifier === 'FINGERPRINT')).toBe(false);
+    });
+
+    it('treats a field with no displayable flag as not offerable, rather than guessing', () => {
+        const groups = [
+            {
+                filterFieldSource: FilterFieldSource.Property,
+                searchFieldData: [{ fieldIdentifier: 'X', fieldLabel: 'X', type: FilterFieldType.String, conditions: [] }],
+            },
+        ];
+        expect(toCatalogueFields(groups as SearchFieldDataByGroupDto[])).toEqual([]);
+    });
+
+    it('survives a source that publishes no fields', () => {
+        expect(toCatalogueFields([{ filterFieldSource: FilterFieldSource.Meta }])).toEqual([]);
+    });
+
+    it('returns nothing for an empty catalogue', () => {
+        expect(toCatalogueFields([])).toEqual([]);
+    });
+});
+
+describe('groupCatalogueFields', () => {
+    const fields = [
+        field(),
+        field({ fieldSource: FilterFieldSource.Property, fieldIdentifier: 'SERIAL_NUMBER', fieldLabel: 'Serial Number' }),
+        field({ fieldSource: FilterFieldSource.Custom, fieldIdentifier: 'costCentre', fieldLabel: 'Cost centre' }),
+    ];
+
+    it('groups fields by source, in a stable source order', () => {
+        expect(groupCatalogueFields(fields, '').map((group) => group.source)).toEqual([
+            FilterFieldSource.Property,
+            FilterFieldSource.Custom,
+        ]);
+    });
+
+    it('drops a group left with no fields, so no empty heading is rendered', () => {
+        expect(groupCatalogueFields(fields, 'cost').map((group) => group.source)).toEqual([FilterFieldSource.Custom]);
+    });
+
+    it('searches across every source, case-insensitively', () => {
+        expect(groupCatalogueFields(fields, 'NUMBER').flatMap((g) => g.fields.map((f) => f.fieldIdentifier))).toEqual(['SERIAL_NUMBER']);
+    });
+
+    it('matches the field identifier as well as the label, so a stored identifier can be found', () => {
+        expect(groupCatalogueFields(fields, 'costcentre').flatMap((g) => g.fields.map((f) => f.fieldIdentifier))).toEqual(['costCentre']);
+    });
+
+    it('ignores surrounding whitespace in the search term', () => {
+        expect(groupCatalogueFields(fields, '  cost  ').flatMap((g) => g.fields)).toHaveLength(1);
+    });
+
+    it('returns every group for an empty search', () => {
+        expect(groupCatalogueFields(fields, '').flatMap((g) => g.fields)).toHaveLength(3);
+    });
+
+    it('returns nothing when the search matches no field', () => {
+        expect(groupCatalogueFields(fields, 'nothing matches this')).toEqual([]);
+    });
+});
+
+describe('toColumnDefinition', () => {
+    it('carries the catalogue label, type and sortability onto the column', () => {
+        expect(toColumnDefinition(field({ sortable: false, attributeContentType: AttributeContentType.Integer }))).toEqual({
+            fieldSource: FilterFieldSource.Property,
+            fieldIdentifier: 'COMMON_NAME',
+            catalogueLabel: 'Common Name',
+            type: FilterFieldType.String,
+            attributeContentType: AttributeContentType.Integer,
+            sortable: false,
+            multiValue: undefined,
+        });
+    });
+
+    it('reports a field with no sortable flag as not sortable', () => {
+        expect(toColumnDefinition(field({ sortable: undefined })).sortable).toBe(false);
+    });
+
+    it('sets no label override, so a newly added column follows the catalogue', () => {
+        expect(toColumnDefinition(field()).label).toBeUndefined();
+    });
+});
+
+describe('isColumnSelected', () => {
+    const selected: ColumnDefinition[] = [
+        { fieldSource: FilterFieldSource.Custom, fieldIdentifier: 'costCentre', catalogueLabel: 'Cost centre' },
+    ];
+
+    it('matches on source and identifier together', () => {
+        expect(isColumnSelected(selected, field({ fieldSource: FilterFieldSource.Custom, fieldIdentifier: 'costCentre' }))).toBe(true);
+    });
+
+    it('does not match the same identifier under a different source', () => {
+        expect(isColumnSelected(selected, field({ fieldSource: FilterFieldSource.Meta, fieldIdentifier: 'costCentre' }))).toBe(false);
+    });
+});
+
+describe('resolveColumns', () => {
+    const fields = [field(), field({ fieldSource: FilterFieldSource.Custom, fieldIdentifier: 'costCentre', fieldLabel: 'Cost centre' })];
+
+    const stored: ColumnDefinition[] = [
+        { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME', catalogueLabel: 'stale label' },
+        { fieldSource: FilterFieldSource.Custom, fieldIdentifier: 'gone', catalogueLabel: 'Gone', label: 'Was renamed' },
+        { fieldSource: FilterFieldSource.Custom, fieldIdentifier: 'costCentre', catalogueLabel: 'Cost centre' },
+    ];
+
+    it('keeps every stored column, in its stored position', () => {
+        expect(resolveColumns(stored, fields).map((column) => column.fieldIdentifier)).toEqual(['COMMON_NAME', 'gone', 'costCentre']);
+    });
+
+    it('marks a column whose field the catalogue no longer publishes as unavailable', () => {
+        expect(resolveColumns(stored, fields).map((column) => column.available)).toEqual([true, false, true]);
+    });
+
+    it('refreshes a resolved column from the live catalogue, so a relabelled field carries through', () => {
+        expect(resolveColumns(stored, fields)[0].catalogueLabel).toBe('Common Name');
+    });
+
+    it('keeps a per-view label override across the refresh', () => {
+        const withOverride = [{ ...stored[0], label: 'Host' }];
+        expect(resolveColumns(withOverride, fields)[0]).toMatchObject({ label: 'Host', catalogueLabel: 'Common Name' });
+    });
+
+    it('leaves an unavailable column exactly as it was stored, since nothing can refresh it', () => {
+        expect(resolveColumns(stored, fields)[1]).toMatchObject({ catalogueLabel: 'Gone', label: 'Was renamed', available: false });
+    });
+
+    it('resolves nothing for no stored columns', () => {
+        expect(resolveColumns([], fields)).toEqual([]);
+    });
+
+    it('marks everything unavailable when the catalogue is empty', () => {
+        expect(resolveColumns(stored, []).every((column) => !column.available)).toBe(true);
+    });
+
+    /**
+     * A platform default column can be absent from the filter-field catalogue and still renderable —
+     * the keys inventory ships three such columns. Marking those unavailable would drop them from the
+     * view on the next save.
+     */
+    it('keeps a platform column the catalogue does not publish available', () => {
+        const platform: ColumnDefinition[] = [
+            { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'CKI_ENABLED', catalogueLabel: 'Status', align: 'center' },
+        ];
+
+        expect(resolveColumns(platform, fields, platform)[0]).toMatchObject({
+            catalogueLabel: 'Status',
+            align: 'center',
+            available: true,
+        });
+    });
+
+    it('still marks an unknown column unavailable when a standard set is given', () => {
+        const platform: ColumnDefinition[] = [
+            { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'CKI_ENABLED', catalogueLabel: 'Status' },
+        ];
+
+        expect(resolveColumns(stored, fields, platform).map((column) => column.available)).toEqual([true, false, true]);
+    });
+
+    it('keeps alignment the catalogue does not carry while refreshing what it does', () => {
+        const aligned = [{ ...stored[0], align: 'center' as const }];
+
+        expect(resolveColumns(aligned, fields)[0]).toMatchObject({ align: 'center', catalogueLabel: 'Common Name' });
+    });
+});
+
+describe('isSameResolution', () => {
+    const resolved = () =>
+        resolveColumns([{ fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME', catalogueLabel: 'x' }], [field()]);
+
+    it('reports two separately built but equal resolutions as the same', () => {
+        expect(isSameResolution(resolved(), resolved())).toBe(true);
+    });
+
+    it('reports a different length as different', () => {
+        expect(isSameResolution(resolved(), [])).toBe(false);
+    });
+
+    it('reports a changed property as different', () => {
+        const changed = resolved().map((column) => ({ ...column, catalogueLabel: 'Renamed' }));
+        expect(isSameResolution(resolved(), changed)).toBe(false);
+    });
+
+    it('reports an added property as different', () => {
+        const changed = resolved().map((column) => ({ ...column, label: 'Override' }));
+        expect(isSameResolution(resolved(), changed)).toBe(false);
+    });
+});
+
+describe('moveColumn', () => {
+    const columns = ['a', 'b', 'c', 'd'].map((id) => ({
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: id,
+        catalogueLabel: id,
+    }));
+    const ids = (result: ColumnDefinition[]) => result.map((column) => column.fieldIdentifier);
+
+    it('moves a column later in the order', () => {
+        expect(ids(moveColumn(columns, 0, 2))).toEqual(['b', 'c', 'a', 'd']);
+    });
+
+    it('moves a column earlier in the order', () => {
+        expect(ids(moveColumn(columns, 3, 1))).toEqual(['a', 'd', 'b', 'c']);
+    });
+
+    it('leaves the order alone when a column is moved onto itself', () => {
+        expect(ids(moveColumn(columns, 2, 2))).toEqual(['a', 'b', 'c', 'd']);
+    });
+
+    it('clamps a target past the end rather than dropping the column', () => {
+        expect(ids(moveColumn(columns, 0, 99))).toEqual(['b', 'c', 'd', 'a']);
+    });
+
+    it('clamps a target before the start', () => {
+        expect(ids(moveColumn(columns, 2, -5))).toEqual(['c', 'a', 'b', 'd']);
+    });
+
+    it('ignores a source index that is not a column', () => {
+        expect(ids(moveColumn(columns, 9, 0))).toEqual(['a', 'b', 'c', 'd']);
+    });
+
+    it('does not mutate the array it was given', () => {
+        const original = [...columns];
+        moveColumn(columns, 0, 3);
+        expect(columns).toEqual(original);
+    });
+});
+
+describe('getCounterState', () => {
+    it('is unremarkable below the warning threshold', () => {
+        expect(getCounterState(COLUMN_COUNT_WARNING_FROM - 1)).toBe('ok');
+    });
+
+    it('warns from the threshold, so the limit is visible before it binds', () => {
+        expect(getCounterState(COLUMN_COUNT_WARNING_FROM)).toBe('warning');
+        expect(getCounterState(MAX_COLUMNS - 1)).toBe('warning');
+    });
+
+    it('reports the cap once it is reached', () => {
+        expect(getCounterState(MAX_COLUMNS)).toBe('full');
+    });
+
+    it('treats an over-full set as full, so a stored view above the cap still renders', () => {
+        expect(getCounterState(MAX_COLUMNS + 4)).toBe('full');
+    });
+
+    it('warns before it blocks', () => {
+        expect(COLUMN_COUNT_WARNING_FROM).toBeLessThan(MAX_COLUMNS);
+    });
+});

--- a/src/utils/columnPicker.ts
+++ b/src/utils/columnPicker.ts
@@ -1,0 +1,161 @@
+import { FilterFieldSource, type SearchFieldDataByGroupDto } from 'types/openapi';
+import type { ColumnDefinition, PickerColumn, SourcedCatalogueField } from 'types/tableColumns';
+import { getColumnKey } from './tableColumns';
+
+/**
+ * The most columns a view may hold. A readability rule rather than a contract limit: if the API ever
+ * enforces a maximum of its own, the picker takes the smaller of the two.
+ */
+export const MAX_COLUMNS = 12;
+
+/** Where the counter starts warning, so the cap is visible before it binds. */
+export const COLUMN_COUNT_WARNING_FROM = 10;
+
+/** The order sources are offered in: object properties first, then the attribute sources. */
+const SOURCE_ORDER: readonly FilterFieldSource[] = [
+    FilterFieldSource.Property,
+    FilterFieldSource.Custom,
+    FilterFieldSource.Meta,
+    FilterFieldSource.Data,
+];
+
+/** Fields the catalogue publishes under one source, after searching. */
+export interface CatalogueFieldGroup {
+    source: FilterFieldSource;
+    fields: SourcedCatalogueField[];
+}
+
+export type ColumnCounterState = 'ok' | 'warning' | 'full';
+
+/**
+ * The fields of a column catalogue, flattened and each stamped with the source it was published
+ * under — an identifier is unique only within its source, so a field carries no meaning without it.
+ *
+ * Only fields the catalogue marks `displayable` are offered. An absent flag is not treated as a
+ * yes: secret and encrypted content, and code blocks, are excluded server-side by that flag alone,
+ * so guessing in its absence is what would put them in front of a user.
+ */
+export function toCatalogueFields(catalogue: SearchFieldDataByGroupDto[]): SourcedCatalogueField[] {
+    return catalogue.flatMap((group) =>
+        (group.searchFieldData ?? [])
+            .filter((field) => (field as SourcedCatalogueField).displayable === true)
+            .map((field) => ({ ...field, fieldSource: group.filterFieldSource }) as SourcedCatalogueField),
+    );
+}
+
+/**
+ * Catalogue fields grouped by source and narrowed by the search term. A group left with no matches
+ * is dropped rather than rendered as an empty heading — a resource with no custom attributes should
+ * not appear to have an empty custom section.
+ */
+export function groupCatalogueFields(fields: SourcedCatalogueField[], search: string): CatalogueFieldGroup[] {
+    const term = search.trim().toLowerCase();
+    const matches = (field: SourcedCatalogueField) =>
+        term === '' ||
+        field.fieldLabel.toLowerCase().includes(term) ||
+        // The identifier is searchable too, so a stored column can be found by what a view recorded.
+        field.fieldIdentifier.toLowerCase().includes(term);
+
+    return SOURCE_ORDER.map((source) => ({
+        source,
+        fields: fields.filter((field) => field.fieldSource === source && matches(field)),
+    })).filter((group) => group.fields.length > 0);
+}
+
+/** A catalogue field as a newly added column. It carries no label override, so it follows the catalogue. */
+export function toColumnDefinition(field: SourcedCatalogueField): ColumnDefinition {
+    return {
+        fieldSource: field.fieldSource,
+        fieldIdentifier: field.fieldIdentifier,
+        catalogueLabel: field.fieldLabel,
+        type: field.type,
+        attributeContentType: field.attributeContentType,
+        // Absent means the backend has not said yes, and an unsortable header is the safe reading.
+        sortable: field.sortable === true,
+        multiValue: field.multiValue,
+    };
+}
+
+/** Whether a catalogue field is already among the selected columns. */
+export function isColumnSelected(selected: ColumnDefinition[], field: SourcedCatalogueField): boolean {
+    const key = getColumnKey(field);
+    return selected.some((column) => getColumnKey(column) === key);
+}
+
+/**
+ * Stored columns resolved against the live catalogue.
+ *
+ * A resolved column is refreshed from the catalogue, so a field relabelled since the view was saved
+ * carries its new label through, while the view's own label override and anything the catalogue does
+ * not carry — alignment — survive.
+ *
+ * A column the catalogue does not publish is only unavailable if the platform does not define it
+ * either. A platform default column can be absent from the filter-field catalogue and still be
+ * renderable, and marking those unavailable would drop them from the view on the next save. Anything
+ * else is kept in place and marked unavailable rather than skipped: silently dropping it makes a
+ * heading vanish with no explanation, and the user's next move is to hunt for a field that is gone.
+ */
+export function resolveColumns(
+    stored: ColumnDefinition[],
+    fields: SourcedCatalogueField[],
+    standardColumns: readonly ColumnDefinition[] = [],
+): PickerColumn[] {
+    const byKey = new Map(fields.map((field) => [getColumnKey(field), field]));
+    const standardByKey = new Map(standardColumns.map((column) => [getColumnKey(column), column]));
+
+    return stored.map((column) => {
+        const key = getColumnKey(column);
+        const field = byKey.get(key);
+
+        if (!field) {
+            const standard = standardByKey.get(key);
+            if (!standard) return { ...column, available: false };
+            return { ...standard, ...(column.label ? { label: column.label } : {}), available: true };
+        }
+
+        return {
+            ...toColumnDefinition(field),
+            ...(column.align ? { align: column.align } : {}),
+            ...(column.label ? { label: column.label } : {}),
+            available: true,
+        };
+    });
+}
+
+/**
+ * Whether two resolutions are the same column list. Lets a re-resolution be dropped rather than
+ * replacing state with an equal value, which is what keeps an unstable catalogue reference from
+ * re-rendering forever.
+ */
+export function isSameResolution(a: readonly PickerColumn[], b: readonly PickerColumn[]): boolean {
+    if (a.length !== b.length) return false;
+
+    return a.every((column, index) => {
+        const other = b[index];
+        const keys = new Set([...Object.keys(column), ...Object.keys(other)]) as Set<keyof PickerColumn>;
+        return [...keys].every((key) => column[key] === other[key]);
+    });
+}
+
+/**
+ * The column list with one column moved. Position is display order — top is leftmost — and the
+ * stored shape is a plain array, so a move is a reorder with no index field to renumber.
+ */
+export function moveColumn<T>(columns: T[], from: number, to: number): T[] {
+    if (from < 0 || from >= columns.length) return columns;
+
+    const target = Math.min(Math.max(to, 0), columns.length - 1);
+    if (target === from) return columns;
+
+    const reordered = [...columns];
+    const [moved] = reordered.splice(from, 1);
+    reordered.splice(target, 0, moved);
+    return reordered;
+}
+
+/** How the column counter should read for a given selection size. */
+export function getCounterState(count: number): ColumnCounterState {
+    if (count >= MAX_COLUMNS) return 'full';
+    if (count >= COLUMN_COUNT_WARNING_FROM) return 'warning';
+    return 'ok';
+}

--- a/src/utils/common-hooks.ts
+++ b/src/utils/common-hooks.ts
@@ -134,3 +134,53 @@ export function useRunOnFinish(isLoading: boolean, callback?: () => void) {
 export function useAreDefaultValuesSame(defaultValues: Record<string, unknown>) {
     return useCallback((values: Record<string, unknown>) => isObjectSame(values, defaultValues), [defaultValues]);
 }
+
+/**
+ * Tracks whether an element's content is wider than the element itself, i.e. whether the browser is
+ * applying the ellipsis. A list cell only reveals its full value when it is actually cut off, and a
+ * column set the user rearranges changes cell widths with no window resize, so the check is driven
+ * by a ResizeObserver on the element rather than by a window listener.
+ *
+ * The returned ref is a callback ref on purpose. Acting on truncation usually means wrapping the
+ * element — in a tooltip, say — which remounts it; an object ref would then still point at the
+ * detached node, whose width is zero, and the truncation would immediately unset itself. Following
+ * the node also means a detached one is never measured.
+ *
+ * `value` is what the element renders; passing it re-measures when the text changes, which a
+ * ResizeObserver alone would miss whenever a longer value happens to occupy the same box.
+ */
+export function useIsTruncated<T extends HTMLElement>(value: unknown): [(node: T | null) => void, boolean] {
+    const [isTruncated, setIsTruncated] = useState(false);
+    const nodeRef = useRef<T | null>(null);
+    const observerRef = useRef<ResizeObserver | null>(null);
+
+    const measure = useCallback(() => {
+        const node = nodeRef.current;
+        if (!node?.isConnected) return;
+        setIsTruncated(node.scrollWidth > node.clientWidth);
+    }, []);
+
+    const ref = useCallback(
+        (node: T | null) => {
+            observerRef.current?.disconnect();
+            observerRef.current = null;
+            nodeRef.current = node;
+            if (!node) return;
+
+            measure();
+            if (typeof ResizeObserver === 'undefined') return;
+            const observer = new ResizeObserver(measure);
+            observer.observe(node);
+            observerRef.current = observer;
+        },
+        [measure],
+    );
+
+    useEffect(() => {
+        measure();
+    }, [value, measure]);
+
+    useEffect(() => () => observerRef.current?.disconnect(), []);
+
+    return [ref, isTruncated];
+}

--- a/src/utils/common-hooks.ts
+++ b/src/utils/common-hooks.ts
@@ -136,18 +136,13 @@ export function useAreDefaultValuesSame(defaultValues: Record<string, unknown>) 
 }
 
 /**
- * Tracks whether an element's content is wider than the element itself, i.e. whether the browser is
- * applying the ellipsis. A list cell only reveals its full value when it is actually cut off, and a
- * column set the user rearranges changes cell widths with no window resize, so the check is driven
- * by a ResizeObserver on the element rather than by a window listener.
+ * Whether an element's content is wider than the element, i.e. whether the browser is applying the
+ * ellipsis. Measured by a ResizeObserver on the element, because rearranging a column set changes
+ * cell widths with no window resize.
  *
- * The returned ref is a callback ref on purpose. Acting on truncation usually means wrapping the
- * element — in a tooltip, say — which remounts it; an object ref would then still point at the
- * detached node, whose width is zero, and the truncation would immediately unset itself. Following
- * the node also means a detached one is never measured.
- *
- * `value` is what the element renders; passing it re-measures when the text changes, which a
- * ResizeObserver alone would miss whenever a longer value happens to occupy the same box.
+ * The returned ref is a callback ref: acting on truncation usually means wrapping the element, which
+ * remounts it, and an object ref would keep pointing at the detached node and measure zero width.
+ * `value` is what the element renders, and re-measures on a text change the observer cannot see.
  */
 export function useIsTruncated<T extends HTMLElement>(value: unknown): [(node: T | null) => void, boolean] {
     const [isTruncated, setIsTruncated] = useState(false);

--- a/src/utils/tableColumns.spec.ts
+++ b/src/utils/tableColumns.spec.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest';
+import type { ColumnDefinition, ProjectedAttributeValues } from 'types/tableColumns';
+import { AttributeContentType, FilterFieldSource, FilterFieldType } from 'types/openapi';
+import { buildColumnHeaders, getColumnHeading, getColumnKey, getColumnSizing, getProjectedContent } from './tableColumns';
+
+const column = (overrides: Partial<ColumnDefinition> = {}): ColumnDefinition => ({
+    fieldSource: FilterFieldSource.Custom,
+    fieldIdentifier: 'costCentre',
+    catalogueLabel: 'Cost centre',
+    ...overrides,
+});
+
+describe('getColumnHeading', () => {
+    it('uses the catalogue label when the view sets no override', () => {
+        expect(getColumnHeading(column())).toBe('Cost centre');
+    });
+
+    it('prefers the view label over the catalogue label', () => {
+        expect(getColumnHeading(column({ label: 'Cost centre (FY26)' }))).toBe('Cost centre (FY26)');
+    });
+
+    it('treats an empty override as absent, so the column keeps following the catalogue', () => {
+        expect(getColumnHeading(column({ label: '' }))).toBe('Cost centre');
+    });
+});
+
+describe('getColumnKey', () => {
+    it('qualifies the identifier with its source, because an identifier is unique only within a source', () => {
+        expect(getColumnKey(column())).toBe('custom:costCentre');
+        expect(getColumnKey(column({ fieldSource: FilterFieldSource.Meta }))).toBe('meta:costCentre');
+    });
+});
+
+describe('getProjectedContent', () => {
+    const attributeValues: ProjectedAttributeValues = {
+        [FilterFieldSource.Custom]: {
+            costCentre: [{ data: 4820 }],
+            environment: [{ data: 'production' }, { data: 'staging' }],
+            empty: [],
+        },
+        [FilterFieldSource.Meta]: {
+            costCentre: [{ data: 'meta-value' }],
+        },
+    };
+
+    it('reads the value nested by source and then identifier', () => {
+        expect(getProjectedContent({ attributeValues }, column())).toEqual([{ data: 4820 }]);
+    });
+
+    it('does not confuse the same identifier across two sources', () => {
+        expect(getProjectedContent({ attributeValues }, column({ fieldSource: FilterFieldSource.Meta }))).toEqual([{ data: 'meta-value' }]);
+    });
+
+    it('returns every value of a multi-valued attribute', () => {
+        expect(getProjectedContent({ attributeValues }, column({ fieldIdentifier: 'environment' }))).toHaveLength(2);
+    });
+
+    it('reports an empty array as absent, so the cell resolves to the empty state', () => {
+        expect(getProjectedContent({ attributeValues }, column({ fieldIdentifier: 'empty' }))).toBeUndefined();
+    });
+
+    it('reports an unprojected identifier as absent', () => {
+        expect(getProjectedContent({ attributeValues }, column({ fieldIdentifier: 'notProjected' }))).toBeUndefined();
+    });
+
+    it('reports an unprojected source as absent', () => {
+        expect(getProjectedContent({ attributeValues }, column({ fieldSource: FilterFieldSource.Data }))).toBeUndefined();
+    });
+
+    it('survives a row that carries no projected values at all', () => {
+        expect(getProjectedContent({}, column())).toBeUndefined();
+    });
+});
+
+describe('getColumnSizing', () => {
+    it('always sets a maxWidth, because that is the switch that turns the one-line rule on', () => {
+        const contentTypes = Object.values(AttributeContentType);
+        for (const attributeContentType of contentTypes) {
+            expect(getColumnSizing(column({ attributeContentType })).maxWidth).toBeGreaterThan(0);
+        }
+    });
+
+    it('gives a date column less room than free text', () => {
+        const date = getColumnSizing(column({ attributeContentType: AttributeContentType.Date }));
+        const text = getColumnSizing(column({ attributeContentType: AttributeContentType.Text }));
+        expect(date.maxWidth).toBeLessThan(text.maxWidth);
+    });
+
+    it('keeps minWidth at or below maxWidth for every content type', () => {
+        for (const attributeContentType of Object.values(AttributeContentType)) {
+            const sizing = getColumnSizing(column({ attributeContentType }));
+            expect(Number.parseInt(sizing.minWidth, 10)).toBeLessThanOrEqual(sizing.maxWidth);
+        }
+    });
+
+    it('falls back to the filter field type when a property column carries no content type', () => {
+        const boolean = getColumnSizing(column({ fieldSource: FilterFieldSource.Property, type: FilterFieldType.Boolean }));
+        const string = getColumnSizing(column({ fieldSource: FilterFieldSource.Property, type: FilterFieldType.String }));
+        expect(boolean.maxWidth).toBeLessThan(string.maxWidth);
+    });
+
+    it('sizes a column with neither content type nor field type from the default', () => {
+        const sizing = getColumnSizing(column());
+        expect(sizing.maxWidth).toBeGreaterThan(0);
+        expect(sizing.minWidth).toMatch(/^\d+px$/);
+    });
+});
+
+describe('buildColumnHeaders', () => {
+    const columns: ColumnDefinition[] = [
+        column({ fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME', catalogueLabel: 'Common Name', sortable: true }),
+        column({ fieldIdentifier: 'costCentre', label: 'Cost centre (FY26)', attributeContentType: AttributeContentType.Integer }),
+    ];
+
+    it('produces one header per column, in the order given', () => {
+        expect(buildColumnHeaders(columns).map((header) => header.id)).toEqual(['property:COMMON_NAME', 'custom:costCentre']);
+    });
+
+    it('renders the heading a view asks for', () => {
+        expect(buildColumnHeaders(columns).map((header) => header.content)).toEqual(['Common Name', 'Cost centre (FY26)']);
+    });
+
+    it('marks a header sortable only when the catalogue says the field is', () => {
+        expect(buildColumnHeaders(columns).map((header) => header.sortable)).toEqual([true, false]);
+    });
+
+    it('sizes every header, so a wide column set degrades by scrolling rather than by squeezing', () => {
+        for (const header of buildColumnHeaders(columns)) {
+            expect(header.minWidth).toBeTruthy();
+            expect(header.maxWidth).toBeTruthy();
+        }
+    });
+
+    it('declares no percentage width, which under table-layout auto is a hint rather than a width', () => {
+        for (const header of buildColumnHeaders(columns)) {
+            expect(header.width).toBeUndefined();
+        }
+    });
+
+    it('marks the sorted column with its direction and leaves the others unmarked', () => {
+        const headers = buildColumnHeaders(columns, { sort: { fieldIdentifier: 'COMMON_NAME', direction: 'desc' } });
+        expect(headers[0].sort).toBe('desc');
+        expect(headers[1].sort).toBeUndefined();
+    });
+
+    it('ignores a sort on a column that is not displayed', () => {
+        const headers = buildColumnHeaders(columns, { sort: { fieldIdentifier: 'NOT_SHOWN', direction: 'asc' } });
+        expect(headers.every((header) => header.sort === undefined)).toBe(true);
+    });
+
+    it('right-aligns numeric columns so digits line up down the column', () => {
+        const headers = buildColumnHeaders(columns);
+        expect(headers[1].align).toBe('right');
+    });
+
+    it('honours an explicit alignment over the content-type default', () => {
+        const headers = buildColumnHeaders([column({ attributeContentType: AttributeContentType.Integer, align: 'center' })]);
+        expect(headers[0].align).toBe('center');
+    });
+
+    it('returns no headers for no columns', () => {
+        expect(buildColumnHeaders([])).toEqual([]);
+    });
+});

--- a/src/utils/tableColumns.spec.ts
+++ b/src/utils/tableColumns.spec.ts
@@ -138,14 +138,33 @@ describe('buildColumnHeaders', () => {
     });
 
     it('marks the sorted column with its direction and leaves the others unmarked', () => {
-        const headers = buildColumnHeaders(columns, { sort: { fieldIdentifier: 'COMMON_NAME', direction: 'desc' } });
+        const headers = buildColumnHeaders(columns, {
+            sort: { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME', direction: 'desc' },
+        });
         expect(headers[0].sort).toBe('desc');
         expect(headers[1].sort).toBeUndefined();
     });
 
     it('ignores a sort on a column that is not displayed', () => {
-        const headers = buildColumnHeaders(columns, { sort: { fieldIdentifier: 'NOT_SHOWN', direction: 'asc' } });
+        const headers = buildColumnHeaders(columns, {
+            sort: { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'NOT_SHOWN', direction: 'asc' },
+        });
         expect(headers.every((header) => header.sort === undefined)).toBe(true);
+    });
+
+    /** An identifier is unique only within its source, so two sources may publish the same one. */
+    it('marks only the sorted source when two columns share an identifier', () => {
+        const shared: ColumnDefinition[] = [
+            column({ fieldSource: FilterFieldSource.Meta, fieldIdentifier: 'name', catalogueLabel: 'Name', sortable: true }),
+            column({ fieldSource: FilterFieldSource.Custom, fieldIdentifier: 'name', catalogueLabel: 'Name', sortable: true }),
+        ];
+
+        const headers = buildColumnHeaders(shared, {
+            sort: { fieldSource: FilterFieldSource.Custom, fieldIdentifier: 'name', direction: 'asc' },
+        });
+
+        expect(headers[0].sort).toBeUndefined();
+        expect(headers[1].sort).toBe('asc');
     });
 
     it('right-aligns numeric columns so digits line up down the column', () => {

--- a/src/utils/tableColumns.ts
+++ b/src/utils/tableColumns.ts
@@ -1,6 +1,6 @@
 import type { SortDirection, TableHeader } from 'components/CustomTable/types';
 import type { BaseAttributeContentModel } from 'types/attributes';
-import { AttributeContentType, FilterFieldType } from 'types/openapi';
+import { AttributeContentType, type FilterFieldSource, FilterFieldType } from 'types/openapi';
 import type { AttributeProjectable, ColumnDefinition, ProjectedAttributeValues } from 'types/tableColumns';
 
 /** Width bounds of one generated column, in pixels. */
@@ -48,10 +48,20 @@ const DEFAULT_SIZING: ColumnSizing = SIZING_BY_CONTENT_TYPE[AttributeContentType
 
 const NUMERIC_CONTENT_TYPES: ReadonlySet<AttributeContentType> = new Set([AttributeContentType.Integer, AttributeContentType.Float]);
 
-/** Ordering the whole result set is sorted by, as a saved view carries it. */
+/**
+ * Ordering the whole result set is sorted by, as a saved view carries it. The source is part of the
+ * identity for the same reason it is in {@link getColumnKey}: an identifier alone does not say which
+ * column was sorted when two sources publish the same one.
+ */
 export interface ColumnSort {
+    fieldSource: FilterFieldSource;
     fieldIdentifier: string;
     direction: SortDirection;
+}
+
+/** A sort's column key, in the same shape {@link getColumnKey} produces. */
+export function getSortKey(sort: ColumnSort): string {
+    return `${sort.fieldSource}:${sort.fieldIdentifier}`;
 }
 
 export interface BuildColumnHeadersOptions {
@@ -112,9 +122,10 @@ function getColumnAlign(column: ColumnDefinition): TableHeader['align'] {
 export function buildColumnHeaders(columns: ColumnDefinition[], options: BuildColumnHeadersOptions = {}): TableHeader[] {
     return columns.map((column) => {
         const sizing = getColumnSizing(column);
-        const isSorted = options.sort?.fieldIdentifier === column.fieldIdentifier;
+        const key = getColumnKey(column);
+        const isSorted = options.sort !== undefined && getSortKey(options.sort) === key;
         return {
-            id: getColumnKey(column),
+            id: key,
             content: getColumnHeading(column),
             sortable: column.sortable === true,
             sort: isSorted ? options.sort?.direction : undefined,

--- a/src/utils/tableColumns.ts
+++ b/src/utils/tableColumns.ts
@@ -79,8 +79,10 @@ export function getColumnHeading(column: ColumnDefinition): string {
 /**
  * A stable key for a column. A field identifier is unique only within its source, so the source has
  * to qualify it — `property:name` and `custom:name` are different columns.
+ *
+ * Takes only the two fields it needs, so a catalogue field keys the same way a column does.
  */
-export function getColumnKey(column: ColumnDefinition): string {
+export function getColumnKey(column: Pick<ColumnDefinition, 'fieldSource' | 'fieldIdentifier'>): string {
     return `${column.fieldSource}:${column.fieldIdentifier}`;
 }
 

--- a/src/utils/tableColumns.ts
+++ b/src/utils/tableColumns.ts
@@ -1,0 +1,126 @@
+import type { SortDirection, TableHeader } from 'components/CustomTable/types';
+import type { BaseAttributeContentModel } from 'types/attributes';
+import { AttributeContentType, FilterFieldType } from 'types/openapi';
+import type { AttributeProjectable, ColumnDefinition, ProjectedAttributeValues } from 'types/tableColumns';
+
+/** Width bounds of one generated column, in pixels. */
+export interface ColumnSizing {
+    minWidth: string;
+    maxWidth: number;
+}
+
+/**
+ * Sizing per content type. Every column gets a `maxWidth`, because that is the only thing that makes
+ * the row cell apply `overflow: hidden` and an ellipsis, and so the switch that turns the one-line
+ * row rule on. The `minWidth` is what makes a twelve-column table degrade by scrolling rather than
+ * by squeezing every column into illegibility.
+ */
+const SIZING_BY_CONTENT_TYPE: Readonly<Record<AttributeContentType, ColumnSizing>> = {
+    [AttributeContentType.Boolean]: { minWidth: '90px', maxWidth: 120 },
+    [AttributeContentType.Integer]: { minWidth: '90px', maxWidth: 140 },
+    [AttributeContentType.Float]: { minWidth: '90px', maxWidth: 140 },
+    [AttributeContentType.Date]: { minWidth: '110px', maxWidth: 160 },
+    [AttributeContentType.Time]: { minWidth: '100px', maxWidth: 140 },
+    [AttributeContentType.Datetime]: { minWidth: '150px', maxWidth: 200 },
+    [AttributeContentType.String]: { minWidth: '140px', maxWidth: 320 },
+    [AttributeContentType.Text]: { minWidth: '180px', maxWidth: 420 },
+    [AttributeContentType.Credential]: { minWidth: '140px', maxWidth: 260 },
+    [AttributeContentType.Object]: { minWidth: '140px', maxWidth: 260 },
+    [AttributeContentType.Resource]: { minWidth: '140px', maxWidth: 260 },
+    [AttributeContentType.File]: { minWidth: '140px', maxWidth: 260 },
+    // Neither can be picked as a column: both are marked displayable=false by the catalogue. They
+    // are sized anyway so the table never has to reason about a missing entry.
+    [AttributeContentType.Secret]: { minWidth: '90px', maxWidth: 120 },
+    [AttributeContentType.Codeblock]: { minWidth: '140px', maxWidth: 320 },
+};
+
+/** A property column reports a filter field type rather than an attribute content type. */
+const SIZING_BY_FIELD_TYPE: Readonly<Record<FilterFieldType, ColumnSizing>> = {
+    [FilterFieldType.Boolean]: SIZING_BY_CONTENT_TYPE[AttributeContentType.Boolean],
+    [FilterFieldType.Number]: SIZING_BY_CONTENT_TYPE[AttributeContentType.Integer],
+    [FilterFieldType.Date]: SIZING_BY_CONTENT_TYPE[AttributeContentType.Date],
+    [FilterFieldType.Datetime]: SIZING_BY_CONTENT_TYPE[AttributeContentType.Datetime],
+    [FilterFieldType.List]: SIZING_BY_CONTENT_TYPE[AttributeContentType.String],
+    [FilterFieldType.String]: SIZING_BY_CONTENT_TYPE[AttributeContentType.String],
+};
+
+const DEFAULT_SIZING: ColumnSizing = SIZING_BY_CONTENT_TYPE[AttributeContentType.String];
+
+const NUMERIC_CONTENT_TYPES: ReadonlySet<AttributeContentType> = new Set([AttributeContentType.Integer, AttributeContentType.Float]);
+
+/** Ordering the whole result set is sorted by, as a saved view carries it. */
+export interface ColumnSort {
+    fieldIdentifier: string;
+    direction: SortDirection;
+}
+
+export interface BuildColumnHeadersOptions {
+    sort?: ColumnSort;
+}
+
+/**
+ * The heading a view shows for a column. An absent or empty override means the column follows the
+ * catalogue, so a field relabelled later carries through.
+ */
+export function getColumnHeading(column: ColumnDefinition): string {
+    return column.label ? column.label : column.catalogueLabel;
+}
+
+/**
+ * A stable key for a column. A field identifier is unique only within its source, so the source has
+ * to qualify it — `property:name` and `custom:name` are different columns.
+ */
+export function getColumnKey(column: ColumnDefinition): string {
+    return `${column.fieldSource}:${column.fieldIdentifier}`;
+}
+
+/**
+ * The projected values a listing entry carries for a column, or `undefined` when the entry has
+ * none. An empty array is reported as absent so the cell resolves to the empty state rather than to
+ * a value renderer with nothing to render.
+ */
+export function getProjectedContent(row: object, column: ColumnDefinition): BaseAttributeContentModel[] | undefined {
+    // Read structurally rather than constraining the row type: the listing DTOs gain
+    // `attributeValues` from the contract, and a caller must not have to declare the field to
+    // render a row that simply has no projected values.
+    const attributeValues = (row as AttributeProjectable).attributeValues;
+    const bySource: ProjectedAttributeValues[keyof ProjectedAttributeValues] = attributeValues?.[column.fieldSource];
+    const content = bySource?.[column.fieldIdentifier];
+    return content && content.length > 0 ? content : undefined;
+}
+
+/** Width bounds for a column, taken from its content type and falling back to its field type. */
+export function getColumnSizing(column: ColumnDefinition): ColumnSizing {
+    if (column.attributeContentType) return SIZING_BY_CONTENT_TYPE[column.attributeContentType] ?? DEFAULT_SIZING;
+    if (column.type) return SIZING_BY_FIELD_TYPE[column.type] ?? DEFAULT_SIZING;
+    return DEFAULT_SIZING;
+}
+
+function getColumnAlign(column: ColumnDefinition): TableHeader['align'] {
+    if (column.align) return column.align;
+    // Numerals are rendered in tabular figures and right-aligned, so digits line up down the column.
+    if (column.attributeContentType && NUMERIC_CONTENT_TYPES.has(column.attributeContentType)) return 'right';
+    if (!column.attributeContentType && column.type === FilterFieldType.Number) return 'right';
+    return undefined;
+}
+
+/**
+ * Table headers for a column definition list. Deliberately declares no percentage `width`: no
+ * `table-layout` is set anywhere in the app, so the table is `auto` and a percentage is a competing
+ * hint rather than a width. The per-column `minWidth`/`maxWidth` are the real sizing.
+ */
+export function buildColumnHeaders(columns: ColumnDefinition[], options: BuildColumnHeadersOptions = {}): TableHeader[] {
+    return columns.map((column) => {
+        const sizing = getColumnSizing(column);
+        const isSorted = options.sort?.fieldIdentifier === column.fieldIdentifier;
+        return {
+            id: getColumnKey(column),
+            content: getColumnHeading(column),
+            sortable: column.sortable === true,
+            sort: isSorted ? options.sort?.direction : undefined,
+            align: getColumnAlign(column),
+            minWidth: sizing.minWidth,
+            maxWidth: sizing.maxWidth,
+        };
+    });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -26,6 +26,9 @@ export default defineConfig({
                 'src/utils/**/*.{ts,tsx}',
                 'src/ducks/**/*.{ts,tsx}',
                 'src/components/PagedList/PagedList.tsx',
+                // Row building runs in the test body rather than in the browser, so the component
+                // test run never instruments it; its unit tests are what report its coverage.
+                'src/components/CustomTable/columns/buildTableRows.tsx',
                 'src/components/Widget/index.tsx',
                 // Build hooks with their own unit tests; report them so Sonar sees the coverage.
                 'scripts/set-openapi-contact.mjs',


### PR DESCRIPTION
Closes #2017
Closes #2018

Two pieces of the custom-columns work, in one PR because #2085 was merged into this branch rather than after it: list rows render from a column definition list, and the dialog that produces that list. Built against the design artifact on #2022 (section 02, the dialog; section 05, cell states; section 06, sizing rules; section 07, the four edge states).

# Rows from column definitions

List rows are rendered from a column definition list rather than from a positional cell array a page assembles, and the cell render registry the inventories plug into lands with them.

## Resolution order

A cell resolves in a fixed order:

1. the registry entry for the column, which owns the rich property cells;
2. otherwise the projected attribute values on the listing entry, rendered by content type;
3. and in either case the shared empty state when that produced nothing.

## What is added

- `renderCell` and `buildTableRows` build a row from a `ColumnDefinition` list, in the order given, so the same row renders under any column ordering.
- `CellRegistry` is keyed by `source:identifier` — a field identifier is unique only within its source. A registry entry that returns `null`, `undefined` or `''` resolves to the empty state, so no renderer has to spell that out.
- `getListCellValues` prepares attribute content for a list cell. It deviates from `getAttributeContent` where a column and a detail page want different things: booleans read `Yes`/`No`, files show the file name with the mime type moved into the reveal, credentials and objects never render raw, and resources link to the referenced object.
- Cell states: an em dash with the accessible name "No value" for absence; one value otherwise; and for several values the first plus a `+N` toggletip listing all of them in `item_order`, reusing the connector capability treatment rather than inventing a second one. Every state is one line high.
- A value too wide for its column truncates and reveals itself in a tooltip; a value that fits gets none.
- `buildColumnHeaders` sizes each column from its content type with a `minWidth` and a `maxWidth`, and declares no percentage `width`. No `table-layout` is set anywhere in the app, so the table is `auto` and a percentage is a competing hint rather than a width; the `maxWidth` is the only thing that makes the row cell truncate at all.
- `Toggletip` accepts custom trigger content, so an overflow pill reuses its hover, pinning and focus behaviour instead of reimplementing it alongside.

## Certificate and key registries

Both inventories get registry entries for their rich property columns and a default column set built from the catalogue's own field identifiers (the `FilterField` enum names), so a saved view naming the same field resolves to the same entry.

Two behaviours change as a result, both called out by the design:

- The certificates Groups cell joined every group with `', '`, so five groups rendered as one ever-widening line. It now shows the first group and a `+N` reveal.
- Unset values that printed per-column copy — `'Unassigned'` for groups, RA profile and owner, `'unknown'` for key size and format — now use the shared empty state. Empty is one state, not one per column.

# The column picker

The dialog where a user arranges the columns of a view: what could be shown on the left, what is shown on the right.

## The two panes

A single combined list makes "what have I already got?" hard to answer once an organisation has thirty custom attributes. Splitting it gives search a natural home on the left and keeps ordering, renaming and removal on the right, where position actually means something.

**Left — available fields.** Grouped by source with a source badge and the catalogue label, searchable across all four sources by label *and* by identifier, so a column can be found by what a view recorded. A group left with no matches is dropped rather than rendered as an empty heading — a resource with no custom attributes does not appear to have an empty custom section.

Only fields the catalogue marks `displayable` are offered, and an absent flag is **not** read as a yes: that flag alone is what keeps secret content, encrypted content and code blocks out of a column, so guessing in its absence is what would put them in front of a user. A field the backend reports as not sortable says so here, before it is chosen, rather than only once its header refuses to sort.

**Right — columns shown.** The column order, top leftmost, which is exactly the stored array — no index field to renumber. Rows reorder by drag with a visible insertion line and by explicit move controls; a heading renames inline with the catalogue label still visible behind it and a revert control beside it. Reverting clears the override rather than restoring a remembered string, which is what `label: null` means in the stored shape.

**Header preview** renders the resulting header row live, so a reorder or a rename can be judged without closing anything.

## The four edge states

1. **At the cap** — the counter warns from 10 and turns to its cap treatment at 12, and selection stops rather than silently ignoring further additions. Unselected fields stay listed and searchable with an inert add control; hiding them would make the catalogue look broken. Twelve is a frontend readability rule, not a contract limit.
2. **At zero** — Save is disabled and the pane says a view needs at least one column. The API rejects an empty set, so this is the one place the dialog blocks outright instead of warning.
3. **Reset** — "Reset to Standard columns" refills the right pane as an edit that can still be cancelled. Getting back to the platform columns outright is the Standard tab, which is why the table itself carries no reset control.
4. **A column whose field is gone** — kept in its stored position, dashed, badged `Unavailable` and showing the stored identifier so an administrator can tell what it was. Removal is its only action and saving drops it. Silently skipping it is the tempting option and the wrong one: a heading vanishes with no explanation and the user's next move is to hunt for a field that no longer exists.

## Two decisions worth flagging

**Reordering is hand-rolled on the HTML5 drag API**, not a drag library. AC 8 requires keyboard operation, and no drag handle is ever reachable from the keyboard — so each row carries explicit move controls regardless. Given that the accessible path exists either way, a dependency would only have replaced the pointer half.

**The catalogue flags are declared on a local type.** `SearchFieldDataDto` in `src/types/openapi` has no `displayable`/`sortable` yet, because regenerating pulls an unrelated platform bump that does not compile (see the generated-types note below). `ColumnCatalogueField` declares both as optional, typed exactly as the contract does, so this becomes redundant — not wrong — once the generated types catch up.

Nothing reaches the API until Save: a half-arranged view must not hit the network on every drag.

# Not included

No page picks its own columns or opens the dialog yet; the pilot wiring (#2020) does that. The certificates page is untouched — its helper is what became definition-driven. The keys page had no helper, so one was extracted and the page now calls it.

# Notes for the wiring ticket

- Three columns in the keys default set have no `FilterField` entry — `CKI_ENABLED`, `CKI_CREATED` and `CK_ASSOCIATIONS` — so they can be shown but not picked, renamed or sorted until the catalogue carries them. They keep their natural identifiers here so adding the fields is the only change needed.
- The certificates default set is 16 columns, above the 12-column cap the design sets for user-built views.
- The published OpenAPI spec now carries `displayable`, `sortable`, `SearchColumnRequestDto` and the projected `attributeValues` map, but regenerating `src/types/openapi` also pulls a full 2.18.1 to 2.20.0 platform bump that does not build: `DiscoveryHistoryDto` and `PublicBrandingDto` are gone, seven generated models are circular type aliases, and the generator's own `runtime.ts` patch misfires. Nothing here needs those types — rows read projected values structurally, and the catalogue flags are declared locally — but #2019 and #2020 do, and that regeneration is its own piece of work.

# Verification

- `npm run typecheck` clean.
- `npm run lint` clean (0 errors).
- Vitest: 3523 passed.
- Playwright CT (chromium): 1671 passed, 0 failed.
- Coverage on new code: 100% on the column modules and every picker file, 96% on `listCellValues`, 94% on `common-hooks`.
