### PR TITLE
Patch openssl in the runtime image for CVE-2026-14456

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,12 @@ RUN npm run build
 FROM nginxinc/nginx-unprivileged:1.31.4-alpine
 
 # Patch base-image OS packages for known CVEs (c-ares CVE-2026-33630;
-# curl/libcurl CVE-2026-5773, CVE-2026-6276).
+# curl/libcurl CVE-2026-5773, CVE-2026-6276; openssl CVE-2026-14456).
 # Pin the minimum fixed version so the build fails fast if the patched package
 # is ever unavailable, keeping the Trivy scan gate reliably green.
 USER root
-RUN apk add --no-cache --upgrade "c-ares>=1.34.8-r0" "curl>=8.20.0-r0" "libcurl>=8.20.0-r0"
+RUN apk add --no-cache --upgrade "c-ares>=1.34.8-r0" "curl>=8.20.0-r0" "libcurl>=8.20.0-r0" \
+    "libcrypto3>=3.5.8-r0" "libssl3>=3.5.8-r0"
 USER 101
 
 WORKDIR /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ FROM nginxinc/nginx-unprivileged:1.31.4-alpine
 # Pin the minimum fixed version so the build fails fast if the patched package
 # is ever unavailable, keeping the Trivy scan gate reliably green.
 USER root
-RUN apk add --no-cache --upgrade "c-ares>=1.34.8-r0" "curl>=8.20.0-r0" "libcurl>=8.20.0-r0" \
-    "libcrypto3>=3.5.8-r0" "libssl3>=3.5.8-r0"
+RUN apk add --no-cache --upgrade "c-ares>=1.34.8-r0" "curl>=8.20.0-r0" "libcrypto3>=3.5.8-r0" \
+    "libcurl>=8.20.0-r0" "libssl3>=3.5.8-r0"
 USER 101
 
 WORKDIR /usr/share/nginx/html


### PR DESCRIPTION
Every Docker build in the repository started failing its Trivy gate on 2026-08-27, with no code change behind it. `qa/automation-env` passed at 03:24 on the 26th and failed at 04:50 on the 27th on the same tree; every run since fails the same way.

The scanner's database picked up **CVE-2026-14456** — an OpenSSL denial of service through unbounded memory growth in the QUIC server — which `nginxinc/nginx-unprivileged:1.31.4-alpine` carries as `libcrypto3`/`libssl3` 3.5.7-r0:

```
frontend-administrator:ci (alpine 3.24.1)   Total: 2 (HIGH: 2, CRITICAL: 0)

libcrypto3  CVE-2026-14456  HIGH  fixed  3.5.7-r0 → 3.5.8-r0
libssl3     CVE-2026-14456  HIGH  fixed  3.5.7-r0 → 3.5.8-r0
```

Alpine 3.24 already publishes the fixed 3.5.8-r0, so the two packages join the `apk add --upgrade` line that is already there for c-ares and curl, pinned to the minimum fixed version — so the build fails fast if that package ever stops being available, rather than silently shipping a vulnerable image.

## Verification

Built the real image from this Dockerfile and scanned it with the same Trivy version CI runs (0.69.3):

```
┌──────────────────────────────────────┬────────┬─────────────────┐
│                Target                │  Type  │ Vulnerabilities │
├──────────────────────────────────────┼────────┼─────────────────┤
│ fe-admin-trivy-check (alpine 3.24.1) │ alpine │        0        │
└──────────────────────────────────────┴────────┴─────────────────┘
```

Confirmed `libcrypto3-3.5.8-r0` and `libssl3-3.5.8-r0` are installed in the built image.

This unblocks every open pull request, so it is worth landing ahead of the feature branches currently red on it (#2084, #2085).
