### PR TITLE
Add the column picker grouped by field source

### DIFF
--- a/src/components/ColumnPicker/AvailableFields.tsx
+++ b/src/components/ColumnPicker/AvailableFields.tsx
@@ -1,0 +1,111 @@
+import { Plus, Search } from 'lucide-react';
+import type { FilterFieldSource } from 'types/openapi';
+import type { ColumnDefinition, SourcedCatalogueField } from 'types/tableColumns';
+import { groupCatalogueFields, isColumnSelected } from 'utils/columnPicker';
+import { getColumnKey } from 'utils/tableColumns';
+import SourceBadge from './SourceBadge';
+
+type Props = Readonly<{
+    fields: SourcedCatalogueField[];
+    selected: ColumnDefinition[];
+    search: string;
+    onSearchChange: (search: string) => void;
+    onAdd: (field: SourcedCatalogueField) => void;
+    /** True once the selection has reached the cap; add controls go quiet but the list stays browsable. */
+    isAtCap: boolean;
+    getSourceLabel: (source: FilterFieldSource) => string;
+}>;
+
+/**
+ * What could be shown. Splitting this from the selected columns gives search a natural home and
+ * keeps ordering, renaming and removal on the other side, where position actually means something.
+ */
+export default function AvailableFields({ fields, selected, search, onSearchChange, onAdd, isAtCap, getSourceLabel }: Props) {
+    const groups = groupCatalogueFields(fields, search);
+
+    return (
+        <section className="flex min-h-0 flex-col" aria-labelledby="available-fields-heading">
+            <h3 id="available-fields-heading" className="mb-2 text-sm font-semibold text-content">
+                Available fields
+            </h3>
+
+            <div className="relative">
+                <Search
+                    size={16}
+                    className="pointer-events-none absolute top-1/2 start-2.5 -translate-y-1/2 text-content-subtle"
+                    aria-hidden
+                />
+                <input
+                    type="search"
+                    value={search}
+                    onChange={(event) => onSearchChange(event.target.value)}
+                    placeholder={`Search ${fields.length} fields...`}
+                    aria-label="Search available fields"
+                    data-testid="available-fields-search"
+                    className="w-full rounded-md border border-divider bg-surface-raised py-1.5 ps-8 pe-2.5 text-sm text-content placeholder:text-content-subtle focus:border-brand focus:outline-hidden focus-visible:ring-2 focus-visible:ring-brand"
+                />
+            </div>
+
+            {isAtCap && (
+                <p className="mt-2 text-xs text-warning" data-testid="available-fields-cap-hint">
+                    Remove a column before adding another.
+                </p>
+            )}
+
+            <div className="mt-2 min-h-0 flex-1 overflow-y-auto" data-testid="available-fields-list">
+                {groups.length === 0 ? (
+                    <p className="px-1 py-3 text-sm text-content-subtle" data-testid="available-fields-empty">
+                        {fields.length === 0 ? 'This resource publishes no columns.' : 'No field matches your search.'}
+                    </p>
+                ) : (
+                    groups.map((group) => (
+                        <div key={group.source} className="mb-3">
+                            <h4 className="mb-1 text-xs font-semibold tracking-wide text-content-muted uppercase">
+                                {getSourceLabel(group.source)}
+                            </h4>
+                            <ul className="m-0 flex list-none flex-col p-0">
+                                {group.fields.map((field) => {
+                                    const added = isColumnSelected(selected, field);
+                                    return (
+                                        <li
+                                            key={getColumnKey(field)}
+                                            className="flex items-center gap-2 rounded-md px-1 py-1 hover:bg-surface-hover"
+                                            data-testid={`available-field-${getColumnKey(field)}`}
+                                        >
+                                            <SourceBadge source={field.fieldSource} label={getSourceLabel(field.fieldSource)} />
+                                            <span className="min-w-0 flex-1 truncate text-sm text-content">{field.fieldLabel}</span>
+                                            {field.sortable !== true && (
+                                                <span className="shrink-0 text-xs text-content-subtle" title="This field cannot be sorted">
+                                                    not sortable
+                                                </span>
+                                            )}
+                                            {added ? (
+                                                <span className="shrink-0 text-xs text-content-muted" data-testid="field-added">
+                                                    added
+                                                </span>
+                                            ) : (
+                                                <button
+                                                    type="button"
+                                                    onClick={() => onAdd(field)}
+                                                    disabled={isAtCap}
+                                                    // Kept listed and searchable at the cap: hiding what cannot
+                                                    // currently be added would make the catalogue look broken.
+                                                    className="inline-flex shrink-0 items-center gap-0.5 rounded-md px-1.5 py-0.5 text-xs font-medium text-brand hover:bg-brand-subtle disabled:cursor-not-allowed disabled:text-content-subtle disabled:hover:bg-transparent"
+                                                    data-testid={`add-field-${getColumnKey(field)}`}
+                                                >
+                                                    <Plus size={12} aria-hidden />
+                                                    add
+                                                    <span className="sr-only">{` ${field.fieldLabel} as a column`}</span>
+                                                </button>
+                                            )}
+                                        </li>
+                                    );
+                                })}
+                            </ul>
+                        </div>
+                    ))
+                )}
+            </div>
+        </section>
+    );
+}

--- a/src/components/ColumnPicker/ColumnPicker.spec.tsx
+++ b/src/components/ColumnPicker/ColumnPicker.spec.tsx
@@ -1,0 +1,269 @@
+import { expect, test } from '../../../playwright/ct-test';
+import { withProviders } from 'utils/test-helpers';
+import { AttributeContentType, FilterFieldSource, FilterFieldType, type SearchFieldDataByGroupDto } from 'types/openapi';
+import type { ColumnDefinition } from 'types/tableColumns';
+import ColumnPicker from './index';
+
+const field = (identifier: string, label: string, overrides: Record<string, unknown> = {}) => ({
+    fieldIdentifier: identifier,
+    fieldLabel: label,
+    type: FilterFieldType.String,
+    conditions: [],
+    displayable: true,
+    sortable: true,
+    ...overrides,
+});
+
+const catalogue = [
+    {
+        filterFieldSource: FilterFieldSource.Property,
+        searchFieldData: [
+            field('COMMON_NAME', 'Common Name'),
+            field('SERIAL_NUMBER', 'Serial Number'),
+            field('ISSUER_DN', 'Issuer DN'),
+            field('FINGERPRINT', 'Fingerprint', { displayable: false }),
+        ],
+    },
+    {
+        filterFieldSource: FilterFieldSource.Custom,
+        searchFieldData: [
+            field('costCentre', 'Cost centre', { sortable: false, attributeContentType: AttributeContentType.Integer }),
+            field('environment', 'Environment', { sortable: false }),
+        ],
+    },
+] as unknown as SearchFieldDataByGroupDto[];
+
+const commonName: ColumnDefinition = {
+    fieldSource: FilterFieldSource.Property,
+    fieldIdentifier: 'COMMON_NAME',
+    catalogueLabel: 'Common Name',
+};
+const serialNumber: ColumnDefinition = {
+    fieldSource: FilterFieldSource.Property,
+    fieldIdentifier: 'SERIAL_NUMBER',
+    catalogueLabel: 'Serial Number',
+};
+
+type MountOptions = {
+    columns?: ColumnDefinition[];
+    standardColumns?: ColumnDefinition[];
+    onSave?: (columns: ColumnDefinition[]) => void;
+    onClose?: () => void;
+    fieldCatalogue?: SearchFieldDataByGroupDto[];
+};
+
+const picker = ({
+    columns = [commonName],
+    standardColumns = [commonName, serialNumber],
+    onSave,
+    onClose,
+    fieldCatalogue = catalogue,
+}: MountOptions = {}) =>
+    withProviders(
+        <ColumnPicker
+            isOpen
+            onClose={onClose ?? (() => {})}
+            onSave={onSave ?? (() => {})}
+            catalogue={fieldCatalogue}
+            columns={columns}
+            standardColumns={standardColumns}
+            resourceLabel="Certificates"
+        />,
+    );
+
+test.describe('ColumnPicker', () => {
+    test('groups available fields by source with human-readable labels', async ({ mount, page }) => {
+        await mount(picker());
+
+        await expect(page.getByRole('heading', { name: 'Property' })).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Custom attribute' })).toBeVisible();
+    });
+
+    test('offers only fields the catalogue marks displayable', async ({ mount, page }) => {
+        await mount(picker());
+
+        await expect(page.getByTestId('available-fields-list')).toContainText('Serial Number');
+        await expect(page.getByTestId('available-fields-list')).not.toContainText('Fingerprint');
+    });
+
+    test('marks a non-sortable field before it is chosen', async ({ mount, page }) => {
+        await mount(picker());
+
+        await expect(page.getByTestId('available-field-custom:costCentre')).toContainText('not sortable');
+        await expect(page.getByTestId('available-field-property:SERIAL_NUMBER')).not.toContainText('not sortable');
+    });
+
+    test('shows which fields are already selected', async ({ mount, page }) => {
+        await mount(picker());
+
+        await expect(page.getByTestId('available-field-property:COMMON_NAME')).toContainText('added');
+        await expect(page.getByTestId('add-field-property:COMMON_NAME')).toHaveCount(0);
+    });
+
+    test('searches across every source and hides groups left empty', async ({ mount, page }) => {
+        await mount(picker());
+
+        await page.getByTestId('available-fields-search').fill('cost');
+
+        await expect(page.getByRole('heading', { name: 'Custom attribute' })).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Property' })).toHaveCount(0);
+    });
+
+    test('says so when nothing matches the search', async ({ mount, page }) => {
+        await mount(picker());
+
+        await page.getByTestId('available-fields-search').fill('zzzz');
+
+        await expect(page.getByTestId('available-fields-empty')).toBeVisible();
+    });
+
+    test('renders no empty group for a resource with no custom attributes', async ({ mount, page }) => {
+        await mount(picker({ fieldCatalogue: [catalogue[0]] }));
+
+        await expect(page.getByRole('heading', { name: 'Property' })).toBeVisible();
+        await expect(page.getByRole('heading', { name: 'Custom attribute' })).toHaveCount(0);
+    });
+
+    test('adds a field to the end of the selected columns', async ({ mount, page }) => {
+        await mount(picker());
+
+        await page.getByTestId('add-field-custom:environment').click();
+
+        await expect(page.getByTestId('selected-columns-list').getByRole('listitem')).toHaveCount(2);
+        await expect(page.getByTestId('column-counter')).toHaveText('2 / 12');
+    });
+
+    test('removes a selected column', async ({ mount, page }) => {
+        await mount(picker());
+
+        await page.getByTestId('selected-column-property:COMMON_NAME-remove').click();
+
+        await expect(page.getByTestId('selected-columns-empty')).toBeVisible();
+    });
+
+    test('reorders columns from the keyboard, not only by pointer drag', async ({ mount, page }) => {
+        await mount(picker({ columns: [commonName, serialNumber] }));
+
+        await page.getByTestId('selected-column-property:SERIAL_NUMBER-up').click();
+
+        await expect(page.getByTestId('header-preview')).toHaveText(/Serial Number.*Common Name/);
+    });
+
+    test('reorders columns by dragging one onto another', async ({ mount, page }) => {
+        await mount(picker({ columns: [commonName, serialNumber] }));
+
+        await page.getByTestId('selected-column-property:SERIAL_NUMBER').dragTo(page.getByTestId('selected-column-property:COMMON_NAME'));
+
+        await expect(page.getByTestId('header-preview')).toHaveText('Serial NumberCommon Name');
+    });
+
+    test('shows where a dragged column would land', async ({ mount, page }) => {
+        await mount(picker({ columns: [commonName, serialNumber] }));
+
+        const source = page.getByTestId('selected-column-property:SERIAL_NUMBER');
+        const target = page.getByTestId('selected-column-property:COMMON_NAME');
+
+        // The drag events are dispatched rather than mimed with the mouse: a completed dragTo
+        // cannot show the mid-drag state, and raw mouse events never start an HTML5 drag at all.
+        await source.dispatchEvent('dragstart');
+        await target.dispatchEvent('dragover');
+
+        await expect(target).toHaveClass(/border-t-brand/);
+        await expect(source).toHaveClass(/opacity-50/);
+
+        await target.dispatchEvent('drop');
+        await expect(target).not.toHaveClass(/border-t-brand/);
+    });
+
+    test('disables the move controls at the ends of the order', async ({ mount, page }) => {
+        await mount(picker({ columns: [commonName, serialNumber] }));
+
+        await expect(page.getByTestId('selected-column-property:COMMON_NAME-up')).toBeDisabled();
+        await expect(page.getByTestId('selected-column-property:SERIAL_NUMBER-down')).toBeDisabled();
+    });
+
+    test('renames a column heading and keeps the catalogue label visible', async ({ mount, page }) => {
+        await mount(picker());
+
+        await page.getByTestId('selected-column-property:COMMON_NAME-rename').click();
+        await page.getByTestId('selected-column-property:COMMON_NAME-rename-input').fill('Host');
+        await page.keyboard.press('Enter');
+
+        const row = page.getByTestId('selected-column-property:COMMON_NAME');
+        await expect(row).toContainText('Host');
+        await expect(row).toContainText('← Common Name');
+    });
+
+    test('reverting a heading restores the catalogue label rather than a remembered string', async ({ mount, page }) => {
+        await mount(picker());
+
+        await page.getByTestId('selected-column-property:COMMON_NAME-rename').click();
+        await page.getByTestId('selected-column-property:COMMON_NAME-rename-input').fill('Host');
+        await page.keyboard.press('Enter');
+        await page.getByTestId('selected-column-property:COMMON_NAME-revert').click();
+
+        await expect(page.getByTestId('header-preview')).toHaveText('Common Name');
+        await expect(page.getByTestId('selected-column-property:COMMON_NAME-revert')).toHaveCount(0);
+    });
+
+    test('renaming a column back to its catalogue label clears the override', async ({ mount, page }) => {
+        await mount(picker());
+
+        await page.getByTestId('selected-column-property:COMMON_NAME-rename').click();
+        await page.getByTestId('selected-column-property:COMMON_NAME-rename-input').fill('Common Name');
+        await page.keyboard.press('Enter');
+
+        await expect(page.getByTestId('selected-column-property:COMMON_NAME-revert')).toHaveCount(0);
+    });
+
+    test('the header preview follows the current selection and order live', async ({ mount, page }) => {
+        await mount(picker());
+
+        await expect(page.getByTestId('header-preview')).toHaveText('Common Name');
+        await page.getByTestId('add-field-custom:environment').click();
+
+        await expect(page.getByTestId('header-preview')).toHaveText(/Common Name.*Environment/);
+    });
+
+    test('refills the selected columns from the platform set', async ({ mount, page }) => {
+        await mount(picker({ columns: [], standardColumns: [commonName, serialNumber] }));
+
+        await page.getByTestId('reset-to-standard').click();
+
+        await expect(page.getByTestId('selected-columns-list').getByRole('listitem')).toHaveCount(2);
+    });
+
+    test('blocks saving with no columns, because the API rejects an empty set', async ({ mount, page }) => {
+        await mount(picker({ columns: [] }));
+
+        await expect(page.getByTestId('selected-columns-empty')).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Save' })).toBeDisabled();
+    });
+
+    test('saves the columns in the arranged order, with the heading override', async ({ mount, page }) => {
+        const saved: ColumnDefinition[][] = [];
+        await mount(picker({ columns: [commonName, serialNumber], onSave: (columns) => saved.push(columns) }));
+
+        await page.getByTestId('selected-column-property:SERIAL_NUMBER-rename').click();
+        await page.getByTestId('selected-column-property:SERIAL_NUMBER-rename-input').fill('Serial');
+        await page.keyboard.press('Enter');
+        await page.getByTestId('selected-column-property:SERIAL_NUMBER-up').click();
+        await page.getByRole('button', { name: 'Save' }).click();
+
+        await expect.poll(() => saved.length).toBe(1);
+        expect(saved[0].map((column) => column.fieldIdentifier)).toEqual(['SERIAL_NUMBER', 'COMMON_NAME']);
+        expect(saved[0][0].label).toBe('Serial');
+    });
+
+    test('cancel reports no columns at all', async ({ mount, page }) => {
+        const saved: ColumnDefinition[][] = [];
+        let closed = 0;
+        await mount(picker({ onSave: (columns) => saved.push(columns), onClose: () => (closed += 1) }));
+
+        await page.getByTestId('add-field-custom:environment').click();
+        await page.getByRole('button', { name: 'Cancel' }).click();
+
+        await expect.poll(() => closed).toBe(1);
+        expect(saved).toEqual([]);
+    });
+});

--- a/src/components/ColumnPicker/ColumnPicker.spec.tsx
+++ b/src/components/ColumnPicker/ColumnPicker.spec.tsx
@@ -3,6 +3,7 @@ import { withProviders } from 'utils/test-helpers';
 import { AttributeContentType, FilterFieldSource, FilterFieldType, type SearchFieldDataByGroupDto } from 'types/openapi';
 import type { ColumnDefinition } from 'types/tableColumns';
 import ColumnPicker from './index';
+import ColumnPickerTestWrapper from './ColumnPickerTestWrapper';
 
 const field = (identifier: string, label: string, overrides: Record<string, unknown> = {}) => ({
     fieldIdentifier: identifier,
@@ -42,6 +43,12 @@ const serialNumber: ColumnDefinition = {
     fieldSource: FilterFieldSource.Property,
     fieldIdentifier: 'SERIAL_NUMBER',
     catalogueLabel: 'Serial Number',
+};
+
+const issuerDn: ColumnDefinition = {
+    fieldSource: FilterFieldSource.Property,
+    fieldIdentifier: 'ISSUER_DN',
+    catalogueLabel: 'Issuer DN',
 };
 
 type MountOptions = {
@@ -157,6 +164,27 @@ test.describe('ColumnPicker', () => {
         await expect(page.getByTestId('header-preview')).toHaveText('Serial NumberCommon Name');
     });
 
+    /**
+     * The drop indicator is a top border on the target row, i.e. "land above this row". Moving down
+     * removes the source first, which shifts the target up one, so the insertion index has to
+     * compensate or the row lands below the row the user was shown.
+     */
+    test('drops a column above the row the indicator marks when moving down', async ({ mount, page }) => {
+        await mount(picker({ columns: [commonName, serialNumber, issuerDn] }));
+
+        await page.getByTestId('selected-column-property:COMMON_NAME').dragTo(page.getByTestId('selected-column-property:ISSUER_DN'));
+
+        await expect(page.getByTestId('header-preview')).toHaveText('Serial NumberCommon NameIssuer DN');
+    });
+
+    test('drops a column above the row the indicator marks when moving up', async ({ mount, page }) => {
+        await mount(picker({ columns: [commonName, serialNumber, issuerDn] }));
+
+        await page.getByTestId('selected-column-property:ISSUER_DN').dragTo(page.getByTestId('selected-column-property:SERIAL_NUMBER'));
+
+        await expect(page.getByTestId('header-preview')).toHaveText('Common NameIssuer DNSerial Number');
+    });
+
     test('shows where a dragged column would land', async ({ mount, page }) => {
         await mount(picker({ columns: [commonName, serialNumber] }));
 
@@ -225,12 +253,74 @@ test.describe('ColumnPicker', () => {
         await expect(page.getByTestId('header-preview')).toHaveText(/Common Name.*Environment/);
     });
 
+    /**
+     * A platform default column can be absent from the filter-field catalogue and still renderable —
+     * the keys inventory ships three such columns. Resetting used to mark them unavailable, and the
+     * next Save then silently removed them from the view.
+     */
+    test('reset keeps a platform column the catalogue does not publish, and saves it', async ({ mount, page }) => {
+        const uncatalogued: ColumnDefinition = {
+            fieldSource: FilterFieldSource.Property,
+            fieldIdentifier: 'CKI_ENABLED',
+            catalogueLabel: 'Status',
+        };
+        const saved: ColumnDefinition[][] = [];
+        await mount(picker({ columns: [], standardColumns: [commonName, uncatalogued], onSave: (columns) => saved.push(columns) }));
+
+        await page.getByTestId('reset-to-standard').click();
+
+        await expect(page.getByTestId('selected-column-property:CKI_ENABLED')).not.toContainText('Unavailable');
+
+        await page.getByRole('button', { name: 'Save' }).click();
+
+        await expect.poll(() => saved.length).toBe(1);
+        expect(saved[0].map((column) => column.fieldIdentifier)).toEqual(['COMMON_NAME', 'CKI_ENABLED']);
+    });
+
     test('refills the selected columns from the platform set', async ({ mount, page }) => {
         await mount(picker({ columns: [], standardColumns: [commonName, serialNumber] }));
 
         await page.getByTestId('reset-to-standard').click();
 
         await expect(page.getByTestId('selected-columns-list').getByRole('listitem')).toHaveCount(2);
+    });
+
+    /**
+     * The dialog holds a working copy, so a re-render with new prop references must not restart the
+     * edit. The catalogue can also land after the dialog opened, which is reconciled onto the working
+     * copy rather than re-seeded from the view.
+     */
+    test('keeps an edited draft when the caller re-renders with new prop references', async ({ mount, page }) => {
+        await mount(
+            withProviders(
+                <ColumnPickerTestWrapper columns={[commonName, serialNumber]} standardColumns={[commonName]} catalogue={catalogue} />,
+            ),
+        );
+
+        await page.getByTestId('selected-column-property:SERIAL_NUMBER-remove').click();
+        await page.getByTestId('available-fields-search').fill('cost');
+        await expect(page.getByTestId('selected-columns-list').getByRole('listitem')).toHaveCount(1);
+
+        // The dialog is modal, so its overlay intercepts a real click on a control outside it.
+        await page.getByTestId('wrapper-rerender').dispatchEvent('click');
+
+        await expect(page.getByTestId('wrapper-rerender')).toHaveText('rerender 1');
+        await expect(page.getByTestId('selected-columns-list').getByRole('listitem')).toHaveCount(1);
+        await expect(page.getByTestId('available-fields-search')).toHaveValue('cost');
+    });
+
+    test('resolves a catalogue that only lands after the dialog is open', async ({ mount, page }) => {
+        await mount(
+            withProviders(<ColumnPickerTestWrapper columns={[issuerDn]} standardColumns={[]} catalogue={catalogue} withheldCatalogue />),
+        );
+
+        await expect(page.getByTestId('selected-column-property:ISSUER_DN')).toContainText('Unavailable');
+        await expect(page.getByRole('button', { name: 'Save' })).toBeDisabled();
+
+        await page.getByTestId('wrapper-release-catalogue').dispatchEvent('click');
+
+        await expect(page.getByTestId('selected-column-property:ISSUER_DN')).not.toContainText('Unavailable');
+        await expect(page.getByRole('button', { name: 'Save' })).toBeEnabled();
     });
 
     test('blocks saving with no columns, because the API rejects an empty set', async ({ mount, page }) => {

--- a/src/components/ColumnPicker/ColumnPickerEdges.spec.tsx
+++ b/src/components/ColumnPicker/ColumnPickerEdges.spec.tsx
@@ -1,0 +1,147 @@
+import { expect, test } from '../../../playwright/ct-test';
+import { withProviders } from 'utils/test-helpers';
+import { FilterFieldSource, FilterFieldType, type SearchFieldDataByGroupDto } from 'types/openapi';
+import type { ColumnDefinition } from 'types/tableColumns';
+import ColumnPicker from './index';
+
+/** Enough fields to reach the cap and still have some left over to prove they stay browsable. */
+const PROPERTY_FIELDS = Array.from({ length: 16 }, (_value, index) => ({
+    fieldIdentifier: `FIELD_${index}`,
+    fieldLabel: `Field ${index}`,
+    type: FilterFieldType.String,
+    conditions: [],
+    displayable: true,
+    sortable: true,
+}));
+
+const catalogue = [
+    { filterFieldSource: FilterFieldSource.Property, searchFieldData: PROPERTY_FIELDS },
+] as unknown as SearchFieldDataByGroupDto[];
+
+const columnsOf = (count: number): ColumnDefinition[] =>
+    PROPERTY_FIELDS.slice(0, count).map((field) => ({
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: field.fieldIdentifier,
+        catalogueLabel: field.fieldLabel,
+    }));
+
+const picker = (columns: ColumnDefinition[], onSave?: (columns: ColumnDefinition[]) => void) =>
+    withProviders(
+        <ColumnPicker
+            isOpen
+            onClose={() => {}}
+            onSave={onSave ?? (() => {})}
+            catalogue={catalogue}
+            columns={columns}
+            standardColumns={columnsOf(2)}
+        />,
+    );
+
+test.describe('ColumnPicker · at the cap', () => {
+    test('counts up to the cap and warns before it binds', async ({ mount, page }) => {
+        await mount(picker(columnsOf(10)));
+
+        await expect(page.getByTestId('column-counter')).toHaveText('10 / 12');
+        await expect(page.getByTestId('column-counter-warning')).toBeVisible();
+    });
+
+    test('does not warn below the threshold', async ({ mount, page }) => {
+        await mount(picker(columnsOf(9)));
+
+        await expect(page.getByTestId('column-counter-warning')).toHaveCount(0);
+    });
+
+    test('stops selection at the cap rather than silently ignoring further additions', async ({ mount, page }) => {
+        await mount(picker(columnsOf(12)));
+
+        await expect(page.getByTestId('column-counter')).toHaveText('12 / 12');
+        await expect(page.getByTestId('add-field-property:FIELD_12')).toBeDisabled();
+        await expect(page.getByTestId('available-fields-cap-hint')).toBeVisible();
+    });
+
+    test('keeps unselected fields listed and searchable at the cap, so the catalogue never looks broken', async ({ mount, page }) => {
+        await mount(picker(columnsOf(12)));
+
+        await expect(page.getByTestId('available-field-property:FIELD_15')).toBeVisible();
+        await page.getByTestId('available-fields-search').fill('Field 14');
+        await expect(page.getByTestId('available-field-property:FIELD_14')).toBeVisible();
+    });
+
+    test('lets a column be removed and another added again', async ({ mount, page }) => {
+        await mount(picker(columnsOf(12)));
+
+        await page.getByTestId('selected-column-property:FIELD_0-remove').click();
+
+        await expect(page.getByTestId('column-counter')).toHaveText('11 / 12');
+        await expect(page.getByTestId('add-field-property:FIELD_12')).toBeEnabled();
+    });
+
+    test('renders a stored view that is already above the cap rather than truncating it', async ({ mount, page }) => {
+        await mount(picker(columnsOf(14)));
+
+        await expect(page.getByTestId('column-counter')).toHaveText('14 / 12');
+        await expect(page.getByTestId('selected-columns-list').getByRole('listitem')).toHaveCount(14);
+    });
+});
+
+test.describe('ColumnPicker · a column whose field is gone', () => {
+    const gone: ColumnDefinition = {
+        fieldSource: FilterFieldSource.Custom,
+        fieldIdentifier: 'cost_centre',
+        catalogueLabel: 'Cost centre',
+    };
+    const withGone = [columnsOf(1)[0], gone, columnsOf(2)[1]];
+
+    test('keeps the column in its stored position and badges it unavailable', async ({ mount, page }) => {
+        await mount(picker(withGone));
+
+        const rows = page.getByTestId('selected-columns-list').getByRole('listitem');
+        await expect(rows).toHaveCount(3);
+        await expect(rows.nth(1)).toContainText('Unavailable');
+    });
+
+    test('shows the stored identifier, so an administrator can tell what the column was', async ({ mount, page }) => {
+        await mount(picker(withGone));
+
+        await expect(page.getByTestId('selected-column-custom:cost_centre')).toContainText('custom / cost_centre');
+    });
+
+    test('offers removal as the only action on it', async ({ mount, page }) => {
+        await mount(picker(withGone));
+
+        const row = page.getByTestId('selected-column-custom:cost_centre');
+        await expect(row.getByRole('button')).toHaveCount(1);
+        await expect(page.getByTestId('selected-column-custom:cost_centre-remove')).toBeVisible();
+    });
+
+    test('leaves it out of the header preview, which is what the table would render', async ({ mount, page }) => {
+        await mount(picker(withGone));
+
+        await expect(page.getByTestId('header-preview')).not.toContainText('Cost centre');
+    });
+
+    test('drops it on save', async ({ mount, page }) => {
+        const saved: ColumnDefinition[][] = [];
+        await mount(picker(withGone, (columns) => saved.push(columns)));
+
+        await page.getByRole('button', { name: 'Save' }).click();
+
+        await expect.poll(() => saved.length).toBe(1);
+        expect(saved[0].map((column) => column.fieldIdentifier)).toEqual(['FIELD_0', 'FIELD_1']);
+    });
+
+    test('still lets the rest of the view be arranged around it', async ({ mount, page }) => {
+        await mount(picker(withGone));
+        const rows = page.getByTestId('selected-columns-list').getByRole('listitem');
+
+        // The unavailable column holds a real position, so moving past it is a real move even
+        // though the preview — which shows what the table would render — does not change yet.
+        await page.getByTestId('selected-column-property:FIELD_1-up').click();
+        await expect(rows.nth(1)).toContainText('Field 1');
+        await expect(rows.nth(2)).toContainText('Unavailable');
+        await expect(page.getByTestId('header-preview')).toHaveText('Field 0Field 1');
+
+        await page.getByTestId('selected-column-property:FIELD_1-up').click();
+        await expect(page.getByTestId('header-preview')).toHaveText('Field 1Field 0');
+    });
+});

--- a/src/components/ColumnPicker/ColumnPickerEdges.spec.tsx
+++ b/src/components/ColumnPicker/ColumnPickerEdges.spec.tsx
@@ -130,6 +130,28 @@ test.describe('ColumnPicker · a column whose field is gone', () => {
         expect(saved[0].map((column) => column.fieldIdentifier)).toEqual(['FIELD_0', 'FIELD_1']);
     });
 
+    /**
+     * Save sends only the available columns, so a draft of nothing but unavailable rows resolves to
+     * the empty set the API rejects — even though the draft itself is not empty.
+     */
+    test('blocks saving a draft of nothing but unavailable columns', async ({ mount, page }) => {
+        await mount(picker([gone]));
+
+        await expect(page.getByTestId('selected-columns-list').getByRole('listitem')).toHaveCount(1);
+        await expect(page.getByRole('button', { name: 'Save' })).toBeDisabled();
+    });
+
+    /** It is not draggable, but it holds a position, so a column has to be placeable above it. */
+    test('accepts a drop, so a column can be placed immediately above it', async ({ mount, page }) => {
+        await mount(picker(withGone));
+        const rows = page.getByTestId('selected-columns-list').getByRole('listitem');
+
+        await page.getByTestId('selected-column-property:FIELD_1').dragTo(page.getByTestId('selected-column-custom:cost_centre'));
+
+        await expect(rows.nth(1)).toContainText('Field 1');
+        await expect(rows.nth(2)).toContainText('Unavailable');
+    });
+
     test('still lets the rest of the view be arranged around it', async ({ mount, page }) => {
         await mount(picker(withGone));
         const rows = page.getByTestId('selected-columns-list').getByRole('listitem');

--- a/src/components/ColumnPicker/ColumnPickerTestWrapper.tsx
+++ b/src/components/ColumnPicker/ColumnPickerTestWrapper.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import type { SearchFieldDataByGroupDto } from 'types/openapi';
+import type { ColumnDefinition } from 'types/tableColumns';
+import ColumnPicker from './index';
+
+type Props = Readonly<{
+    columns: ColumnDefinition[];
+    standardColumns?: ColumnDefinition[];
+    catalogue: SearchFieldDataByGroupDto[];
+    /** Withholds the catalogue until released, so a test can make it land after the dialog opened. */
+    withheldCatalogue?: boolean;
+    onSave?: (columns: ColumnDefinition[]) => void;
+}>;
+
+const clone = <T,>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+
+/**
+ * Drives {@link ColumnPicker} through prop changes that a component test cannot produce with
+ * `component.update()`, because the dialog renders into a portal and updating unmounts it.
+ *
+ * Every render hands the picker freshly cloned props, which is what a caller re-rendering from a
+ * selector does. The dialog is expected to keep the working copy across that.
+ */
+export default function ColumnPickerTestWrapper({ columns, standardColumns = [], catalogue, withheldCatalogue = false, onSave }: Props) {
+    const [isReleased, setIsReleased] = useState(!withheldCatalogue);
+    const [nonce, setNonce] = useState(0);
+
+    return (
+        <div>
+            <button type="button" data-testid="wrapper-rerender" onClick={() => setNonce((current) => current + 1)}>
+                {`rerender ${nonce}`}
+            </button>
+            <button type="button" data-testid="wrapper-release-catalogue" onClick={() => setIsReleased(true)}>
+                release catalogue
+            </button>
+            <ColumnPicker
+                isOpen
+                onClose={() => {}}
+                onSave={onSave ?? (() => {})}
+                catalogue={isReleased ? clone(catalogue) : []}
+                columns={clone(columns)}
+                standardColumns={clone(standardColumns)}
+                resourceLabel="Certificates"
+            />
+        </div>
+    );
+}

--- a/src/components/ColumnPicker/HeaderPreview.tsx
+++ b/src/components/ColumnPicker/HeaderPreview.tsx
@@ -1,0 +1,36 @@
+import type { PickerColumn } from 'types/tableColumns';
+import { getColumnHeading, getColumnKey } from 'utils/tableColumns';
+
+type Props = Readonly<{
+    columns: PickerColumn[];
+}>;
+
+/**
+ * The header row the current selection would produce, rendered live inside the dialog so a reorder
+ * or a rename can be judged without closing anything. Unavailable columns are left out, because
+ * they are what the table will not render either.
+ */
+export default function HeaderPreview({ columns }: Props) {
+    const rendered = columns.filter((column) => column.available);
+
+    return (
+        <section className="mt-4" aria-labelledby="column-header-preview-label">
+            <h3 className="mb-1.5 text-xs font-medium text-content-muted" id="column-header-preview-label">
+                Header preview
+            </h3>
+            <div className="overflow-x-auto rounded-md border border-divider bg-surface-sunken" data-testid="header-preview">
+                {rendered.length === 0 ? (
+                    <p className="px-3 py-2 text-xs text-content-subtle">No columns to preview.</p>
+                ) : (
+                    <ul className="m-0 flex list-none items-center gap-4 px-3 py-2">
+                        {rendered.map((column) => (
+                            <li key={getColumnKey(column)} className="text-xs font-medium whitespace-nowrap text-content">
+                                {getColumnHeading(column)}
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </div>
+        </section>
+    );
+}

--- a/src/components/ColumnPicker/SelectedColumnRow.tsx
+++ b/src/components/ColumnPicker/SelectedColumnRow.tsx
@@ -61,10 +61,20 @@ export default function SelectedColumnRow({
 
     // A column whose field the catalogue no longer publishes cannot be renamed or reordered into
     // meaning — it can only be taken out. It keeps its position and shows the stored identifier, so
-    // an administrator can tell what it was.
+    // an administrator can tell what it was. It is not draggable, but it does accept a drop, or no
+    // column could be placed immediately above it.
     if (!column.available) {
         return (
             <li
+                onDragOver={(event) => {
+                    event.preventDefault();
+                    onDragOver(index);
+                }}
+                onDrop={(event) => {
+                    event.preventDefault();
+                    onDrop();
+                }}
+                onDragEnd={onDragEnd}
                 className={cn('flex items-center gap-2 rounded-md border border-dashed border-outline px-2 py-1.5', {
                     'border-t-2 border-t-brand': isDropTarget,
                 })}

--- a/src/components/ColumnPicker/SelectedColumnRow.tsx
+++ b/src/components/ColumnPicker/SelectedColumnRow.tsx
@@ -1,0 +1,194 @@
+import cn from 'classnames';
+import { ChevronDown, ChevronUp, GripVertical, RotateCcw, X } from 'lucide-react';
+import { useState } from 'react';
+import Badge from 'components/Badge';
+import type { FilterFieldSource } from 'types/openapi';
+import type { PickerColumn } from 'types/tableColumns';
+import { getColumnHeading } from 'utils/tableColumns';
+import SourceBadge from './SourceBadge';
+
+type Props = Readonly<{
+    column: PickerColumn;
+    index: number;
+    total: number;
+    getSourceLabel: (source: FilterFieldSource) => string;
+    onRename: (index: number, label: string) => void;
+    onRevert: (index: number) => void;
+    onRemove: (index: number) => void;
+    onMove: (from: number, to: number) => void;
+    onDragStart: (index: number) => void;
+    onDragOver: (index: number) => void;
+    onDrop: () => void;
+    onDragEnd: () => void;
+    isDragging: boolean;
+    /** True when a dragged row would land immediately above this one. */
+    isDropTarget: boolean;
+    dataTestId: string;
+}>;
+
+/**
+ * One selected column. Position is display order — top is leftmost — so the row carries both the
+ * pointer affordance (a drag handle) and explicit move controls: reordering has to be reachable
+ * from the keyboard, and a drag handle alone never is.
+ */
+export default function SelectedColumnRow({
+    column,
+    index,
+    total,
+    getSourceLabel,
+    onRename,
+    onRevert,
+    onRemove,
+    onMove,
+    onDragStart,
+    onDragOver,
+    onDrop,
+    onDragEnd,
+    isDragging,
+    isDropTarget,
+    dataTestId,
+}: Props) {
+    const [isRenaming, setIsRenaming] = useState(false);
+    const [draft, setDraft] = useState('');
+
+    const heading = getColumnHeading(column);
+    const isRenamed = Boolean(column.label);
+
+    const commitRename = () => {
+        setIsRenaming(false);
+        onRename(index, draft);
+    };
+
+    // A column whose field the catalogue no longer publishes cannot be renamed or reordered into
+    // meaning — it can only be taken out. It keeps its position and shows the stored identifier, so
+    // an administrator can tell what it was.
+    if (!column.available) {
+        return (
+            <li
+                className={cn('flex items-center gap-2 rounded-md border border-dashed border-outline px-2 py-1.5', {
+                    'border-t-2 border-t-brand': isDropTarget,
+                })}
+                data-testid={dataTestId}
+            >
+                <span className="w-4 shrink-0" aria-hidden />
+                <Badge color="warning" size="small" className="shrink-0">
+                    Unavailable
+                </Badge>
+                <span className="min-w-0 flex-1 truncate text-sm text-content-muted">
+                    {column.catalogueLabel}
+                    <span className="ms-1.5 text-xs text-content-subtle">{`${column.fieldSource} / ${column.fieldIdentifier}`}</span>
+                </span>
+                <button
+                    type="button"
+                    onClick={() => onRemove(index)}
+                    aria-label={`Remove unavailable column ${column.catalogueLabel}`}
+                    className="shrink-0 rounded-md p-1 text-content-subtle hover:bg-surface-hover hover:text-danger focus:outline-hidden focus-visible:ring-2 focus-visible:ring-brand"
+                    data-testid={`${dataTestId}-remove`}
+                >
+                    <X size={14} aria-hidden />
+                </button>
+            </li>
+        );
+    }
+
+    return (
+        <li
+            draggable
+            onDragStart={() => onDragStart(index)}
+            onDragOver={(event) => {
+                event.preventDefault();
+                onDragOver(index);
+            }}
+            onDrop={(event) => {
+                event.preventDefault();
+                onDrop();
+            }}
+            onDragEnd={onDragEnd}
+            className={cn('flex items-center gap-2 rounded-md border border-transparent px-2 py-1.5 hover:bg-surface-hover', {
+                'opacity-50': isDragging,
+                'border-t-2 border-t-brand': isDropTarget,
+            })}
+            data-testid={dataTestId}
+        >
+            <GripVertical size={16} className="shrink-0 cursor-grab text-content-subtle" aria-hidden data-testid={`${dataTestId}-handle`} />
+            <SourceBadge source={column.fieldSource} label={getSourceLabel(column.fieldSource)} />
+
+            {isRenaming ? (
+                <input
+                    // biome-ignore lint/a11y/noAutofocus: the field replaces the heading the user just chose to edit
+                    autoFocus
+                    value={draft}
+                    onChange={(event) => setDraft(event.target.value)}
+                    onBlur={commitRename}
+                    onKeyDown={(event) => {
+                        if (event.key === 'Enter') commitRename();
+                        if (event.key === 'Escape') setIsRenaming(false);
+                    }}
+                    aria-label={`Heading for ${column.catalogueLabel}`}
+                    className="min-w-0 flex-1 rounded-md border border-brand bg-surface-raised px-1.5 py-0.5 text-sm text-content focus:outline-hidden"
+                    data-testid={`${dataTestId}-rename-input`}
+                />
+            ) : (
+                <button
+                    type="button"
+                    onClick={() => {
+                        setDraft(heading);
+                        setIsRenaming(true);
+                    }}
+                    className="min-w-0 flex-1 truncate rounded-md px-1 text-start text-sm text-content hover:bg-surface-active focus:outline-hidden focus-visible:ring-2 focus-visible:ring-brand"
+                    data-testid={`${dataTestId}-rename`}
+                >
+                    {heading}
+                    {isRenamed && (
+                        // The catalogue label stays visible behind the override, so it is clear what
+                        // reverting would restore.
+                        <span className="ms-1.5 text-xs text-content-subtle">{`← ${column.catalogueLabel}`}</span>
+                    )}
+                    <span className="sr-only"> — rename this column heading</span>
+                </button>
+            )}
+
+            {isRenamed && !isRenaming && (
+                <button
+                    type="button"
+                    onClick={() => onRevert(index)}
+                    aria-label={`Revert ${heading} to the catalogue label ${column.catalogueLabel}`}
+                    className="shrink-0 rounded-md p-1 text-content-subtle hover:bg-surface-hover hover:text-content focus:outline-hidden focus-visible:ring-2 focus-visible:ring-brand"
+                    data-testid={`${dataTestId}-revert`}
+                >
+                    <RotateCcw size={13} aria-hidden />
+                </button>
+            )}
+
+            <button
+                type="button"
+                onClick={() => onMove(index, index - 1)}
+                disabled={index === 0}
+                aria-label={`Move ${heading} earlier`}
+                className="shrink-0 rounded-md p-1 text-content-subtle hover:bg-surface-hover hover:text-content disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent focus:outline-hidden focus-visible:ring-2 focus-visible:ring-brand"
+                data-testid={`${dataTestId}-up`}
+            >
+                <ChevronUp size={14} aria-hidden />
+            </button>
+            <button
+                type="button"
+                onClick={() => onMove(index, index + 1)}
+                disabled={index === total - 1}
+                aria-label={`Move ${heading} later`}
+                className="shrink-0 rounded-md p-1 text-content-subtle hover:bg-surface-hover hover:text-content disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent focus:outline-hidden focus-visible:ring-2 focus-visible:ring-brand"
+                data-testid={`${dataTestId}-down`}
+            >
+                <ChevronDown size={14} aria-hidden />
+            </button>
+            <button
+                type="button"
+                onClick={() => onRemove(index)}
+                aria-label={`Remove column ${heading}`}
+                className="shrink-0 rounded-md p-1 text-content-subtle hover:bg-surface-hover hover:text-danger focus:outline-hidden focus-visible:ring-2 focus-visible:ring-brand"
+                data-testid={`${dataTestId}-remove`}
+            >
+                <X size={14} aria-hidden />
+            </button>
+        </li>
+    );
+}

--- a/src/components/ColumnPicker/SelectedColumns.tsx
+++ b/src/components/ColumnPicker/SelectedColumns.tsx
@@ -22,7 +22,11 @@ const COUNTER_CLASSES = {
     full: 'text-danger',
 } as const;
 
-/** What you do show, in the order you show it. */
+/**
+ * The selected columns, in display order, with the count against the cap and the reset control.
+ * Reordering is available by drag and by the per-row move buttons, because a drag handle alone is
+ * not reachable from the keyboard.
+ */
 export default function SelectedColumns({ columns, getSourceLabel, onRename, onRevert, onRemove, onMove, onResetToStandard }: Props) {
     const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
     const [dropIndex, setDropIndex] = useState<number | null>(null);
@@ -35,7 +39,12 @@ export default function SelectedColumns({ columns, getSourceLabel, onRename, onR
     };
 
     const handleDrop = () => {
-        if (draggingIndex !== null && dropIndex !== null) onMove(draggingIndex, dropIndex);
+        if (draggingIndex !== null && dropIndex !== null) {
+            // The indicator is a top border on the target row, i.e. "land above this row". The move
+            // takes the source out before inserting, which shifts a target below it up by one, so a
+            // downward move has to compensate or the row lands below the highlighted one.
+            onMove(draggingIndex, draggingIndex < dropIndex ? dropIndex - 1 : dropIndex);
+        }
         finishDrag();
     };
 

--- a/src/components/ColumnPicker/SelectedColumns.tsx
+++ b/src/components/ColumnPicker/SelectedColumns.tsx
@@ -1,0 +1,110 @@
+import cn from 'classnames';
+import { useState } from 'react';
+import type { FilterFieldSource } from 'types/openapi';
+import type { PickerColumn } from 'types/tableColumns';
+import { COLUMN_COUNT_WARNING_FROM, getCounterState, MAX_COLUMNS } from 'utils/columnPicker';
+import { getColumnKey } from 'utils/tableColumns';
+import SelectedColumnRow from './SelectedColumnRow';
+
+type Props = Readonly<{
+    columns: PickerColumn[];
+    getSourceLabel: (source: FilterFieldSource) => string;
+    onRename: (index: number, label: string) => void;
+    onRevert: (index: number) => void;
+    onRemove: (index: number) => void;
+    onMove: (from: number, to: number) => void;
+    onResetToStandard: () => void;
+}>;
+
+const COUNTER_CLASSES = {
+    ok: 'text-content-muted',
+    warning: 'text-warning',
+    full: 'text-danger',
+} as const;
+
+/** What you do show, in the order you show it. */
+export default function SelectedColumns({ columns, getSourceLabel, onRename, onRevert, onRemove, onMove, onResetToStandard }: Props) {
+    const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
+    const [dropIndex, setDropIndex] = useState<number | null>(null);
+
+    const counterState = getCounterState(columns.length);
+
+    const finishDrag = () => {
+        setDraggingIndex(null);
+        setDropIndex(null);
+    };
+
+    const handleDrop = () => {
+        if (draggingIndex !== null && dropIndex !== null) onMove(draggingIndex, dropIndex);
+        finishDrag();
+    };
+
+    return (
+        <section className="flex min-h-0 flex-col" aria-labelledby="selected-columns-heading">
+            <div className="mb-2 flex items-center justify-between gap-2">
+                <h3 id="selected-columns-heading" className="text-sm font-semibold text-content">
+                    Columns shown
+                </h3>
+                <span
+                    className={cn('text-xs font-medium', COUNTER_CLASSES[counterState])}
+                    // The count is announced when it changes, so the cap is not something a
+                    // keyboard user discovers only by an add control going quiet.
+                    aria-live="polite"
+                    data-testid="column-counter"
+                >
+                    {`${columns.length} / ${MAX_COLUMNS}`}
+                </span>
+            </div>
+
+            {columns.length === 0 ? (
+                <p
+                    className="rounded-md border border-dashed border-outline px-3 py-6 text-center text-sm text-content-muted"
+                    data-testid="selected-columns-empty"
+                >
+                    A view needs at least one column.
+                </p>
+            ) : (
+                <ul className="m-0 min-h-0 flex-1 list-none overflow-y-auto p-0" data-testid="selected-columns-list">
+                    {columns.map((column, index) => (
+                        <SelectedColumnRow
+                            key={getColumnKey(column)}
+                            column={column}
+                            index={index}
+                            total={columns.length}
+                            getSourceLabel={getSourceLabel}
+                            onRename={onRename}
+                            onRevert={onRevert}
+                            onRemove={onRemove}
+                            onMove={onMove}
+                            onDragStart={setDraggingIndex}
+                            onDragOver={setDropIndex}
+                            onDrop={handleDrop}
+                            onDragEnd={finishDrag}
+                            isDragging={draggingIndex === index}
+                            isDropTarget={draggingIndex !== null && dropIndex === index && draggingIndex !== index}
+                            dataTestId={`selected-column-${getColumnKey(column)}`}
+                        />
+                    ))}
+                </ul>
+            )}
+
+            {counterState === 'warning' && (
+                <p className="mt-2 text-xs text-warning" data-testid="column-counter-warning">
+                    {`A table stays readable up to ${MAX_COLUMNS} columns; you are past ${COLUMN_COUNT_WARNING_FROM - 1}.`}
+                </p>
+            )}
+
+            <button
+                type="button"
+                onClick={onResetToStandard}
+                // Refills the pane as an edit the user can still cancel. Getting back to the
+                // platform columns outright is the Standard tab, which is why the table itself
+                // carries no reset control.
+                className="mt-3 self-start rounded-md px-1 text-xs font-medium text-brand hover:text-brand-hover focus:outline-hidden focus-visible:ring-2 focus-visible:ring-brand"
+                data-testid="reset-to-standard"
+            >
+                Reset to Standard columns
+            </button>
+        </section>
+    );
+}

--- a/src/components/ColumnPicker/SourceBadge.tsx
+++ b/src/components/ColumnPicker/SourceBadge.tsx
@@ -1,0 +1,45 @@
+import Badge, { type BadgeColor } from 'components/Badge';
+import { FilterFieldSource } from 'types/openapi';
+
+/**
+ * Default labels for the four field sources. The platform publishes its own through
+ * `PlatformEnum.FilterFieldSource`; a caller that has them passes `getSourceLabel` and these are
+ * only what the picker falls back to before the enums have loaded.
+ */
+export const DEFAULT_SOURCE_LABELS: Readonly<Record<FilterFieldSource, string>> = {
+    [FilterFieldSource.Property]: 'Property',
+    [FilterFieldSource.Custom]: 'Custom attribute',
+    [FilterFieldSource.Meta]: 'Metadata',
+    [FilterFieldSource.Data]: 'Data attribute',
+};
+
+/** One colour per source, so a field's origin is readable at a glance down a long list. */
+const SOURCE_COLORS: Readonly<Record<FilterFieldSource, BadgeColor>> = {
+    [FilterFieldSource.Property]: 'secondary',
+    [FilterFieldSource.Custom]: 'info',
+    [FilterFieldSource.Meta]: 'success',
+    [FilterFieldSource.Data]: 'warning',
+};
+
+/** Short forms, because the badge sits before every field label and the full names crowd the row. */
+const SOURCE_ABBREVIATIONS: Readonly<Record<FilterFieldSource, string>> = {
+    [FilterFieldSource.Property]: 'Prop',
+    [FilterFieldSource.Custom]: 'Custom',
+    [FilterFieldSource.Meta]: 'Meta',
+    [FilterFieldSource.Data]: 'Data',
+};
+
+type Props = Readonly<{
+    source: FilterFieldSource;
+    /** The full source name, announced to screen readers in place of the abbreviation. */
+    label: string;
+}>;
+
+export default function SourceBadge({ source, label }: Props) {
+    return (
+        <Badge color={SOURCE_COLORS[source]} size="small" className="shrink-0">
+            <span aria-hidden="true">{SOURCE_ABBREVIATIONS[source]}</span>
+            <span className="sr-only">{label}</span>
+        </Badge>
+    );
+}

--- a/src/components/ColumnPicker/index.tsx
+++ b/src/components/ColumnPicker/index.tsx
@@ -1,0 +1,166 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Dialog from 'components/Dialog';
+import type { FilterFieldSource, SearchFieldDataByGroupDto } from 'types/openapi';
+import type { ColumnDefinition, PickerColumn, SourcedCatalogueField } from 'types/tableColumns';
+import { MAX_COLUMNS, isColumnSelected, moveColumn, resolveColumns, toCatalogueFields, toColumnDefinition } from 'utils/columnPicker';
+import AvailableFields from './AvailableFields';
+import HeaderPreview from './HeaderPreview';
+import SelectedColumns from './SelectedColumns';
+import { DEFAULT_SOURCE_LABELS } from './SourceBadge';
+
+export type ColumnPickerProps = Readonly<{
+    isOpen: boolean;
+    /** Closes without applying anything, discarding every change made in the dialog. */
+    onClose: () => void;
+    /** Receives the arranged columns. Unavailable ones are already dropped. */
+    onSave: (columns: ColumnDefinition[]) => void;
+    /** The column catalogue for the resource, i.e. `GET /v1/{resource}/search`. */
+    catalogue: SearchFieldDataByGroupDto[];
+    /** The columns the view currently holds. */
+    columns: ColumnDefinition[];
+    /** The platform default set, offered inside the dialog as "Reset to Standard columns". */
+    standardColumns?: ColumnDefinition[];
+    /** Named in the dialog caption, e.g. "Certificates". */
+    resourceLabel?: string;
+    /** Resolves a source to its platform label; falls back to the picker's own names. */
+    getSourceLabel?: (source: FilterFieldSource) => string;
+    dataTestId?: string;
+}>;
+
+/**
+ * The dialog where a user arranges the columns of a view: what could be shown on the left, what is
+ * shown on the right.
+ *
+ * A single combined list makes "what have I already got?" hard to answer once an organisation has
+ * thirty custom attributes, so the two panes are split — search belongs to the left, and ordering,
+ * renaming and removal to the right, where position means something. Nothing reaches the API until
+ * Save: a half-arranged view must not hit the network on every drag.
+ */
+export default function ColumnPicker({
+    isOpen,
+    onClose,
+    onSave,
+    catalogue,
+    columns,
+    standardColumns = [],
+    resourceLabel,
+    getSourceLabel,
+    dataTestId = 'column-picker',
+}: ColumnPickerProps) {
+    const fields = useMemo(() => toCatalogueFields(catalogue), [catalogue]);
+    const [draft, setDraft] = useState<PickerColumn[]>([]);
+    const [search, setSearch] = useState('');
+
+    // Seeded on open rather than on every change to `columns`, so the dialog holds a working copy
+    // and Cancel is simply never reading it back.
+    useEffect(() => {
+        if (!isOpen) return;
+        setDraft(resolveColumns(columns, fields));
+        setSearch('');
+    }, [isOpen, columns, fields]);
+
+    const resolveSourceLabel = useCallback(
+        (source: FilterFieldSource) => getSourceLabel?.(source) ?? DEFAULT_SOURCE_LABELS[source],
+        [getSourceLabel],
+    );
+
+    const handleAdd = useCallback((field: SourcedCatalogueField) => {
+        setDraft((current) => {
+            // Selection stops at the cap rather than silently ignoring further additions, and a
+            // field already shown is never added twice.
+            if (current.length >= MAX_COLUMNS || isColumnSelected(current, field)) return current;
+            return [...current, { ...toColumnDefinition(field), available: true }];
+        });
+    }, []);
+
+    const handleRename = useCallback((index: number, label: string) => {
+        setDraft((current) =>
+            current.map((column, position) => {
+                if (position !== index) return column;
+                const trimmed = label.trim();
+                // An empty or unchanged heading is not an override: clearing it puts the column back
+                // to following the catalogue, which is what `label: null` means in the stored shape.
+                const { label: _previous, ...rest } = column;
+                return trimmed && trimmed !== column.catalogueLabel ? { ...rest, label: trimmed } : rest;
+            }),
+        );
+    }, []);
+
+    const handleRevert = useCallback((index: number) => {
+        setDraft((current) =>
+            current.map((column, position) => {
+                if (position !== index) return column;
+                const { label: _removed, ...rest } = column;
+                return rest;
+            }),
+        );
+    }, []);
+
+    const handleRemove = useCallback((index: number) => {
+        setDraft((current) => current.filter((_column, position) => position !== index));
+    }, []);
+
+    const handleMove = useCallback((from: number, to: number) => {
+        setDraft((current) => moveColumn(current, from, to));
+    }, []);
+
+    const handleResetToStandard = useCallback(() => {
+        setDraft(resolveColumns(standardColumns, fields));
+    }, [standardColumns, fields]);
+
+    const handleSave = useCallback(() => {
+        // An unresolved column is dropped on save; until then it stayed visible so the user could
+        // see what had gone rather than watch a heading disappear.
+        onSave(draft.filter((column) => column.available).map(({ available: _available, ...column }) => column));
+    }, [draft, onSave]);
+
+    const isAtCap = draft.length >= MAX_COLUMNS;
+
+    return (
+        <Dialog
+            isOpen={isOpen}
+            toggle={onClose}
+            size="xl"
+            dataTestId={dataTestId}
+            caption={
+                <span className="flex flex-col">
+                    <span>Edit columns</span>
+                    {resourceLabel && (
+                        <span className="text-xs font-normal text-content-muted">{`${resourceLabel} · visible only to you`}</span>
+                    )}
+                </span>
+            }
+            body={
+                <div>
+                    <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+                        <AvailableFields
+                            fields={fields}
+                            selected={draft}
+                            search={search}
+                            onSearchChange={setSearch}
+                            onAdd={handleAdd}
+                            isAtCap={isAtCap}
+                            getSourceLabel={resolveSourceLabel}
+                        />
+                        <SelectedColumns
+                            columns={draft}
+                            getSourceLabel={resolveSourceLabel}
+                            onRename={handleRename}
+                            onRevert={handleRevert}
+                            onRemove={handleRemove}
+                            onMove={handleMove}
+                            onResetToStandard={handleResetToStandard}
+                        />
+                    </div>
+                    <HeaderPreview columns={draft} />
+                </div>
+            }
+            buttons={[
+                { key: 'cancel', color: 'secondary', variant: 'outline', body: 'Cancel', onClick: onClose },
+                // The API rejects an empty column set, so this is the one place the dialog blocks
+                // outright rather than warning.
+                { key: 'save', color: 'primary', body: 'Save', onClick: handleSave, disabled: draft.length === 0 },
+            ]}
+        />
+    );
+}

--- a/src/components/ColumnPicker/index.tsx
+++ b/src/components/ColumnPicker/index.tsx
@@ -1,12 +1,22 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Dialog from 'components/Dialog';
 import type { FilterFieldSource, SearchFieldDataByGroupDto } from 'types/openapi';
 import type { ColumnDefinition, PickerColumn, SourcedCatalogueField } from 'types/tableColumns';
-import { MAX_COLUMNS, isColumnSelected, moveColumn, resolveColumns, toCatalogueFields, toColumnDefinition } from 'utils/columnPicker';
+import {
+    MAX_COLUMNS,
+    isColumnSelected,
+    isSameResolution,
+    moveColumn,
+    resolveColumns,
+    toCatalogueFields,
+    toColumnDefinition,
+} from 'utils/columnPicker';
 import AvailableFields from './AvailableFields';
 import HeaderPreview from './HeaderPreview';
 import SelectedColumns from './SelectedColumns';
 import { DEFAULT_SOURCE_LABELS } from './SourceBadge';
+
+const NO_STANDARD_COLUMNS: ColumnDefinition[] = [];
 
 export type ColumnPickerProps = Readonly<{
     isOpen: boolean;
@@ -29,12 +39,9 @@ export type ColumnPickerProps = Readonly<{
 
 /**
  * The dialog where a user arranges the columns of a view: what could be shown on the left, what is
- * shown on the right.
- *
- * A single combined list makes "what have I already got?" hard to answer once an organisation has
- * thirty custom attributes, so the two panes are split — search belongs to the left, and ordering,
- * renaming and removal to the right, where position means something. Nothing reaches the API until
- * Save: a half-arranged view must not hit the network on every drag.
+ * shown on the right. Two panes rather than one combined list, because an organisation with thirty
+ * custom attributes makes "what have I already got?" unanswerable. Nothing reaches the API until
+ * Save, so a half-arranged view never hits the network.
  */
 export default function ColumnPicker({
     isOpen,
@@ -42,7 +49,7 @@ export default function ColumnPicker({
     onSave,
     catalogue,
     columns,
-    standardColumns = [],
+    standardColumns = NO_STANDARD_COLUMNS,
     resourceLabel,
     getSourceLabel,
     dataTestId = 'column-picker',
@@ -51,13 +58,30 @@ export default function ColumnPicker({
     const [draft, setDraft] = useState<PickerColumn[]>([]);
     const [search, setSearch] = useState('');
 
-    // Seeded on open rather than on every change to `columns`, so the dialog holds a working copy
-    // and Cancel is simply never reading it back.
+    const hasSeeded = useRef(false);
+
+    // Seeded once per open, so the dialog holds a working copy and Cancel is simply never reading it
+    // back. A later change to `columns` or to the catalogue must not restart the user's edit, but the
+    // catalogue can also land after the dialog opened — so that case is reconciled onto the working
+    // copy, refreshing labels and availability without discarding anything the user has done.
     useEffect(() => {
-        if (!isOpen) return;
-        setDraft(resolveColumns(columns, fields));
+        if (!isOpen) {
+            hasSeeded.current = false;
+            return;
+        }
+
+        if (hasSeeded.current) {
+            setDraft((current) => {
+                const reconciled = resolveColumns(current, fields, standardColumns);
+                return isSameResolution(current, reconciled) ? current : reconciled;
+            });
+            return;
+        }
+
+        hasSeeded.current = true;
+        setDraft(resolveColumns(columns, fields, standardColumns));
         setSearch('');
-    }, [isOpen, columns, fields]);
+    }, [isOpen, columns, fields, standardColumns]);
 
     const resolveSourceLabel = useCallback(
         (source: FilterFieldSource) => getSourceLabel?.(source) ?? DEFAULT_SOURCE_LABELS[source],
@@ -105,14 +129,21 @@ export default function ColumnPicker({
     }, []);
 
     const handleResetToStandard = useCallback(() => {
-        setDraft(resolveColumns(standardColumns, fields));
+        setDraft(resolveColumns(standardColumns, fields, standardColumns));
     }, [standardColumns, fields]);
 
+    // What Save would actually send: an unresolved column is dropped, having stayed visible until
+    // then so the user could see what had gone rather than watch a heading disappear.
+    const savableColumns = useMemo(
+        () => draft.filter((column) => column.available).map(({ available: _available, ...column }) => column),
+        [draft],
+    );
+
     const handleSave = useCallback(() => {
-        // An unresolved column is dropped on save; until then it stayed visible so the user could
-        // see what had gone rather than watch a heading disappear.
-        onSave(draft.filter((column) => column.available).map(({ available: _available, ...column }) => column));
-    }, [draft, onSave]);
+        // Guarded as well as disabled: the API rejects an empty column set.
+        if (savableColumns.length === 0) return;
+        onSave(savableColumns);
+    }, [savableColumns, onSave]);
 
     const isAtCap = draft.length >= MAX_COLUMNS;
 
@@ -158,8 +189,9 @@ export default function ColumnPicker({
             buttons={[
                 { key: 'cancel', color: 'secondary', variant: 'outline', body: 'Cancel', onClick: onClose },
                 // The API rejects an empty column set, so this is the one place the dialog blocks
-                // outright rather than warning.
-                { key: 'save', color: 'primary', body: 'Save', onClick: handleSave, disabled: draft.length === 0 },
+                // outright rather than warning. Counted over what would be sent, not over the draft:
+                // a draft of nothing but unavailable rows resolves to an empty request.
+                { key: 'save', color: 'primary', body: 'Save', onClick: handleSave, disabled: savableColumns.length === 0 },
             ]}
         />
     );

--- a/src/types/tableColumns.ts
+++ b/src/types/tableColumns.ts
@@ -1,5 +1,5 @@
 import type { BaseAttributeContentModel } from './attributes';
-import type { AttributeContentType, FilterFieldSource, FilterFieldType } from './openapi';
+import type { AttributeContentType, FilterFieldSource, FilterFieldType, SearchFieldDataDto } from './openapi';
 
 /**
  * Attribute values a listing entry carries for the columns that were requested, nested by field
@@ -30,4 +30,33 @@ export interface ColumnDefinition {
     sortable?: boolean;
     multiValue?: boolean;
     align?: 'left' | 'center' | 'right';
+}
+
+/**
+ * A field the column catalogue offers, i.e. `GET /v1/{resource}/search` extended with the two flags
+ * the list contract added.
+ *
+ * They are declared here rather than read off the generated DTO because regenerating
+ * `src/types/openapi` currently pulls an unrelated platform bump that does not compile. Both are
+ * optional and typed exactly as the contract declares them, so this becomes redundant — not wrong —
+ * once the generated types catch up.
+ */
+export interface ColumnCatalogueField extends SearchFieldDataDto {
+    /** Whether the field may be requested as a column of the listing. */
+    displayable?: boolean;
+    /** Whether the listing may be ordered by the field. */
+    sortable?: boolean;
+}
+
+/** A catalogue field paired with the source it was published under. */
+export interface SourcedCatalogueField extends ColumnCatalogueField {
+    fieldSource: FilterFieldSource;
+}
+
+/**
+ * A column in the picker's selected list. `available: false` marks a stored column whose field the
+ * catalogue no longer publishes — a deleted custom attribute, or a renamed metadata identifier.
+ */
+export interface PickerColumn extends ColumnDefinition {
+    available: boolean;
 }

--- a/src/types/tableColumns.ts
+++ b/src/types/tableColumns.ts
@@ -34,12 +34,8 @@ export interface ColumnDefinition {
 
 /**
  * A field the column catalogue offers, i.e. `GET /v1/{resource}/search` extended with the two flags
- * the list contract added.
- *
- * They are declared here rather than read off the generated DTO because regenerating
- * `src/types/openapi` currently pulls an unrelated platform bump that does not compile. Both are
- * optional and typed exactly as the contract declares them, so this becomes redundant — not wrong —
- * once the generated types catch up.
+ * the list contract added. Both mirror the contract exactly, and stand in until the generated DTO in
+ * `src/types/openapi` carries them.
  */
 export interface ColumnCatalogueField extends SearchFieldDataDto {
     /** Whether the field may be requested as a column of the listing. */

--- a/src/utils/columnPicker.spec.ts
+++ b/src/utils/columnPicker.spec.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it } from 'vitest';
+import { AttributeContentType, FilterFieldSource, FilterFieldType, type SearchFieldDataByGroupDto } from 'types/openapi';
+import type { ColumnDefinition, SourcedCatalogueField } from 'types/tableColumns';
+import {
+    COLUMN_COUNT_WARNING_FROM,
+    MAX_COLUMNS,
+    getCounterState,
+    groupCatalogueFields,
+    isColumnSelected,
+    moveColumn,
+    resolveColumns,
+    toCatalogueFields,
+    toColumnDefinition,
+} from './columnPicker';
+
+const field = (overrides: Partial<SourcedCatalogueField> = {}): SourcedCatalogueField =>
+    ({
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'COMMON_NAME',
+        fieldLabel: 'Common Name',
+        type: FilterFieldType.String,
+        conditions: [],
+        displayable: true,
+        sortable: true,
+        ...overrides,
+    }) as SourcedCatalogueField;
+
+const catalogue: SearchFieldDataByGroupDto[] = [
+    {
+        filterFieldSource: FilterFieldSource.Property,
+        searchFieldData: [
+            {
+                fieldIdentifier: 'COMMON_NAME',
+                fieldLabel: 'Common Name',
+                type: FilterFieldType.String,
+                conditions: [],
+                displayable: true,
+                sortable: true,
+            },
+            {
+                fieldIdentifier: 'FINGERPRINT',
+                fieldLabel: 'Fingerprint',
+                type: FilterFieldType.String,
+                conditions: [],
+                displayable: false,
+                sortable: true,
+            },
+        ] as SearchFieldDataByGroupDto['searchFieldData'],
+    },
+    {
+        filterFieldSource: FilterFieldSource.Custom,
+        searchFieldData: [
+            {
+                fieldIdentifier: 'costCentre',
+                fieldLabel: 'Cost centre',
+                type: FilterFieldType.Number,
+                conditions: [],
+                attributeContentType: AttributeContentType.Integer,
+                displayable: true,
+                sortable: false,
+            },
+        ] as SearchFieldDataByGroupDto['searchFieldData'],
+    },
+    { filterFieldSource: FilterFieldSource.Meta, searchFieldData: undefined },
+];
+
+describe('toCatalogueFields', () => {
+    it('flattens the catalogue and stamps each field with the source it was published under', () => {
+        expect(toCatalogueFields(catalogue).map((f) => [f.fieldSource, f.fieldIdentifier])).toEqual([
+            [FilterFieldSource.Property, 'COMMON_NAME'],
+            [FilterFieldSource.Custom, 'costCentre'],
+        ]);
+    });
+
+    it('offers only fields the catalogue marks displayable', () => {
+        expect(toCatalogueFields(catalogue).some((f) => f.fieldIdentifier === 'FINGERPRINT')).toBe(false);
+    });
+
+    it('treats a field with no displayable flag as not offerable, rather than guessing', () => {
+        const groups = [
+            {
+                filterFieldSource: FilterFieldSource.Property,
+                searchFieldData: [{ fieldIdentifier: 'X', fieldLabel: 'X', type: FilterFieldType.String, conditions: [] }],
+            },
+        ];
+        expect(toCatalogueFields(groups as SearchFieldDataByGroupDto[])).toEqual([]);
+    });
+
+    it('survives a source that publishes no fields', () => {
+        expect(toCatalogueFields([{ filterFieldSource: FilterFieldSource.Meta }])).toEqual([]);
+    });
+
+    it('returns nothing for an empty catalogue', () => {
+        expect(toCatalogueFields([])).toEqual([]);
+    });
+});
+
+describe('groupCatalogueFields', () => {
+    const fields = [
+        field(),
+        field({ fieldSource: FilterFieldSource.Property, fieldIdentifier: 'SERIAL_NUMBER', fieldLabel: 'Serial Number' }),
+        field({ fieldSource: FilterFieldSource.Custom, fieldIdentifier: 'costCentre', fieldLabel: 'Cost centre' }),
+    ];
+
+    it('groups fields by source, in a stable source order', () => {
+        expect(groupCatalogueFields(fields, '').map((group) => group.source)).toEqual([
+            FilterFieldSource.Property,
+            FilterFieldSource.Custom,
+        ]);
+    });
+
+    it('drops a group left with no fields, so no empty heading is rendered', () => {
+        expect(groupCatalogueFields(fields, 'cost').map((group) => group.source)).toEqual([FilterFieldSource.Custom]);
+    });
+
+    it('searches across every source, case-insensitively', () => {
+        expect(groupCatalogueFields(fields, 'NUMBER').flatMap((g) => g.fields.map((f) => f.fieldIdentifier))).toEqual(['SERIAL_NUMBER']);
+    });
+
+    it('matches the field identifier as well as the label, so a stored identifier can be found', () => {
+        expect(groupCatalogueFields(fields, 'costcentre').flatMap((g) => g.fields.map((f) => f.fieldIdentifier))).toEqual(['costCentre']);
+    });
+
+    it('ignores surrounding whitespace in the search term', () => {
+        expect(groupCatalogueFields(fields, '  cost  ').flatMap((g) => g.fields)).toHaveLength(1);
+    });
+
+    it('returns every group for an empty search', () => {
+        expect(groupCatalogueFields(fields, '').flatMap((g) => g.fields)).toHaveLength(3);
+    });
+
+    it('returns nothing when the search matches no field', () => {
+        expect(groupCatalogueFields(fields, 'nothing matches this')).toEqual([]);
+    });
+});
+
+describe('toColumnDefinition', () => {
+    it('carries the catalogue label, type and sortability onto the column', () => {
+        expect(toColumnDefinition(field({ sortable: false, attributeContentType: AttributeContentType.Integer }))).toEqual({
+            fieldSource: FilterFieldSource.Property,
+            fieldIdentifier: 'COMMON_NAME',
+            catalogueLabel: 'Common Name',
+            type: FilterFieldType.String,
+            attributeContentType: AttributeContentType.Integer,
+            sortable: false,
+            multiValue: undefined,
+        });
+    });
+
+    it('reports a field with no sortable flag as not sortable', () => {
+        expect(toColumnDefinition(field({ sortable: undefined })).sortable).toBe(false);
+    });
+
+    it('sets no label override, so a newly added column follows the catalogue', () => {
+        expect(toColumnDefinition(field()).label).toBeUndefined();
+    });
+});
+
+describe('isColumnSelected', () => {
+    const selected: ColumnDefinition[] = [
+        { fieldSource: FilterFieldSource.Custom, fieldIdentifier: 'costCentre', catalogueLabel: 'Cost centre' },
+    ];
+
+    it('matches on source and identifier together', () => {
+        expect(isColumnSelected(selected, field({ fieldSource: FilterFieldSource.Custom, fieldIdentifier: 'costCentre' }))).toBe(true);
+    });
+
+    it('does not match the same identifier under a different source', () => {
+        expect(isColumnSelected(selected, field({ fieldSource: FilterFieldSource.Meta, fieldIdentifier: 'costCentre' }))).toBe(false);
+    });
+});
+
+describe('resolveColumns', () => {
+    const fields = [field(), field({ fieldSource: FilterFieldSource.Custom, fieldIdentifier: 'costCentre', fieldLabel: 'Cost centre' })];
+
+    const stored: ColumnDefinition[] = [
+        { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME', catalogueLabel: 'stale label' },
+        { fieldSource: FilterFieldSource.Custom, fieldIdentifier: 'gone', catalogueLabel: 'Gone', label: 'Was renamed' },
+        { fieldSource: FilterFieldSource.Custom, fieldIdentifier: 'costCentre', catalogueLabel: 'Cost centre' },
+    ];
+
+    it('keeps every stored column, in its stored position', () => {
+        expect(resolveColumns(stored, fields).map((column) => column.fieldIdentifier)).toEqual(['COMMON_NAME', 'gone', 'costCentre']);
+    });
+
+    it('marks a column whose field the catalogue no longer publishes as unavailable', () => {
+        expect(resolveColumns(stored, fields).map((column) => column.available)).toEqual([true, false, true]);
+    });
+
+    it('refreshes a resolved column from the live catalogue, so a relabelled field carries through', () => {
+        expect(resolveColumns(stored, fields)[0].catalogueLabel).toBe('Common Name');
+    });
+
+    it('keeps a per-view label override across the refresh', () => {
+        const withOverride = [{ ...stored[0], label: 'Host' }];
+        expect(resolveColumns(withOverride, fields)[0]).toMatchObject({ label: 'Host', catalogueLabel: 'Common Name' });
+    });
+
+    it('leaves an unavailable column exactly as it was stored, since nothing can refresh it', () => {
+        expect(resolveColumns(stored, fields)[1]).toMatchObject({ catalogueLabel: 'Gone', label: 'Was renamed', available: false });
+    });
+
+    it('resolves nothing for no stored columns', () => {
+        expect(resolveColumns([], fields)).toEqual([]);
+    });
+
+    it('marks everything unavailable when the catalogue is empty', () => {
+        expect(resolveColumns(stored, []).every((column) => !column.available)).toBe(true);
+    });
+});
+
+describe('moveColumn', () => {
+    const columns = ['a', 'b', 'c', 'd'].map((id) => ({
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: id,
+        catalogueLabel: id,
+    }));
+    const ids = (result: ColumnDefinition[]) => result.map((column) => column.fieldIdentifier);
+
+    it('moves a column later in the order', () => {
+        expect(ids(moveColumn(columns, 0, 2))).toEqual(['b', 'c', 'a', 'd']);
+    });
+
+    it('moves a column earlier in the order', () => {
+        expect(ids(moveColumn(columns, 3, 1))).toEqual(['a', 'd', 'b', 'c']);
+    });
+
+    it('leaves the order alone when a column is moved onto itself', () => {
+        expect(ids(moveColumn(columns, 2, 2))).toEqual(['a', 'b', 'c', 'd']);
+    });
+
+    it('clamps a target past the end rather than dropping the column', () => {
+        expect(ids(moveColumn(columns, 0, 99))).toEqual(['b', 'c', 'd', 'a']);
+    });
+
+    it('clamps a target before the start', () => {
+        expect(ids(moveColumn(columns, 2, -5))).toEqual(['c', 'a', 'b', 'd']);
+    });
+
+    it('ignores a source index that is not a column', () => {
+        expect(ids(moveColumn(columns, 9, 0))).toEqual(['a', 'b', 'c', 'd']);
+    });
+
+    it('does not mutate the array it was given', () => {
+        const original = [...columns];
+        moveColumn(columns, 0, 3);
+        expect(columns).toEqual(original);
+    });
+});
+
+describe('getCounterState', () => {
+    it('is unremarkable below the warning threshold', () => {
+        expect(getCounterState(COLUMN_COUNT_WARNING_FROM - 1)).toBe('ok');
+    });
+
+    it('warns from the threshold, so the limit is visible before it binds', () => {
+        expect(getCounterState(COLUMN_COUNT_WARNING_FROM)).toBe('warning');
+        expect(getCounterState(MAX_COLUMNS - 1)).toBe('warning');
+    });
+
+    it('reports the cap once it is reached', () => {
+        expect(getCounterState(MAX_COLUMNS)).toBe('full');
+    });
+
+    it('treats an over-full set as full, so a stored view above the cap still renders', () => {
+        expect(getCounterState(MAX_COLUMNS + 4)).toBe('full');
+    });
+
+    it('warns before it blocks', () => {
+        expect(COLUMN_COUNT_WARNING_FROM).toBeLessThan(MAX_COLUMNS);
+    });
+});

--- a/src/utils/columnPicker.spec.ts
+++ b/src/utils/columnPicker.spec.ts
@@ -7,6 +7,7 @@ import {
     getCounterState,
     groupCatalogueFields,
     isColumnSelected,
+    isSameResolution,
     moveColumn,
     resolveColumns,
     toCatalogueFields,
@@ -206,6 +207,60 @@ describe('resolveColumns', () => {
 
     it('marks everything unavailable when the catalogue is empty', () => {
         expect(resolveColumns(stored, []).every((column) => !column.available)).toBe(true);
+    });
+
+    /**
+     * A platform default column can be absent from the filter-field catalogue and still renderable —
+     * the keys inventory ships three such columns. Marking those unavailable would drop them from the
+     * view on the next save.
+     */
+    it('keeps a platform column the catalogue does not publish available', () => {
+        const platform: ColumnDefinition[] = [
+            { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'CKI_ENABLED', catalogueLabel: 'Status', align: 'center' },
+        ];
+
+        expect(resolveColumns(platform, fields, platform)[0]).toMatchObject({
+            catalogueLabel: 'Status',
+            align: 'center',
+            available: true,
+        });
+    });
+
+    it('still marks an unknown column unavailable when a standard set is given', () => {
+        const platform: ColumnDefinition[] = [
+            { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'CKI_ENABLED', catalogueLabel: 'Status' },
+        ];
+
+        expect(resolveColumns(stored, fields, platform).map((column) => column.available)).toEqual([true, false, true]);
+    });
+
+    it('keeps alignment the catalogue does not carry while refreshing what it does', () => {
+        const aligned = [{ ...stored[0], align: 'center' as const }];
+
+        expect(resolveColumns(aligned, fields)[0]).toMatchObject({ align: 'center', catalogueLabel: 'Common Name' });
+    });
+});
+
+describe('isSameResolution', () => {
+    const resolved = () =>
+        resolveColumns([{ fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME', catalogueLabel: 'x' }], [field()]);
+
+    it('reports two separately built but equal resolutions as the same', () => {
+        expect(isSameResolution(resolved(), resolved())).toBe(true);
+    });
+
+    it('reports a different length as different', () => {
+        expect(isSameResolution(resolved(), [])).toBe(false);
+    });
+
+    it('reports a changed property as different', () => {
+        const changed = resolved().map((column) => ({ ...column, catalogueLabel: 'Renamed' }));
+        expect(isSameResolution(resolved(), changed)).toBe(false);
+    });
+
+    it('reports an added property as different', () => {
+        const changed = resolved().map((column) => ({ ...column, label: 'Override' }));
+        expect(isSameResolution(resolved(), changed)).toBe(false);
     });
 });
 

--- a/src/utils/columnPicker.ts
+++ b/src/utils/columnPicker.ts
@@ -1,0 +1,125 @@
+import { FilterFieldSource, type SearchFieldDataByGroupDto } from 'types/openapi';
+import type { ColumnDefinition, PickerColumn, SourcedCatalogueField } from 'types/tableColumns';
+import { getColumnKey } from './tableColumns';
+
+/**
+ * The most columns a view may hold. A readability rule rather than a contract limit: if the API ever
+ * enforces a maximum of its own, the picker takes the smaller of the two.
+ */
+export const MAX_COLUMNS = 12;
+
+/** Where the counter starts warning, so the cap is visible before it binds. */
+export const COLUMN_COUNT_WARNING_FROM = 10;
+
+/** The order sources are offered in: object properties first, then the attribute sources. */
+const SOURCE_ORDER: readonly FilterFieldSource[] = [
+    FilterFieldSource.Property,
+    FilterFieldSource.Custom,
+    FilterFieldSource.Meta,
+    FilterFieldSource.Data,
+];
+
+/** Fields the catalogue publishes under one source, after searching. */
+export interface CatalogueFieldGroup {
+    source: FilterFieldSource;
+    fields: SourcedCatalogueField[];
+}
+
+export type ColumnCounterState = 'ok' | 'warning' | 'full';
+
+/**
+ * The fields of a column catalogue, flattened and each stamped with the source it was published
+ * under — an identifier is unique only within its source, so a field carries no meaning without it.
+ *
+ * Only fields the catalogue marks `displayable` are offered. An absent flag is not treated as a
+ * yes: secret and encrypted content, and code blocks, are excluded server-side by that flag alone,
+ * so guessing in its absence is what would put them in front of a user.
+ */
+export function toCatalogueFields(catalogue: SearchFieldDataByGroupDto[]): SourcedCatalogueField[] {
+    return catalogue.flatMap((group) =>
+        (group.searchFieldData ?? [])
+            .filter((field) => (field as SourcedCatalogueField).displayable === true)
+            .map((field) => ({ ...field, fieldSource: group.filterFieldSource }) as SourcedCatalogueField),
+    );
+}
+
+/**
+ * Catalogue fields grouped by source and narrowed by the search term. A group left with no matches
+ * is dropped rather than rendered as an empty heading — a resource with no custom attributes should
+ * not appear to have an empty custom section.
+ */
+export function groupCatalogueFields(fields: SourcedCatalogueField[], search: string): CatalogueFieldGroup[] {
+    const term = search.trim().toLowerCase();
+    const matches = (field: SourcedCatalogueField) =>
+        term === '' ||
+        field.fieldLabel.toLowerCase().includes(term) ||
+        // The identifier is searchable too, so a stored column can be found by what a view recorded.
+        field.fieldIdentifier.toLowerCase().includes(term);
+
+    return SOURCE_ORDER.map((source) => ({
+        source,
+        fields: fields.filter((field) => field.fieldSource === source && matches(field)),
+    })).filter((group) => group.fields.length > 0);
+}
+
+/** A catalogue field as a newly added column. It carries no label override, so it follows the catalogue. */
+export function toColumnDefinition(field: SourcedCatalogueField): ColumnDefinition {
+    return {
+        fieldSource: field.fieldSource,
+        fieldIdentifier: field.fieldIdentifier,
+        catalogueLabel: field.fieldLabel,
+        type: field.type,
+        attributeContentType: field.attributeContentType,
+        // Absent means the backend has not said yes, and an unsortable header is the safe reading.
+        sortable: field.sortable === true,
+        multiValue: field.multiValue,
+    };
+}
+
+/** Whether a catalogue field is already among the selected columns. */
+export function isColumnSelected(selected: ColumnDefinition[], field: SourcedCatalogueField): boolean {
+    const key = getColumnKey(field);
+    return selected.some((column) => getColumnKey(column) === key);
+}
+
+/**
+ * Stored columns resolved against the live catalogue.
+ *
+ * A resolved column is refreshed from the catalogue, so a field relabelled since the view was saved
+ * carries its new label through, while the view's own label override survives. A column whose field
+ * the catalogue no longer publishes is kept in place and marked unavailable rather than skipped:
+ * silently dropping it makes a heading vanish with no explanation, and the user's next move is to
+ * hunt for a field that no longer exists.
+ */
+export function resolveColumns(stored: ColumnDefinition[], fields: SourcedCatalogueField[]): PickerColumn[] {
+    const byKey = new Map(fields.map((field) => [getColumnKey(field), field]));
+
+    return stored.map((column) => {
+        const field = byKey.get(getColumnKey(column));
+        if (!field) return { ...column, available: false };
+        return { ...toColumnDefinition(field), ...(column.label ? { label: column.label } : {}), available: true };
+    });
+}
+
+/**
+ * The column list with one column moved. Position is display order — top is leftmost — and the
+ * stored shape is a plain array, so a move is a reorder with no index field to renumber.
+ */
+export function moveColumn<T>(columns: T[], from: number, to: number): T[] {
+    if (from < 0 || from >= columns.length) return columns;
+
+    const target = Math.min(Math.max(to, 0), columns.length - 1);
+    if (target === from) return columns;
+
+    const reordered = [...columns];
+    const [moved] = reordered.splice(from, 1);
+    reordered.splice(target, 0, moved);
+    return reordered;
+}
+
+/** How the column counter should read for a given selection size. */
+export function getCounterState(count: number): ColumnCounterState {
+    if (count >= MAX_COLUMNS) return 'full';
+    if (count >= COLUMN_COUNT_WARNING_FROM) return 'warning';
+    return 'ok';
+}

--- a/src/utils/columnPicker.ts
+++ b/src/utils/columnPicker.ts
@@ -86,18 +86,54 @@ export function isColumnSelected(selected: ColumnDefinition[], field: SourcedCat
  * Stored columns resolved against the live catalogue.
  *
  * A resolved column is refreshed from the catalogue, so a field relabelled since the view was saved
- * carries its new label through, while the view's own label override survives. A column whose field
- * the catalogue no longer publishes is kept in place and marked unavailable rather than skipped:
- * silently dropping it makes a heading vanish with no explanation, and the user's next move is to
- * hunt for a field that no longer exists.
+ * carries its new label through, while the view's own label override and anything the catalogue does
+ * not carry — alignment — survive.
+ *
+ * A column the catalogue does not publish is only unavailable if the platform does not define it
+ * either. A platform default column can be absent from the filter-field catalogue and still be
+ * renderable, and marking those unavailable would drop them from the view on the next save. Anything
+ * else is kept in place and marked unavailable rather than skipped: silently dropping it makes a
+ * heading vanish with no explanation, and the user's next move is to hunt for a field that is gone.
  */
-export function resolveColumns(stored: ColumnDefinition[], fields: SourcedCatalogueField[]): PickerColumn[] {
+export function resolveColumns(
+    stored: ColumnDefinition[],
+    fields: SourcedCatalogueField[],
+    standardColumns: readonly ColumnDefinition[] = [],
+): PickerColumn[] {
     const byKey = new Map(fields.map((field) => [getColumnKey(field), field]));
+    const standardByKey = new Map(standardColumns.map((column) => [getColumnKey(column), column]));
 
     return stored.map((column) => {
-        const field = byKey.get(getColumnKey(column));
-        if (!field) return { ...column, available: false };
-        return { ...toColumnDefinition(field), ...(column.label ? { label: column.label } : {}), available: true };
+        const key = getColumnKey(column);
+        const field = byKey.get(key);
+
+        if (!field) {
+            const standard = standardByKey.get(key);
+            if (!standard) return { ...column, available: false };
+            return { ...standard, ...(column.label ? { label: column.label } : {}), available: true };
+        }
+
+        return {
+            ...toColumnDefinition(field),
+            ...(column.align ? { align: column.align } : {}),
+            ...(column.label ? { label: column.label } : {}),
+            available: true,
+        };
+    });
+}
+
+/**
+ * Whether two resolutions are the same column list. Lets a re-resolution be dropped rather than
+ * replacing state with an equal value, which is what keeps an unstable catalogue reference from
+ * re-rendering forever.
+ */
+export function isSameResolution(a: readonly PickerColumn[], b: readonly PickerColumn[]): boolean {
+    if (a.length !== b.length) return false;
+
+    return a.every((column, index) => {
+        const other = b[index];
+        const keys = new Set([...Object.keys(column), ...Object.keys(other)]) as Set<keyof PickerColumn>;
+        return [...keys].every((key) => column[key] === other[key]);
     });
 }
 

--- a/src/utils/tableColumns.ts
+++ b/src/utils/tableColumns.ts
@@ -69,8 +69,10 @@ export function getColumnHeading(column: ColumnDefinition): string {
 /**
  * A stable key for a column. A field identifier is unique only within its source, so the source has
  * to qualify it — `property:name` and `custom:name` are different columns.
+ *
+ * Takes only the two fields it needs, so a catalogue field keys the same way a column does.
  */
-export function getColumnKey(column: ColumnDefinition): string {
+export function getColumnKey(column: Pick<ColumnDefinition, 'fieldSource' | 'fieldIdentifier'>): string {
     return `${column.fieldSource}:${column.fieldIdentifier}`;
 }
 


### PR DESCRIPTION
Closes #2018

> Stacked on #2084 (fe#2017). The base is `feat/2017-data-driven-row-rendering`, because the picker produces the `ColumnDefinition` list that ticket introduced and reuses its heading helpers. Review the top commit; GitHub retargets this to `main` once #2084 merges.

The dialog where a user arranges the columns of a view: what could be shown on the left, what is shown on the right. Built from the design artifact on #2022 (section 02, the dialog; section 07, all four edge states).

## The two panes

A single combined list makes "what have I already got?" hard to answer once an organisation has thirty custom attributes. Splitting it gives search a natural home on the left and keeps ordering, renaming and removal on the right, where position actually means something.

**Left — available fields.** Grouped by source with a source badge and the catalogue label, searchable across all four sources by label *and* by identifier, so a column can be found by what a view recorded. A group left with no matches is dropped rather than rendered as an empty heading — a resource with no custom attributes does not appear to have an empty custom section.

Only fields the catalogue marks `displayable` are offered, and an absent flag is **not** read as a yes: that flag alone is what keeps secret content, encrypted content and code blocks out of a column, so guessing in its absence is what would put them in front of a user. A field the backend reports as not sortable says so here, before it is chosen, rather than only once its header refuses to sort.

**Right — columns shown.** The column order, top leftmost, which is exactly the stored array — no index field to renumber. Rows reorder by drag with a visible insertion line and by explicit move controls; a heading renames inline with the catalogue label still visible behind it and a revert control beside it. Reverting clears the override rather than restoring a remembered string, which is what `label: null` means in the stored shape.

**Header preview** renders the resulting header row live, so a reorder or a rename can be judged without closing anything.

## The four edge states

1. **At the cap** — the counter warns from 10 and turns to its cap treatment at 12, and selection stops rather than silently ignoring further additions. Unselected fields stay listed and searchable with an inert add control; hiding them would make the catalogue look broken. Twelve is a frontend readability rule, not a contract limit.
2. **At zero** — Save is disabled and the pane says a view needs at least one column. The API rejects an empty set, so this is the one place the dialog blocks outright instead of warning.
3. **Reset** — "Reset to Standard columns" refills the right pane as an edit that can still be cancelled. Getting back to the platform columns outright is the Standard tab, which is why the table itself carries no reset control.
4. **A column whose field is gone** — kept in its stored position, dashed, badged `Unavailable` and showing the stored identifier so an administrator can tell what it was. Removal is its only action and saving drops it. Silently skipping it is the tempting option and the wrong one: a heading vanishes with no explanation and the user's next move is to hunt for a field that no longer exists.

## Two decisions worth flagging

**Reordering is hand-rolled on the HTML5 drag API**, not a drag library. AC 8 requires keyboard operation, and no drag handle is ever reachable from the keyboard — so each row carries explicit move controls regardless. Given that the accessible path exists either way, a dependency would only have replaced the pointer half.

**The catalogue flags are declared on a local type.** `SearchFieldDataDto` in `src/types/openapi` has no `displayable`/`sortable` yet, because regenerating pulls an unrelated platform bump that does not compile (see #2084). `ColumnCatalogueField` declares both as optional, typed exactly as the contract does, so this becomes redundant — not wrong — once the generated types catch up.

Nothing reaches the API until Save: a half-arranged view must not hit the network on every drag. No page opens the dialog yet; #2020 does that.

## Verification

- `npm run typecheck` clean.
- `npm run lint` clean (0 errors).
- Vitest: 3523 passed.
- Playwright CT (chromium): 1671 passed, 0 failed.
- Coverage: 100% on every new file.
