### PR TITLE
Apply the operator's default theme on first load

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,14 +172,31 @@ secret status and donut palette entry satisfies it — so a new status colour ha
 the band, not at either extreme.
 
 **Runtime.** `src/utils/theme.ts` owns theme resolution, persistence and DOM application, and is
-framework-free. `components/ThemeProvider` exposes `useTheme()` (mode, resolvedTheme, setMode,
-cycleMode) and tracks the OS preference live via a `matchMedia` listener; `useTheme()` throws when
-called outside the provider, so any component test harness that renders a theme-consuming component
-needs a `ThemeProvider` wrapper. An inline script in `index.html` applies the persisted theme before
-first paint so dark-mode users never see a white flash; it duplicates the resolution logic from
-`theme.ts` deliberately, because it runs before any module has loaded, and the two must be kept in
-step by hand. The user-facing control is a single header icon (`components/ThemeToggle`) that cycles
-System → Light → Dark → System.
+framework-free. There are four modes: `light` and `dark` are the platform's own themes, `systemLight`
+and `systemDark` are the operator's branded theme in its two compositions, and are offered only once
+branding is configured. Each resolves to one of the two `ResolvedTheme` values that the stylesheet
+actually renders.
+
+Resolution follows a strict precedence: the user's own stored choice, then the operator's default
+(`defaultTheme` from public branding), then the OS preference. The OS is therefore consulted only on
+the fallback path — where the `matchMedia` listener does keep the theme moving live — and is ignored
+once either of the first two exists.
+
+`components/ThemeProvider` exposes `useTheme()` (mode, resolvedTheme, setMode, modes — `modes` being
+the list the control may offer, two without branding and four with it). It is store-free so a
+component test can mount it directly; `components/ThemeProvider/ConnectedThemeProvider` is the
+wrapper that feeds it the branding read from the `branding` duck, and withholds it while the read is
+in flight or has failed, because a failed read settles the slice on the platform default and would
+otherwise be indistinguishable from a live "not branded" answer. `useTheme()` throws when called
+outside the provider, so any component test harness that renders a theme-consuming component needs a
+`ThemeProvider` wrapper.
+
+The operator default is cached in `localStorage` under `theme-operator-default`, written only from a
+live branding response. An inline script in `index.html` applies the stored mode, or that cache, or
+the OS preference before first paint so nobody sees a white flash; it duplicates the resolution logic
+from `theme.ts` deliberately, because it runs before any module has loaded, and the two must be kept
+in step by hand. The user-facing control is a header dropdown (`components/ThemeToggle`) listing the
+available modes as a Radix radio group, with the active one marked.
 
 **Accessibility.** `src/utils/theme-tokens.spec.ts` parses the semantic tokens out of the stylesheet
 and asserts WCAG AA (4.5:1) contrast for every text/background pairing, in both themes, plus AA

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,31 +172,40 @@ secret status and donut palette entry satisfies it — so a new status colour ha
 the band, not at either extreme.
 
 **Runtime.** `src/utils/theme.ts` owns theme resolution, persistence and DOM application, and is
-framework-free. There are four modes: `light` and `dark` are the platform's own themes, `systemLight`
-and `systemDark` are the operator's branded theme in its two compositions, and are offered only once
-branding is configured. Each resolves to one of the two `ResolvedTheme` values that the stylesheet
-actually renders.
+framework-free. There are three modes — `system`, `light`, `dark` — and `system` resolves from the OS
+preference, giving the two `ResolvedTheme` values the stylesheet actually renders.
 
-Resolution follows a strict precedence: the user's own stored choice, then the operator's default
-(`defaultTheme` from public branding), then the OS preference. The OS is therefore consulted only on
-the fallback path — where the `matchMedia` listener does keep the theme moving live — and is ignored
-once either of the first two exists.
+**Branding does not add modes.** It changes which palette `light` and `dark` render: the operator's
+compositions when branding is configured, the platform's own when it is not. That swap lives in the
+stylesheet's token layer, so nothing in the theme runtime needs to know whether the instance is
+branded. The one branding input it does read is `defaultTheme`.
 
-`components/ThemeProvider` exposes `useTheme()` (mode, resolvedTheme, setMode, modes — `modes` being
-the list the control may offer, two without branding and four with it). It is store-free so a
-component test can mount it directly; `components/ThemeProvider/ConnectedThemeProvider` is the
-wrapper that feeds it the branding read from the `branding` duck, and withholds it while the read is
-in flight or has failed, because a failed read settles the slice on the platform default and would
-otherwise be indistinguishable from a live "not branded" answer. `useTheme()` throws when called
-outside the provider, so any component test harness that renders a theme-consuming component needs a
-`ThemeProvider` wrapper.
+Resolution has two steps, and keeping them separate is what makes the model work. `initialMode()`
+picks the mode: the user's own stored choice, then the operator's default, then `system`. Then
+`resolveTheme()` renders it, consulting the OS only for `system` — where the `matchMedia` listener
+keeps the theme moving live. So an operator default of `dark` puts the control on Dark rather than
+leaving it on System showing a light page, and a user who then picks System outranks the operator and
+follows their own OS again.
+
+That last part is why `readStoredMode()` returns `undefined` rather than defaulting to `system`:
+"never chose" has to stay distinguishable from "chose System", or the operator default could never
+apply. For the same reason the chosen mode is persisted in `setMode`/`cycleMode` rather than in an
+effect on `mode` — an effect would also fire for the operator default and pin the user to it.
+
+`components/ThemeProvider` exposes `useTheme()` (mode, resolvedTheme, setMode, cycleMode). It is
+store-free so a component test can mount it directly; `components/ThemeProvider/ConnectedThemeProvider`
+is the wrapper that feeds it the branding read from the `branding` duck, and withholds it while the
+read is in flight or has failed, because a failed read settles the slice on the platform default and
+would otherwise be indistinguishable from a live "not branded" answer. `useTheme()` throws when
+called outside the provider, so any component test harness that renders a theme-consuming component
+needs a `ThemeProvider` wrapper.
 
 The operator default is cached in `localStorage` under `theme-operator-default`, written only from a
 live branding response. An inline script in `index.html` applies the stored mode, or that cache, or
 the OS preference before first paint so nobody sees a white flash; it duplicates the resolution logic
 from `theme.ts` deliberately, because it runs before any module has loaded, and the two must be kept
-in step by hand. The user-facing control is a header dropdown (`components/ThemeToggle`) listing the
-available modes as a Radix radio group, with the active one marked.
+in step by hand. The user-facing control is a single header icon (`components/ThemeToggle`) that
+cycles System → Light → Dark → System.
 
 **Accessibility.** `src/utils/theme-tokens.spec.ts` parses the semantic tokens out of the stylesheet
 and asserts WCAG AA (4.5:1) contrast for every text/background pairing, in both themes, plus AA

--- a/index.html
+++ b/index.html
@@ -12,18 +12,26 @@
             }
         </script>
         <script>
-            // Apply the stored theme before first paint so dark-mode users never see a white flash.
+            // Apply the theme before first paint so dark-mode users never see a white flash.
             // Mirrors utils/theme.ts; it cannot import from it because no module has loaded yet.
             (function () {
-                // Start from the operating system preference, then let an explicit stored choice
-                // override it. Reading storage can throw outright when storage is blocked, so the
-                // system preference is resolved first and remains the fallback in that case.
+                // Same precedence as initialMode(): the user's own choice, then the operator's default, then the
+                // operating system preference. The operator default is server-held, so what is read here is the copy
+                // cached by the last branding response - on a first-ever visit there is none and the system
+                // preference stands. Reading storage can throw outright when storage is blocked, so the system
+                // preference is resolved first and remains the fallback in that case.
                 var prefersDark = globalThis.matchMedia && globalThis.matchMedia('(prefers-color-scheme: dark)').matches;
                 var resolved = prefersDark ? 'dark' : 'light';
                 try {
+                    var operatorDefault = localStorage.getItem('theme-operator-default');
+                    if (operatorDefault === 'light' || operatorDefault === 'dark') {
+                        resolved = operatorDefault;
+                    }
                     var stored = localStorage.getItem('theme-mode');
-                    if (stored === 'light' || stored === 'dark') {
-                        resolved = stored;
+                    if (stored === 'light' || stored === 'systemLight') {
+                        resolved = 'light';
+                    } else if (stored === 'dark' || stored === 'systemDark') {
+                        resolved = 'dark';
                     }
                 } catch {
                     // Storage unavailable; the system preference resolved above stands.

--- a/index.html
+++ b/index.html
@@ -15,11 +15,12 @@
             // Apply the theme before first paint so dark-mode users never see a white flash.
             // Mirrors utils/theme.ts; it cannot import from it because no module has loaded yet.
             (function () {
-                // Same precedence as initialMode(): the user's own choice, then the operator's default, then the
-                // operating system preference. The operator default is server-held, so what is read here is the copy
-                // cached by the last branding response - on a first-ever visit there is none and the system
-                // preference stands. Reading storage can throw outright when storage is blocked, so the system
-                // preference is resolved first and remains the fallback in that case.
+                // Same precedence as initialMode() then resolveTheme(): the user's own choice, then the operator's
+                // default, then the operating system preference - and an explicit 'system' choice returns to the OS
+                // preference rather than keeping the operator default. The operator default is server-held, so what is
+                // read here is the copy cached by the last branding response; on a first-ever visit there is none and
+                // the system preference stands. Reading storage can throw outright when storage is blocked, so the
+                // system preference is resolved first and remains the fallback in that case.
                 var prefersDark = globalThis.matchMedia && globalThis.matchMedia('(prefers-color-scheme: dark)').matches;
                 var resolved = prefersDark ? 'dark' : 'light';
                 try {
@@ -28,10 +29,11 @@
                         resolved = operatorDefault;
                     }
                     var stored = localStorage.getItem('theme-mode');
-                    if (stored === 'light' || stored === 'systemLight') {
-                        resolved = 'light';
-                    } else if (stored === 'dark' || stored === 'systemDark') {
-                        resolved = 'dark';
+                    if (stored === 'light' || stored === 'dark') {
+                        resolved = stored;
+                    } else if (stored === 'system') {
+                        // An explicit System choice outranks the operator default, back to the OS preference.
+                        resolved = prefersDark ? 'dark' : 'light';
                     }
                 } catch {
                     // Storage unavailable; the system preference resolved above stands.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { Provider } from 'react-redux';
 import AppRouter from './components/AppRouter';
-import ThemeProvider from './components/ThemeProvider';
+import ConnectedThemeProvider from './components/ThemeProvider/ConnectedThemeProvider';
 import configureStore from './store';
 
 export const store = configureStore();
@@ -8,9 +8,9 @@ export const store = configureStore();
 const App = () => {
     return (
         <Provider store={store}>
-            <ThemeProvider>
+            <ConnectedThemeProvider>
                 <AppRouter />
-            </ThemeProvider>
+            </ConnectedThemeProvider>
         </Provider>
     );
 };

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -46,7 +46,7 @@ function Dropdown({
                     aria-label={ariaLabel}
                     className={cn(
                         'group p-2 inline-flex items-center gap-x-2 text-sm font-medium rounded-lg text-inherit',
-                        'focus:outline-hidden disabled:opacity-50 disabled:pointer-events-none',
+                        'focus:outline-hidden focus-visible:ring-2 focus-visible:ring-current disabled:opacity-50 disabled:pointer-events-none',
                         {
                             'border border-outline shadow-2xs bg-surface-raised text-content hover:bg-surface-hover focus:bg-surface-hover':
                                 btnStyle !== 'transparent',

--- a/src/components/ThemeProvider/ConnectedThemeProvider.tsx
+++ b/src/components/ThemeProvider/ConnectedThemeProvider.tsx
@@ -22,8 +22,9 @@ function ConnectedThemeProvider({ children }: Readonly<Props>) {
     }, [dispatch]);
 
     // A failed read still settles the store on the platform default so the login page can render. Handing that to
-    // ThemeProvider would look like a live "not branded" answer, clearing the cached operator default and dropping a
-    // branded instance to the platform pair. Withholding it instead leaves the cache — and the branded modes — intact.
+    // ThemeProvider would look like a live "not branded" answer and clear the cached operator default, so a returning
+    // user on a branded instance would lose the operator's theme to a transient network error. Withholding it instead
+    // leaves the cache intact.
     return <ThemeProvider branding={readFailed ? undefined : branding}>{children}</ThemeProvider>;
 }
 

--- a/src/components/ThemeProvider/ConnectedThemeProvider.tsx
+++ b/src/components/ThemeProvider/ConnectedThemeProvider.tsx
@@ -15,12 +15,16 @@ type Props = {
 function ConnectedThemeProvider({ children }: Readonly<Props>) {
     const dispatch = useDispatch();
     const branding = useSelector(selectors.publicBranding);
+    const readFailed = useSelector(selectors.publicBrandingReadFailed);
 
     useEffect(() => {
         dispatch(actions.getPublicBranding());
     }, [dispatch]);
 
-    return <ThemeProvider branding={branding}>{children}</ThemeProvider>;
+    // A failed read still settles the store on the platform default so the login page can render. Handing that to
+    // ThemeProvider would look like a live "not branded" answer, clearing the cached operator default and dropping a
+    // branded instance to the platform pair. Withholding it instead leaves the cache — and the branded modes — intact.
+    return <ThemeProvider branding={readFailed ? undefined : branding}>{children}</ThemeProvider>;
 }
 
 export default ConnectedThemeProvider;

--- a/src/components/ThemeProvider/ConnectedThemeProvider.tsx
+++ b/src/components/ThemeProvider/ConnectedThemeProvider.tsx
@@ -1,0 +1,26 @@
+import { useEffect, type ReactNode } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { actions, selectors } from 'ducks/branding';
+import ThemeProvider from './index';
+
+type Props = {
+    children: ReactNode;
+};
+
+/**
+ * Feeds the operator's branding into {@link ThemeProvider}. The read is the anonymous one, because the theme has to be
+ * resolved on the login page too, before there is any session. ThemeProvider itself stays store-free so that a
+ * component test can mount it on its own.
+ */
+function ConnectedThemeProvider({ children }: Readonly<Props>) {
+    const dispatch = useDispatch();
+    const branding = useSelector(selectors.publicBranding);
+
+    useEffect(() => {
+        dispatch(actions.getPublicBranding());
+    }, [dispatch]);
+
+    return <ThemeProvider branding={branding}>{children}</ThemeProvider>;
+}
+
+export default ConnectedThemeProvider;

--- a/src/components/ThemeProvider/Probe.tsx
+++ b/src/components/ThemeProvider/Probe.tsx
@@ -1,18 +1,19 @@
 import { useTheme } from './index';
+import { THEME_MODES } from 'utils/theme';
 
 export default function Probe() {
-    const { mode, resolvedTheme, setMode, cycleMode } = useTheme();
+    const { mode, resolvedTheme, setMode, modes } = useTheme();
 
     return (
         <div>
             <span data-testid="mode">{mode}</span>
             <span data-testid="resolved">{resolvedTheme}</span>
-            <button type="button" data-testid="cycle" onClick={cycleMode}>
-                cycle
-            </button>
-            <button type="button" data-testid="set-dark" onClick={() => setMode('dark')}>
-                dark
-            </button>
+            <span data-testid="modes">{modes.join(',')}</span>
+            {THEME_MODES.map((option) => (
+                <button key={option} type="button" data-testid={`set-${option}`} onClick={() => setMode(option)}>
+                    {option}
+                </button>
+            ))}
         </div>
     );
 }

--- a/src/components/ThemeProvider/Probe.tsx
+++ b/src/components/ThemeProvider/Probe.tsx
@@ -2,13 +2,15 @@ import { useTheme } from './index';
 import { THEME_MODES } from 'utils/theme';
 
 export default function Probe() {
-    const { mode, resolvedTheme, setMode, modes } = useTheme();
+    const { mode, resolvedTheme, setMode, cycleMode } = useTheme();
 
     return (
         <div>
             <span data-testid="mode">{mode}</span>
             <span data-testid="resolved">{resolvedTheme}</span>
-            <span data-testid="modes">{modes.join(',')}</span>
+            <button type="button" data-testid="cycle" onClick={cycleMode}>
+                cycle
+            </button>
             {THEME_MODES.map((option) => (
                 <button key={option} type="button" data-testid={`set-${option}`} onClick={() => setMode(option)}>
                     {option}

--- a/src/components/ThemeProvider/ThemeProvider.spec.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.spec.tsx
@@ -1,29 +1,34 @@
+import type { Page } from '@playwright/test';
 import { expect, test } from '../../../playwright/ct-test';
+import type { BrandingTheme } from 'types/branding';
 import ThemeProvider from './index';
 import Probe from './Probe';
 
-test.describe('ThemeProvider', () => {
-    test('should default to system mode', async ({ mount, page }) => {
-        await mount(
-            <ThemeProvider>
-                <Probe />
-            </ThemeProvider>,
-        );
-        await expect(page.getByTestId('mode')).toHaveText('system');
-    });
+const branded = (defaultTheme: BrandingTheme) => ({ configured: true, defaultTheme });
+const unbranded = { configured: false };
 
-    test('should resolve system mode to the OS preference', async ({ mount, page }) => {
+const seed = (page: Page, values: Record<string, string>) =>
+    page.evaluate((entries) => {
+        for (const [key, value] of Object.entries(entries)) {
+            globalThis.localStorage.setItem(key, value);
+        }
+    }, values);
+
+test.describe('ThemeProvider', () => {
+    test('should fall back to the OS preference when nothing else is set', async ({ mount, page }) => {
         await page.emulateMedia({ colorScheme: 'dark' });
         await mount(
             <ThemeProvider>
                 <Probe />
             </ThemeProvider>,
         );
+
+        await expect(page.getByTestId('mode')).toHaveText('dark');
         await expect(page.getByTestId('resolved')).toHaveText('dark');
         await expect(page.locator('html')).toHaveClass(/dark/);
     });
 
-    test('should follow OS changes live while in system mode', async ({ mount, page }) => {
+    test('should follow OS changes live while on the fallback path', async ({ mount, page }) => {
         await page.emulateMedia({ colorScheme: 'light' });
         await mount(
             <ThemeProvider>
@@ -36,6 +41,30 @@ test.describe('ThemeProvider', () => {
         await expect(page.getByTestId('resolved')).toHaveText('dark');
     });
 
+    test('should apply the operator default over the OS preference', async ({ mount, page }) => {
+        await page.emulateMedia({ colorScheme: 'light' });
+        await mount(
+            <ThemeProvider branding={branded('dark' as BrandingTheme)}>
+                <Probe />
+            </ThemeProvider>,
+        );
+
+        await expect(page.getByTestId('mode')).toHaveText('systemDark');
+        await expect(page.getByTestId('resolved')).toHaveText('dark');
+    });
+
+    test('should let a stored choice win over the operator default', async ({ mount, page }) => {
+        await seed(page, { 'theme-mode': 'light' });
+        await mount(
+            <ThemeProvider branding={branded('dark' as BrandingTheme)}>
+                <Probe />
+            </ThemeProvider>,
+        );
+
+        await expect(page.getByTestId('mode')).toHaveText('light');
+        await expect(page.getByTestId('resolved')).toHaveText('light');
+    });
+
     test('should ignore the OS preference once a mode is chosen', async ({ mount, page }) => {
         await page.emulateMedia({ colorScheme: 'light' });
         await mount(
@@ -44,36 +73,99 @@ test.describe('ThemeProvider', () => {
             </ThemeProvider>,
         );
         await page.getByTestId('set-dark').click();
+        await expect(page.getByTestId('resolved')).toHaveText('dark');
 
+        await page.emulateMedia({ colorScheme: 'light' });
         await expect(page.getByTestId('resolved')).toHaveText('dark');
         await expect(page.locator('html')).toHaveClass(/dark/);
     });
 
-    test('should cycle system to light to dark and back', async ({ mount, page }) => {
-        await mount(
-            <ThemeProvider>
-                <Probe />
-            </ThemeProvider>,
-        );
-        const mode = page.getByTestId('mode');
-
-        await page.getByTestId('cycle').click();
-        await expect(mode).toHaveText('light');
-        await page.getByTestId('cycle').click();
-        await expect(mode).toHaveText('dark');
-        await page.getByTestId('cycle').click();
-        await expect(mode).toHaveText('system');
-    });
-
     test('should persist the chosen mode', async ({ mount, page }) => {
         await mount(
+            <ThemeProvider branding={branded('light' as BrandingTheme)}>
+                <Probe />
+            </ThemeProvider>,
+        );
+        await page.getByTestId('set-systemDark').click();
+        await expect(page.getByTestId('mode')).toHaveText('systemDark');
+
+        await expect.poll(async () => page.evaluate(() => globalThis.localStorage.getItem('theme-mode'))).toBe('systemDark');
+    });
+
+    test('should not persist a mode the user never chose', async ({ mount, page }) => {
+        await mount(
+            <ThemeProvider branding={branded('dark' as BrandingTheme)}>
+                <Probe />
+            </ThemeProvider>,
+        );
+        await expect(page.getByTestId('mode')).toHaveText('systemDark');
+
+        expect(await page.evaluate(() => globalThis.localStorage.getItem('theme-mode'))).toBeNull();
+    });
+
+    test('should offer only the platform modes without branding', async ({ mount, page }) => {
+        await mount(
+            <ThemeProvider branding={unbranded}>
+                <Probe />
+            </ThemeProvider>,
+        );
+
+        await expect(page.getByTestId('modes')).toHaveText('light,dark');
+    });
+
+    test('should offer all four modes once branding is configured', async ({ mount, page }) => {
+        await mount(
+            <ThemeProvider branding={branded('light' as BrandingTheme)}>
+                <Probe />
+            </ThemeProvider>,
+        );
+
+        await expect(page.getByTestId('modes')).toHaveText('light,dark,systemLight,systemDark');
+    });
+
+    test('should report a stored branded choice as its platform mode when branding is gone', async ({ mount, page }) => {
+        await seed(page, { 'theme-mode': 'systemDark' });
+        await mount(
+            <ThemeProvider branding={unbranded}>
+                <Probe />
+            </ThemeProvider>,
+        );
+
+        await expect(page.getByTestId('mode')).toHaveText('dark');
+        await expect(page.getByTestId('resolved')).toHaveText('dark');
+    });
+
+    test('should cache the operator default for the next load', async ({ mount, page }) => {
+        await mount(
+            <ThemeProvider branding={branded('dark' as BrandingTheme)}>
+                <Probe />
+            </ThemeProvider>,
+        );
+
+        await expect.poll(async () => page.evaluate(() => globalThis.localStorage.getItem('theme-operator-default'))).toBe('dark');
+    });
+
+    test('should clear the cached operator default once branding is removed', async ({ mount, page }) => {
+        await seed(page, { 'theme-operator-default': 'dark' });
+        await mount(
+            <ThemeProvider branding={unbranded}>
+                <Probe />
+            </ThemeProvider>,
+        );
+
+        await expect.poll(async () => page.evaluate(() => globalThis.localStorage.getItem('theme-operator-default'))).toBeNull();
+    });
+
+    test('should apply the cached operator default before the branding read lands', async ({ mount, page }) => {
+        await page.emulateMedia({ colorScheme: 'light' });
+        await seed(page, { 'theme-operator-default': 'dark' });
+        await mount(
             <ThemeProvider>
                 <Probe />
             </ThemeProvider>,
         );
-        await page.getByTestId('set-dark').click();
-        await expect(page.getByTestId('mode')).toHaveText('dark');
 
-        await expect.poll(async () => page.evaluate(() => globalThis.localStorage.getItem('theme-mode'))).toBe('dark');
+        await expect(page.getByTestId('mode')).toHaveText('systemDark');
+        await expect(page.getByTestId('modes')).toHaveText('light,dark,systemLight,systemDark');
     });
 });

--- a/src/components/ThemeProvider/ThemeProvider.spec.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.spec.tsx
@@ -93,8 +93,8 @@ test.describe('ThemeProvider', () => {
             resolved: 'light',
         },
         {
-            // Left behind by the withdrawn four-mode revision. Not a choice at all, so the operator default applies.
-            because: 'a mode from the withdrawn four-mode revision is not a choice',
+            // A stored value outside the three supported modes is not a choice at all, so the operator default applies.
+            because: 'an unsupported stored mode is not a choice',
             stored: 'systemDark',
             operatorDefault: 'dark',
             os: 'light',
@@ -163,7 +163,6 @@ test.describe('ThemeProvider', () => {
         expect(await page.evaluate(() => globalThis.localStorage.getItem('theme-mode'))).toBeNull();
     });
 
-    /** The first click has to advance from what is in force, which on a branded instance is the operator's default. */
     test('should cycle on from the operator default rather than from system', async ({ mount, page }) => {
         await mount(
             <ThemeProvider branding={branded('light' as BrandingTheme)}>

--- a/src/components/ThemeProvider/ThemeProvider.spec.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.spec.tsx
@@ -60,43 +60,67 @@ test.describe('ThemeProvider', () => {
         await expect(page.getByTestId('resolved')).toHaveText('dark');
     });
 
-    test('should apply the operator default over the OS preference', async ({ mount, page }) => {
-        await page.emulateMedia({ colorScheme: 'light' });
-        await mount(
-            <ThemeProvider branding={branded('dark' as BrandingTheme)}>
-                <Probe />
-            </ThemeProvider>,
-        );
+    /**
+     * The precedence order as the table it is. Every row sets the OS to something the expected outcome does *not*
+     * agree with where that is possible, so a row can only pass because the rule under test won rather than because
+     * the OS happened to match.
+     */
+    const PRECEDENCE = [
+        {
+            because: 'the operator default beats the OS preference',
+            stored: undefined,
+            operatorDefault: 'dark',
+            os: 'light',
+            mode: 'dark',
+            resolved: 'dark',
+        },
+        {
+            because: 'a stored choice beats the operator default',
+            stored: 'light',
+            operatorDefault: 'dark',
+            os: 'dark',
+            mode: 'light',
+            resolved: 'light',
+        },
+        {
+            // A stored `system` is a choice like any other, so it outranks the operator and hands control back to
+            // the OS. This is the row that stops "no preference" and "chose System" being conflated.
+            because: 'a stored system choice beats the operator default and returns to the OS',
+            stored: 'system',
+            operatorDefault: 'dark',
+            os: 'light',
+            mode: 'system',
+            resolved: 'light',
+        },
+        {
+            // Left behind by the withdrawn four-mode revision. Not a choice at all, so the operator default applies.
+            because: 'a mode from the withdrawn four-mode revision is not a choice',
+            stored: 'systemDark',
+            operatorDefault: 'dark',
+            os: 'light',
+            mode: 'dark',
+            resolved: 'dark',
+        },
+    ] as const;
 
-        await expect(page.getByTestId('mode')).toHaveText('dark');
-        await expect(page.getByTestId('resolved')).toHaveText('dark');
-    });
+    for (const { because, stored, operatorDefault, os, mode, resolved } of PRECEDENCE) {
+        test(`should resolve to ${mode} because ${because}`, async ({ mount, page }) => {
+            await page.emulateMedia({ colorScheme: os });
 
-    /** An explicit System choice is a choice, so it has to beat the operator default and follow the OS instead. */
-    test('should let an explicit system choice outrank the operator default', async ({ mount, page }) => {
-        await page.emulateMedia({ colorScheme: 'light' });
-        await seed(page, { 'theme-mode': 'system' });
-        await mount(
-            <ThemeProvider branding={branded('dark' as BrandingTheme)}>
-                <Probe />
-            </ThemeProvider>,
-        );
+            if (stored !== undefined) {
+                await seed(page, { 'theme-mode': stored });
+            }
 
-        await expect(page.getByTestId('mode')).toHaveText('system');
-        await expect(page.getByTestId('resolved')).toHaveText('light');
-    });
+            await mount(
+                <ThemeProvider branding={branded(operatorDefault as BrandingTheme)}>
+                    <Probe />
+                </ThemeProvider>,
+            );
 
-    test('should let a stored choice win over the operator default', async ({ mount, page }) => {
-        await seed(page, { 'theme-mode': 'light' });
-        await mount(
-            <ThemeProvider branding={branded('dark' as BrandingTheme)}>
-                <Probe />
-            </ThemeProvider>,
-        );
-
-        await expect(page.getByTestId('mode')).toHaveText('light');
-        await expect(page.getByTestId('resolved')).toHaveText('light');
-    });
+            await expect(page.getByTestId('mode')).toHaveText(mode);
+            await expect(page.getByTestId('resolved')).toHaveText(resolved);
+        });
+    }
 
     test('should ignore the OS preference once a mode is chosen', async ({ mount, page }) => {
         await page.emulateMedia({ colorScheme: 'light' });
@@ -137,23 +161,6 @@ test.describe('ThemeProvider', () => {
         await expect(page.getByTestId('mode')).toHaveText('dark');
 
         expect(await page.evaluate(() => globalThis.localStorage.getItem('theme-mode'))).toBeNull();
-    });
-
-    /**
-     * A browser that saw the four-mode build has one of the retired modes stored. It must read as "no preference" so
-     * the operator default takes over, rather than pinning the user to a mode that no longer exists.
-     */
-    test('should ignore a mode stored by the retired four-mode build', async ({ mount, page }) => {
-        await page.emulateMedia({ colorScheme: 'light' });
-        await seed(page, { 'theme-mode': 'systemDark' });
-        await mount(
-            <ThemeProvider branding={branded('dark' as BrandingTheme)}>
-                <Probe />
-            </ThemeProvider>,
-        );
-
-        await expect(page.getByTestId('mode')).toHaveText('dark');
-        await expect(page.getByTestId('resolved')).toHaveText('dark');
     });
 
     /** The first click has to advance from what is in force, which on a branded instance is the operator's default. */

--- a/src/components/ThemeProvider/ThemeProvider.spec.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.spec.tsx
@@ -5,8 +5,12 @@ import { DARK_SCHEME_QUERY } from 'utils/theme';
 import ThemeProvider from './index';
 import Probe from './Probe';
 
-const branded = (defaultTheme: BrandingTheme) => ({ configured: true, defaultTheme });
-const unbranded = { configured: false };
+/**
+ * Branding reaches the provider as its default theme and nothing else: it decides which palette light and dark render,
+ * not which modes exist, so `configured` is not something the theme runtime consults.
+ */
+const branded = (defaultTheme: BrandingTheme) => ({ defaultTheme });
+const unbranded = {};
 
 /**
  * Switches the OS preference and returns once the page has dispatched the change to a listener. An expectation that
@@ -38,7 +42,7 @@ test.describe('ThemeProvider', () => {
             </ThemeProvider>,
         );
 
-        await expect(page.getByTestId('mode')).toHaveText('dark');
+        await expect(page.getByTestId('mode')).toHaveText('system');
         await expect(page.getByTestId('resolved')).toHaveText('dark');
         await expect(page.locator('html')).toHaveClass(/dark/);
     });
@@ -64,8 +68,22 @@ test.describe('ThemeProvider', () => {
             </ThemeProvider>,
         );
 
-        await expect(page.getByTestId('mode')).toHaveText('systemDark');
+        await expect(page.getByTestId('mode')).toHaveText('dark');
         await expect(page.getByTestId('resolved')).toHaveText('dark');
+    });
+
+    /** An explicit System choice is a choice, so it has to beat the operator default and follow the OS instead. */
+    test('should let an explicit system choice outrank the operator default', async ({ mount, page }) => {
+        await page.emulateMedia({ colorScheme: 'light' });
+        await seed(page, { 'theme-mode': 'system' });
+        await mount(
+            <ThemeProvider branding={branded('dark' as BrandingTheme)}>
+                <Probe />
+            </ThemeProvider>,
+        );
+
+        await expect(page.getByTestId('mode')).toHaveText('system');
+        await expect(page.getByTestId('resolved')).toHaveText('light');
     });
 
     test('should let a stored choice win over the operator default', async ({ mount, page }) => {
@@ -104,10 +122,10 @@ test.describe('ThemeProvider', () => {
                 <Probe />
             </ThemeProvider>,
         );
-        await page.getByTestId('set-systemDark').click();
-        await expect(page.getByTestId('mode')).toHaveText('systemDark');
+        await page.getByTestId('set-dark').click();
+        await expect(page.getByTestId('mode')).toHaveText('dark');
 
-        await expect.poll(async () => page.evaluate(() => globalThis.localStorage.getItem('theme-mode'))).toBe('systemDark');
+        await expect.poll(async () => page.evaluate(() => globalThis.localStorage.getItem('theme-mode'))).toBe('dark');
     });
 
     test('should not persist a mode the user never chose', async ({ mount, page }) => {
@@ -116,41 +134,42 @@ test.describe('ThemeProvider', () => {
                 <Probe />
             </ThemeProvider>,
         );
-        await expect(page.getByTestId('mode')).toHaveText('systemDark');
+        await expect(page.getByTestId('mode')).toHaveText('dark');
 
         expect(await page.evaluate(() => globalThis.localStorage.getItem('theme-mode'))).toBeNull();
     });
 
-    test('should offer only the platform modes without branding', async ({ mount, page }) => {
-        await mount(
-            <ThemeProvider branding={unbranded}>
-                <Probe />
-            </ThemeProvider>,
-        );
-
-        await expect(page.getByTestId('modes')).toHaveText('light,dark');
-    });
-
-    test('should offer all four modes once branding is configured', async ({ mount, page }) => {
-        await mount(
-            <ThemeProvider branding={branded('light' as BrandingTheme)}>
-                <Probe />
-            </ThemeProvider>,
-        );
-
-        await expect(page.getByTestId('modes')).toHaveText('light,dark,systemLight,systemDark');
-    });
-
-    test('should report a stored branded choice as its platform mode when branding is gone', async ({ mount, page }) => {
+    /**
+     * A browser that saw the four-mode build has one of the retired modes stored. It must read as "no preference" so
+     * the operator default takes over, rather than pinning the user to a mode that no longer exists.
+     */
+    test('should ignore a mode stored by the retired four-mode build', async ({ mount, page }) => {
+        await page.emulateMedia({ colorScheme: 'light' });
         await seed(page, { 'theme-mode': 'systemDark' });
         await mount(
-            <ThemeProvider branding={unbranded}>
+            <ThemeProvider branding={branded('dark' as BrandingTheme)}>
                 <Probe />
             </ThemeProvider>,
         );
 
         await expect(page.getByTestId('mode')).toHaveText('dark');
         await expect(page.getByTestId('resolved')).toHaveText('dark');
+    });
+
+    /** The first click has to advance from what is in force, which on a branded instance is the operator's default. */
+    test('should cycle on from the operator default rather than from system', async ({ mount, page }) => {
+        await mount(
+            <ThemeProvider branding={branded('light' as BrandingTheme)}>
+                <Probe />
+            </ThemeProvider>,
+        );
+        await expect(page.getByTestId('mode')).toHaveText('light');
+
+        await page.getByTestId('cycle').click();
+        await expect(page.getByTestId('mode')).toHaveText('dark');
+
+        await page.getByTestId('cycle').click();
+        await expect(page.getByTestId('mode')).toHaveText('system');
     });
 
     test('should cache the operator default for the next load', async ({ mount, page }) => {
@@ -195,7 +214,7 @@ test.describe('ThemeProvider', () => {
             </ThemeProvider>,
         );
 
-        await expect(page.getByTestId('mode')).toHaveText('systemDark');
-        await expect(page.getByTestId('modes')).toHaveText('light,dark,systemLight,systemDark');
+        await expect(page.getByTestId('mode')).toHaveText('dark');
+        await expect(page.getByTestId('resolved')).toHaveText('dark');
     });
 });

--- a/src/components/ThemeProvider/ThemeProvider.spec.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.spec.tsx
@@ -1,11 +1,26 @@
 import type { Page } from '@playwright/test';
 import { expect, test } from '../../../playwright/ct-test';
 import type { BrandingTheme } from 'types/branding';
+import { DARK_SCHEME_QUERY } from 'utils/theme';
 import ThemeProvider from './index';
 import Probe from './Probe';
 
 const branded = (defaultTheme: BrandingTheme) => ({ configured: true, defaultTheme });
 const unbranded = { configured: false };
+
+/**
+ * Switches the OS preference and returns once the page has dispatched the change to a listener. An expectation that
+ * the theme did *not* move is satisfied by the state before the switch as well, so it has to be made after the event
+ * the provider would have reacted to rather than racing it.
+ */
+const switchOsPreference = async (page: Page, colorScheme: 'light' | 'dark') => {
+    await page.evaluate((query) => {
+        Object.assign(globalThis, { __osChangeSeen: false });
+        globalThis.matchMedia(query).addEventListener('change', () => Object.assign(globalThis, { __osChangeSeen: true }));
+    }, DARK_SCHEME_QUERY);
+    await page.emulateMedia({ colorScheme });
+    await expect.poll(async () => page.evaluate(() => Reflect.get(globalThis, '__osChangeSeen'))).toBe(true);
+};
 
 const seed = (page: Page, values: Record<string, string>) =>
     page.evaluate((entries) => {
@@ -72,12 +87,15 @@ test.describe('ThemeProvider', () => {
                 <Probe />
             </ThemeProvider>,
         );
-        await page.getByTestId('set-dark').click();
-        await expect(page.getByTestId('resolved')).toHaveText('dark');
+        await page.getByTestId('set-light').click();
+        await expect(page.getByTestId('resolved')).toHaveText('light');
 
-        await page.emulateMedia({ colorScheme: 'light' });
-        await expect(page.getByTestId('resolved')).toHaveText('dark');
-        await expect(page.locator('html')).toHaveClass(/dark/);
+        // The same transition the fallback-path test above follows. Without the choice made first, the theme would
+        // move with it, so what is asserted below holds only because the chosen mode outranks the OS.
+        await switchOsPreference(page, 'dark');
+
+        await expect(page.getByTestId('resolved')).toHaveText('light');
+        await expect(page.locator('html')).not.toHaveClass(/dark/);
     });
 
     test('should persist the chosen mode', async ({ mount, page }) => {

--- a/src/components/ThemeProvider/ThemeProvider.spec.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.spec.tsx
@@ -156,6 +156,18 @@ test.describe('ThemeProvider', () => {
         await expect.poll(async () => page.evaluate(() => globalThis.localStorage.getItem('theme-operator-default'))).toBeNull();
     });
 
+    test('should keep the cached operator default while no branding has been read', async ({ mount, page }) => {
+        await seed(page, { 'theme-operator-default': 'dark' });
+        await mount(
+            <ThemeProvider>
+                <Probe />
+            </ThemeProvider>,
+        );
+
+        await expect(page.getByTestId('mode')).toBeVisible();
+        await expect.poll(async () => page.evaluate(() => globalThis.localStorage.getItem('theme-operator-default'))).toBe('dark');
+    });
+
     test('should apply the cached operator default before the branding read lands', async ({ mount, page }) => {
         await page.emulateMedia({ colorScheme: 'light' });
         await seed(page, { 'theme-operator-default': 'dark' });

--- a/src/components/ThemeProvider/index.tsx
+++ b/src/components/ThemeProvider/index.tsx
@@ -1,12 +1,18 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
+import type { PublicBrandingModel } from 'types/branding';
 import {
     applyTheme,
+    availableModes,
     DARK_SCHEME_QUERY,
-    nextMode,
+    initialMode,
+    operatorDefaultTheme,
+    platformMode,
     prefersDarkScheme,
     readStoredMode,
+    readStoredOperatorDefault,
     resolveTheme,
     storeMode,
+    storeOperatorDefault,
     type ResolvedTheme,
     type ThemeMode,
 } from 'utils/theme';
@@ -15,7 +21,8 @@ export type ThemeContextValue = {
     mode: ThemeMode;
     resolvedTheme: ResolvedTheme;
     setMode: (mode: ThemeMode) => void;
-    cycleMode: () => void;
+    /** The modes the user may pick from: the branded pair is offered only once branding is configured. */
+    modes: readonly ThemeMode[];
 };
 
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
@@ -32,11 +39,16 @@ export function useTheme(): ThemeContextValue {
 
 type Props = {
     children: ReactNode;
+    /** The operator's branding, once read. Absent while the read is in flight, and on a Core that predates branding. */
+    branding?: Pick<PublicBrandingModel, 'configured' | 'defaultTheme'>;
 };
 
-function ThemeProvider({ children }: Readonly<Props>) {
-    const [mode, setMode] = useState<ThemeMode>(readStoredMode);
+function ThemeProvider({ children, branding }: Readonly<Props>) {
+    const [chosenMode, setChosenMode] = useState<ThemeMode | undefined>(readStoredMode);
     const [prefersDark, setPrefersDark] = useState<boolean>(prefersDarkScheme);
+    // Read once: after the first branding response the live value below is authoritative, and re-reading storage on
+    // every render would only reintroduce a value the operator may just have cleared.
+    const [cachedOperatorDefault] = useState<ResolvedTheme | undefined>(readStoredOperatorDefault);
 
     useEffect(() => {
         const query = globalThis.matchMedia?.(DARK_SCHEME_QUERY);
@@ -53,25 +65,40 @@ function ThemeProvider({ children }: Readonly<Props>) {
         return () => query.removeEventListener('change', onChange);
     }, []);
 
-    const resolvedTheme = resolveTheme(mode, prefersDark);
+    const liveOperatorDefault = operatorDefaultTheme(branding?.defaultTheme);
+    const operatorDefault = branding ? liveOperatorDefault : cachedOperatorDefault;
+
+    // `defaultTheme` is present exactly when branding is configured, so the cache doubles as knowledge that the
+    // instance is branded. Without it a returning user would be offered two modes until the read lands, then four.
+    const brandingConfigured = branding?.configured ?? cachedOperatorDefault !== undefined;
+
+    // Left undefined until the user picks, so an OS change still moves the theme while the fallback path is in force.
+    const rawMode = initialMode(chosenMode, operatorDefault, prefersDark);
+    const mode = brandingConfigured ? rawMode : platformMode(rawMode);
+    const resolvedTheme = resolveTheme(mode);
+    const modes = availableModes(brandingConfigured);
 
     useEffect(() => {
         applyTheme(resolvedTheme);
     }, [resolvedTheme]);
 
-    // Persisting in an effect keeps the state updaters pure, so cycleMode can use the functional
-    // form and never reads a stale mode. This also runs on mount, which simply makes the default
-    // explicit in storage.
+    // Only a live response may write the cache. Writing it from the cached value would keep a stale default alive
+    // forever, and writing it before any response would clear a default the instance still has.
     useEffect(() => {
-        storeMode(mode);
-    }, [mode]);
+        if (branding) {
+            storeOperatorDefault(liveOperatorDefault);
+        }
+    }, [branding, liveOperatorDefault]);
 
-    const cycleMode = useCallback(() => setMode(nextMode), []);
+    // Persisted here rather than in an effect on `mode`, so that only an explicit choice is stored. An effect would
+    // also fire for the operator default and the OS fallback, which would make "never chose" indistinguishable from
+    // "chose exactly what the operator set" and pin the user to it.
+    const setMode = useCallback((next: ThemeMode) => {
+        setChosenMode(next);
+        storeMode(next);
+    }, []);
 
-    const value = useMemo<ThemeContextValue>(
-        () => ({ mode, resolvedTheme, setMode, cycleMode }),
-        [mode, resolvedTheme, setMode, cycleMode],
-    );
+    const value = useMemo<ThemeContextValue>(() => ({ mode, resolvedTheme, setMode, modes }), [mode, resolvedTheme, setMode, modes]);
 
     return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 }

--- a/src/components/ThemeProvider/index.tsx
+++ b/src/components/ThemeProvider/index.tsx
@@ -39,7 +39,7 @@ export function useTheme(): ThemeContextValue {
 
 type Props = {
     children: ReactNode;
-    /** The operator's branding, once read. Absent while the read is in flight, and on a Core that predates branding. */
+    /** The operator's branding, once successfully read. Absent while the read is in flight, when it failed, and on a Core that predates branding. */
     branding?: Pick<PublicBrandingModel, 'configured' | 'defaultTheme'>;
 };
 

--- a/src/components/ThemeProvider/index.tsx
+++ b/src/components/ThemeProvider/index.tsx
@@ -2,11 +2,10 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useState, t
 import type { PublicBrandingModel } from 'types/branding';
 import {
     applyTheme,
-    availableModes,
     DARK_SCHEME_QUERY,
     initialMode,
+    nextMode,
     operatorDefaultTheme,
-    platformMode,
     prefersDarkScheme,
     readStoredMode,
     readStoredOperatorDefault,
@@ -21,8 +20,7 @@ export type ThemeContextValue = {
     mode: ThemeMode;
     resolvedTheme: ResolvedTheme;
     setMode: (mode: ThemeMode) => void;
-    /** The modes the user may pick from: the branded pair is offered only once branding is configured. */
-    modes: readonly ThemeMode[];
+    cycleMode: () => void;
 };
 
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
@@ -39,8 +37,15 @@ export function useTheme(): ThemeContextValue {
 
 type Props = {
     children: ReactNode;
-    /** The operator's branding, once successfully read. Absent while the read is in flight, when it failed, and on a Core that predates branding. */
-    branding?: Pick<PublicBrandingModel, 'configured' | 'defaultTheme'>;
+    /**
+     * The operator's branding, once successfully read. Absent while the read is in flight, when it failed, and on a
+     * Core that predates branding.
+     *
+     * Only `defaultTheme` is used. Branding does not change which modes exist or how they resolve - it changes the
+     * palette that light and dark render, which is the stylesheet's business - so the theme runtime needs nothing else
+     * from it.
+     */
+    branding?: Pick<PublicBrandingModel, 'defaultTheme'>;
 };
 
 function ThemeProvider({ children, branding }: Readonly<Props>) {
@@ -68,15 +73,10 @@ function ThemeProvider({ children, branding }: Readonly<Props>) {
     const liveOperatorDefault = operatorDefaultTheme(branding?.defaultTheme);
     const operatorDefault = branding ? liveOperatorDefault : cachedOperatorDefault;
 
-    // `defaultTheme` is present exactly when branding is configured, so the cache doubles as knowledge that the
-    // instance is branded. Without it a returning user would be offered two modes until the read lands, then four.
-    const brandingConfigured = branding?.configured ?? cachedOperatorDefault !== undefined;
-
-    // Left undefined until the user picks, so an OS change still moves the theme while the fallback path is in force.
-    const rawMode = initialMode(chosenMode, operatorDefault, prefersDark);
-    const mode = brandingConfigured ? rawMode : platformMode(rawMode);
-    const resolvedTheme = resolveTheme(mode);
-    const modes = availableModes(brandingConfigured);
+    // Left undefined until the user picks, so the operator default still applies, and an OS change still moves the
+    // theme while `system` is in force.
+    const mode = initialMode(chosenMode, operatorDefault);
+    const resolvedTheme = resolveTheme(mode, prefersDark);
 
     useEffect(() => {
         applyTheme(resolvedTheme);
@@ -91,14 +91,30 @@ function ThemeProvider({ children, branding }: Readonly<Props>) {
     }, [branding, liveOperatorDefault]);
 
     // Persisted here rather than in an effect on `mode`, so that only an explicit choice is stored. An effect would
-    // also fire for the operator default and the OS fallback, which would make "never chose" indistinguishable from
-    // "chose exactly what the operator set" and pin the user to it.
+    // also fire for the operator default and the system fallback, which would make "never chose" indistinguishable
+    // from "chose exactly what the operator set" and pin the user to it.
     const setMode = useCallback((next: ThemeMode) => {
         setChosenMode(next);
         storeMode(next);
     }, []);
 
-    const value = useMemo<ThemeContextValue>(() => ({ mode, resolvedTheme, setMode, modes }), [mode, resolvedTheme, setMode, modes]);
+    // Cycles from whatever is in force, including a mode the user has not chosen yet: on a branded instance the first
+    // click has to advance from the operator's default, not from `system`. Kept in the functional form so two clicks
+    // in one batch cannot both read the same mode - only the fallback is closed over, and a click cannot change it.
+    const fallbackMode: ThemeMode = operatorDefault ?? 'system';
+    const cycleMode = useCallback(() => {
+        setChosenMode((current) => {
+            const next = nextMode(current ?? fallbackMode);
+
+            storeMode(next);
+            return next;
+        });
+    }, [fallbackMode]);
+
+    const value = useMemo<ThemeContextValue>(
+        () => ({ mode, resolvedTheme, setMode, cycleMode }),
+        [mode, resolvedTheme, setMode, cycleMode],
+    );
 
     return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
 }

--- a/src/components/ThemeToggle/ThemeToggle.spec.tsx
+++ b/src/components/ThemeToggle/ThemeToggle.spec.tsx
@@ -3,36 +3,94 @@ import type { BrandingTheme } from 'types/branding';
 import ThemeProvider from 'components/ThemeProvider';
 import ThemeToggle from './index';
 
-const branded = { configured: true, defaultTheme: 'light' as BrandingTheme };
-const unbranded = { configured: false };
+/**
+ * Branding reaches the theme runtime as a default theme and nothing else. It does not add modes: the control offers
+ * System, Light and Dark either way, and what changes is the palette those two render, which is the stylesheet's job.
+ */
+const branded = { defaultTheme: 'dark' as BrandingTheme };
 
 test.describe('ThemeToggle', () => {
-    test('should show the current mode on the trigger', async ({ mount, page }) => {
-        await page.emulateMedia({ colorScheme: 'light' });
+    test('should render with the system icon and label by default', async ({ mount, page }) => {
         await mount(
-            <ThemeProvider branding={unbranded}>
+            <ThemeProvider>
                 <ThemeToggle />
             </ThemeProvider>,
         );
-        const trigger = page.getByTestId('theme-toggle').locator('button');
+        const toggle = page.getByTestId('theme-toggle');
 
-        await expect(trigger).toBeVisible();
-        await expect(trigger).toHaveAttribute('aria-label', 'Theme: Light');
-        await expect(trigger.locator('[data-theme-icon="light"].lucide-sun')).toBeVisible();
+        await expect(toggle).toBeVisible();
+        await expect(toggle).toHaveAttribute('aria-label', 'Theme: System. Switch to Light.');
+        await expect(toggle.locator('[data-theme-icon="system"].lucide-monitor')).toBeVisible();
     });
 
-    test('should show a keyboard focus indicator on the trigger', async ({ mount, page }) => {
+    test('should advance to light on the first click', async ({ mount, page }) => {
         await mount(
-            <ThemeProvider branding={unbranded}>
+            <ThemeProvider>
                 <ThemeToggle />
             </ThemeProvider>,
         );
-        const trigger = page.getByTestId('theme-toggle').locator('button');
-        await trigger.focus();
+        const toggle = page.getByTestId('theme-toggle');
+
+        await toggle.click();
+        await expect(toggle).toHaveAttribute('aria-label', 'Theme: Light. Switch to Dark.');
+        await expect(toggle.locator('[data-theme-icon="light"].lucide-sun')).toBeVisible();
+        await expect(page.locator('html')).not.toHaveClass(/dark/);
+    });
+
+    test('should advance to dark on the second click and darken the document', async ({ mount, page }) => {
+        await mount(
+            <ThemeProvider>
+                <ThemeToggle />
+            </ThemeProvider>,
+        );
+        const toggle = page.getByTestId('theme-toggle');
+
+        await toggle.click();
+        await toggle.click();
+        await expect(toggle).toHaveAttribute('aria-label', 'Theme: Dark. Switch to System.');
+        await expect(toggle.locator('[data-theme-icon="dark"].lucide-moon')).toBeVisible();
+        await expect(page.locator('html')).toHaveClass(/dark/);
+    });
+
+    test('should return to system on the third click', async ({ mount, page }) => {
+        await mount(
+            <ThemeProvider>
+                <ThemeToggle />
+            </ThemeProvider>,
+        );
+        const toggle = page.getByTestId('theme-toggle');
+
+        await toggle.click();
+        await toggle.click();
+        await toggle.click();
+        await expect(toggle).toHaveAttribute('aria-label', 'Theme: System. Switch to Light.');
+    });
+
+    test('should be reachable and operable by keyboard', async ({ mount, page }) => {
+        await mount(
+            <ThemeProvider>
+                <ThemeToggle />
+            </ThemeProvider>,
+        );
+        const toggle = page.getByTestId('theme-toggle');
+
+        await toggle.focus();
+        await page.keyboard.press('Enter');
+        await expect(toggle).toHaveAttribute('aria-label', 'Theme: Light. Switch to Dark.');
+    });
+
+    test('should show a keyboard focus indicator', async ({ mount, page }) => {
+        await mount(
+            <ThemeProvider>
+                <ThemeToggle />
+            </ThemeProvider>,
+        );
+        const toggle = page.getByTestId('theme-toggle');
+        await toggle.focus();
 
         await expect
             .poll(async () =>
-                trigger.evaluate(
+                toggle.evaluate(
                     (element) =>
                         globalThis.getComputedStyle(element).outlineStyle !== 'none' ||
                         globalThis.getComputedStyle(element).boxShadow !== 'none',
@@ -41,142 +99,26 @@ test.describe('ThemeToggle', () => {
             .toBe(true);
     });
 
-    test('should offer only Light and Dark without branding', async ({ mount, page }) => {
-        await mount(
-            <ThemeProvider branding={unbranded}>
-                <ThemeToggle />
-            </ThemeProvider>,
-        );
-        await page.getByTestId('theme-toggle').locator('button').click();
-
-        await expect(page.getByTestId('theme-option-light')).toBeVisible();
-        await expect(page.getByTestId('theme-option-dark')).toBeVisible();
-        await expect(page.getByTestId('theme-option-systemLight')).toHaveCount(0);
-        await expect(page.getByTestId('theme-option-systemDark')).toHaveCount(0);
-    });
-
-    test('should offer all four modes once branding is configured', async ({ mount, page }) => {
-        await mount(
-            <ThemeProvider branding={branded}>
-                <ThemeToggle />
-            </ThemeProvider>,
-        );
-        await page.getByTestId('theme-toggle').locator('button').click();
-
-        await expect(page.getByRole('menuitemradio')).toHaveCount(4);
-        await expect(page.getByTestId('theme-option-systemLight')).toBeVisible();
-        await expect(page.getByTestId('theme-option-systemDark')).toBeVisible();
-    });
-
-    test('should mark the active mode', async ({ mount, page }) => {
-        await mount(
-            <ThemeProvider branding={branded}>
-                <ThemeToggle />
-            </ThemeProvider>,
-        );
-        await page.getByTestId('theme-toggle').locator('button').click();
-
-        await expect(page.getByTestId('theme-option-systemLight')).toHaveAttribute('aria-checked', 'true');
-        await expect(page.getByTestId('theme-option-dark')).toHaveAttribute('aria-checked', 'false');
-    });
-
-    test('should apply the mode the user selects', async ({ mount, page }) => {
-        await mount(
-            <ThemeProvider branding={unbranded}>
-                <ThemeToggle />
-            </ThemeProvider>,
-        );
-        const trigger = page.getByTestId('theme-toggle').locator('button');
-
-        await trigger.click();
-        await page.getByTestId('theme-option-dark').click();
-
-        await expect(page.locator('html')).toHaveClass(/dark/);
-        await expect(trigger).toHaveAttribute('aria-label', 'Theme: Dark');
-        await expect(trigger.locator('[data-theme-icon="dark"].lucide-moon')).toBeVisible();
-    });
-
-    test('should select a branded mode and report it on the trigger', async ({ mount, page }) => {
-        await mount(
-            <ThemeProvider branding={branded}>
-                <ThemeToggle />
-            </ThemeProvider>,
-        );
-        const trigger = page.getByTestId('theme-toggle').locator('button');
-
-        await trigger.click();
-        await page.getByTestId('theme-option-systemDark').click();
-
-        await expect(trigger).toHaveAttribute('aria-label', 'Theme: System Dark');
-        await expect(page.locator('html')).toHaveClass(/dark/);
-    });
-
     /**
-     * Arrow and typeahead navigation *inside* an open Radix menu does not move focus under Playwright CT - bare
-     * `DropdownMenu` behaves the same way as this component and as the shared `Dropdown`, so it is an artefact of the
-     * environment rather than something to pin here. What is asserted is the part that does work and is the actual
-     * accessibility contract: the trigger opens by keyboard, focus enters the menu, the active mode stays identified
-     * by `aria-checked` wherever focus lands, Enter activates the focused option and Escape dismisses without
-     * changing anything.
+     * On a branded instance the control starts on the operator's default rather than on System, because that is what
+     * is actually being rendered. The OS is set to the opposite so the label can only be Dark if the operator default
+     * won, not because the OS agreed with it.
      */
-    test('should open by keyboard with focus in the menu', async ({ mount, page }) => {
+    test('should start on the operator default and cycle on from there', async ({ mount, page }) => {
         await page.emulateMedia({ colorScheme: 'light' });
         await mount(
             <ThemeProvider branding={branded}>
                 <ThemeToggle />
             </ThemeProvider>,
         );
-        const trigger = page.getByTestId('theme-toggle').locator('button');
+        const toggle = page.getByTestId('theme-toggle');
 
-        await trigger.focus();
-        await page.keyboard.press('Enter');
+        await expect(toggle).toHaveAttribute('aria-label', 'Theme: Dark. Switch to System.');
+        await expect(page.locator('html')).toHaveClass(/dark/);
 
-        // Located by CSS, not by role: while the menu is open Radix marks the rest of the page aria-hidden, which
-        // takes the trigger out of the accessibility tree and with it any getByRole locator.
-        await expect(trigger).toHaveAttribute('aria-expanded', 'true');
-        // Opening focuses the first option rather than the checked one, which is Radix's behaviour, not a choice made
-        // here. What matters for a screen reader is that focus enters the menu and the active mode is marked.
-        await expect(page.getByTestId('theme-option-light')).toBeFocused();
-        await expect(page.getByTestId('theme-option-systemLight')).toHaveAttribute('aria-checked', 'true');
-    });
-
-    test('should activate the focused option with Enter', async ({ mount, page }) => {
-        // Start dark, so the option Radix focuses on open - the first one, Light - is not the mode already in force
-        // and the assertions below can only hold if Enter actually activated it.
-        await page.emulateMedia({ colorScheme: 'dark' });
-        await mount(
-            <ThemeProvider branding={unbranded}>
-                <ThemeToggle />
-            </ThemeProvider>,
-        );
-        const trigger = page.getByTestId('theme-toggle').locator('button');
-        await expect(trigger).toHaveAttribute('aria-label', 'Theme: Dark');
-
-        await trigger.focus();
-        await page.keyboard.press('Enter');
-        await expect(page.getByTestId('theme-option-light')).toBeFocused();
-        await page.keyboard.press('Enter');
-
-        await expect(trigger).toHaveAttribute('aria-expanded', 'false');
-        await expect(trigger).toHaveAttribute('aria-label', 'Theme: Light');
-        await expect(page.locator('html')).not.toHaveClass(/dark/);
-    });
-
-    test('should dismiss with Escape without changing the theme', async ({ mount, page }) => {
-        await page.emulateMedia({ colorScheme: 'light' });
-        await mount(
-            <ThemeProvider branding={unbranded}>
-                <ThemeToggle />
-            </ThemeProvider>,
-        );
-        const trigger = page.getByTestId('theme-toggle').locator('button');
-
-        await trigger.click();
-        await expect(page.getByTestId('theme-option-dark')).toBeVisible();
-        await page.keyboard.press('Escape');
-
-        await expect(trigger).toHaveAttribute('aria-expanded', 'false');
-        await expect(trigger).toHaveAttribute('aria-label', 'Theme: Light');
+        await toggle.click();
+        await expect(toggle).toHaveAttribute('aria-label', 'Theme: System. Switch to Light.');
+        // System now follows the OS, which is light, so the operator default is genuinely out of the way.
         await expect(page.locator('html')).not.toHaveClass(/dark/);
     });
 });

--- a/src/components/ThemeToggle/ThemeToggle.spec.tsx
+++ b/src/components/ThemeToggle/ThemeToggle.spec.tsx
@@ -21,6 +21,26 @@ test.describe('ThemeToggle', () => {
         await expect(trigger.locator('[data-theme-icon="light"].lucide-sun')).toBeVisible();
     });
 
+    test('should show a keyboard focus indicator on the trigger', async ({ mount, page }) => {
+        await mount(
+            <ThemeProvider branding={unbranded}>
+                <ThemeToggle />
+            </ThemeProvider>,
+        );
+        const trigger = page.getByTestId('theme-toggle').locator('button');
+        await trigger.focus();
+
+        await expect
+            .poll(async () =>
+                trigger.evaluate(
+                    (element) =>
+                        globalThis.getComputedStyle(element).outlineStyle !== 'none' ||
+                        globalThis.getComputedStyle(element).boxShadow !== 'none',
+                ),
+            )
+            .toBe(true);
+    });
+
     test('should offer only Light and Dark without branding', async ({ mount, page }) => {
         await mount(
             <ThemeProvider branding={unbranded}>

--- a/src/components/ThemeToggle/ThemeToggle.spec.tsx
+++ b/src/components/ThemeToggle/ThemeToggle.spec.tsx
@@ -1,74 +1,157 @@
 import { expect, test } from '../../../playwright/ct-test';
+import type { BrandingTheme } from 'types/branding';
 import ThemeProvider from 'components/ThemeProvider';
 import ThemeToggle from './index';
 
+const branded = { configured: true, defaultTheme: 'light' as BrandingTheme };
+const unbranded = { configured: false };
+
 test.describe('ThemeToggle', () => {
-    test('should render with the system icon and label by default', async ({ mount, page }) => {
+    test('should show the current mode on the trigger', async ({ mount, page }) => {
+        await page.emulateMedia({ colorScheme: 'light' });
         await mount(
-            <ThemeProvider>
+            <ThemeProvider branding={unbranded}>
                 <ThemeToggle />
             </ThemeProvider>,
         );
-        const toggle = page.getByTestId('theme-toggle');
+        const trigger = page.getByTestId('theme-toggle').locator('button');
 
-        await expect(toggle).toBeVisible();
-        await expect(toggle).toHaveAttribute('aria-label', 'Theme: System. Switch to Light.');
-        await expect(toggle.locator('[data-theme-icon="system"].lucide-monitor')).toBeVisible();
+        await expect(trigger).toBeVisible();
+        await expect(trigger).toHaveAttribute('aria-label', 'Theme: Light');
+        await expect(trigger.locator('[data-theme-icon="light"].lucide-sun')).toBeVisible();
     });
 
-    test('should advance to light on the first click', async ({ mount, page }) => {
+    test('should offer only Light and Dark without branding', async ({ mount, page }) => {
         await mount(
-            <ThemeProvider>
+            <ThemeProvider branding={unbranded}>
                 <ThemeToggle />
             </ThemeProvider>,
         );
-        const toggle = page.getByTestId('theme-toggle');
+        await page.getByTestId('theme-toggle').locator('button').click();
 
-        await toggle.click();
-        await expect(toggle).toHaveAttribute('aria-label', 'Theme: Light. Switch to Dark.');
-        await expect(toggle.locator('[data-theme-icon="light"].lucide-sun')).toBeVisible();
-        await expect(page.locator('html')).not.toHaveClass(/dark/);
+        await expect(page.getByTestId('theme-option-light')).toBeVisible();
+        await expect(page.getByTestId('theme-option-dark')).toBeVisible();
+        await expect(page.getByTestId('theme-option-systemLight')).toHaveCount(0);
+        await expect(page.getByTestId('theme-option-systemDark')).toHaveCount(0);
     });
 
-    test('should advance to dark on the second click and darken the document', async ({ mount, page }) => {
+    test('should offer all four modes once branding is configured', async ({ mount, page }) => {
         await mount(
-            <ThemeProvider>
+            <ThemeProvider branding={branded}>
                 <ThemeToggle />
             </ThemeProvider>,
         );
-        const toggle = page.getByTestId('theme-toggle');
+        await page.getByTestId('theme-toggle').locator('button').click();
 
-        await toggle.click();
-        await toggle.click();
-        await expect(toggle).toHaveAttribute('aria-label', 'Theme: Dark. Switch to System.');
-        await expect(toggle.locator('[data-theme-icon="dark"].lucide-moon')).toBeVisible();
+        await expect(page.getByRole('menuitemradio')).toHaveCount(4);
+        await expect(page.getByTestId('theme-option-systemLight')).toBeVisible();
+        await expect(page.getByTestId('theme-option-systemDark')).toBeVisible();
+    });
+
+    test('should mark the active mode', async ({ mount, page }) => {
+        await mount(
+            <ThemeProvider branding={branded}>
+                <ThemeToggle />
+            </ThemeProvider>,
+        );
+        await page.getByTestId('theme-toggle').locator('button').click();
+
+        await expect(page.getByTestId('theme-option-systemLight')).toHaveAttribute('aria-checked', 'true');
+        await expect(page.getByTestId('theme-option-dark')).toHaveAttribute('aria-checked', 'false');
+    });
+
+    test('should apply the mode the user selects', async ({ mount, page }) => {
+        await mount(
+            <ThemeProvider branding={unbranded}>
+                <ThemeToggle />
+            </ThemeProvider>,
+        );
+        const trigger = page.getByTestId('theme-toggle').locator('button');
+
+        await trigger.click();
+        await page.getByTestId('theme-option-dark').click();
+
+        await expect(page.locator('html')).toHaveClass(/dark/);
+        await expect(trigger).toHaveAttribute('aria-label', 'Theme: Dark');
+        await expect(trigger.locator('[data-theme-icon="dark"].lucide-moon')).toBeVisible();
+    });
+
+    test('should select a branded mode and report it on the trigger', async ({ mount, page }) => {
+        await mount(
+            <ThemeProvider branding={branded}>
+                <ThemeToggle />
+            </ThemeProvider>,
+        );
+        const trigger = page.getByTestId('theme-toggle').locator('button');
+
+        await trigger.click();
+        await page.getByTestId('theme-option-systemDark').click();
+
+        await expect(trigger).toHaveAttribute('aria-label', 'Theme: System Dark');
         await expect(page.locator('html')).toHaveClass(/dark/);
     });
 
-    test('should return to system on the third click', async ({ mount, page }) => {
+    /**
+     * Arrow and typeahead navigation *inside* an open Radix menu does not move focus under Playwright CT - bare
+     * `DropdownMenu` behaves the same way as this component and as the shared `Dropdown`, so it is an artefact of the
+     * environment rather than something to pin here. What is asserted is the part that does work and is the actual
+     * accessibility contract: the trigger opens by keyboard, focus lands on the active option, Enter activates it and
+     * Escape dismisses without changing anything.
+     */
+    test('should open by keyboard with focus in the menu', async ({ mount, page }) => {
+        await page.emulateMedia({ colorScheme: 'light' });
         await mount(
-            <ThemeProvider>
+            <ThemeProvider branding={branded}>
                 <ThemeToggle />
             </ThemeProvider>,
         );
-        const toggle = page.getByTestId('theme-toggle');
+        const trigger = page.getByTestId('theme-toggle').locator('button');
 
-        await toggle.click();
-        await toggle.click();
-        await toggle.click();
-        await expect(toggle).toHaveAttribute('aria-label', 'Theme: System. Switch to Light.');
+        await trigger.focus();
+        await page.keyboard.press('Enter');
+
+        // Located by CSS, not by role: while the menu is open Radix marks the rest of the page aria-hidden, which
+        // takes the trigger out of the accessibility tree and with it any getByRole locator.
+        await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+        // Opening focuses the first option rather than the checked one, which is Radix's behaviour, not a choice made
+        // here. What matters for a screen reader is that focus enters the menu and the active mode is marked.
+        await expect(page.getByTestId('theme-option-light')).toBeFocused();
+        await expect(page.getByTestId('theme-option-systemLight')).toHaveAttribute('aria-checked', 'true');
     });
 
-    test('should be reachable and operable by keyboard', async ({ mount, page }) => {
+    test('should activate the focused option with Enter', async ({ mount, page }) => {
+        await page.emulateMedia({ colorScheme: 'light' });
         await mount(
-            <ThemeProvider>
+            <ThemeProvider branding={unbranded}>
                 <ThemeToggle />
             </ThemeProvider>,
         );
-        const toggle = page.getByTestId('theme-toggle');
+        const trigger = page.getByTestId('theme-toggle').locator('button');
 
-        await toggle.focus();
+        await trigger.focus();
         await page.keyboard.press('Enter');
-        await expect(toggle).toHaveAttribute('aria-label', 'Theme: Light. Switch to Dark.');
+        await expect(page.getByTestId('theme-option-light')).toBeFocused();
+        await page.keyboard.press('Enter');
+
+        await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+        await expect(trigger).toHaveAttribute('aria-label', 'Theme: Light');
+    });
+
+    test('should dismiss with Escape without changing the theme', async ({ mount, page }) => {
+        await page.emulateMedia({ colorScheme: 'light' });
+        await mount(
+            <ThemeProvider branding={unbranded}>
+                <ThemeToggle />
+            </ThemeProvider>,
+        );
+        const trigger = page.getByTestId('theme-toggle').locator('button');
+
+        await trigger.click();
+        await expect(page.getByTestId('theme-option-dark')).toBeVisible();
+        await page.keyboard.press('Escape');
+
+        await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+        await expect(trigger).toHaveAttribute('aria-label', 'Theme: Light');
+        await expect(page.locator('html')).not.toHaveClass(/dark/);
     });
 });

--- a/src/components/ThemeToggle/ThemeToggle.spec.tsx
+++ b/src/components/ThemeToggle/ThemeToggle.spec.tsx
@@ -115,8 +115,9 @@ test.describe('ThemeToggle', () => {
      * Arrow and typeahead navigation *inside* an open Radix menu does not move focus under Playwright CT - bare
      * `DropdownMenu` behaves the same way as this component and as the shared `Dropdown`, so it is an artefact of the
      * environment rather than something to pin here. What is asserted is the part that does work and is the actual
-     * accessibility contract: the trigger opens by keyboard, focus lands on the active option, Enter activates it and
-     * Escape dismisses without changing anything.
+     * accessibility contract: the trigger opens by keyboard, focus enters the menu, the active mode stays identified
+     * by `aria-checked` wherever focus lands, Enter activates the focused option and Escape dismisses without
+     * changing anything.
      */
     test('should open by keyboard with focus in the menu', async ({ mount, page }) => {
         await page.emulateMedia({ colorScheme: 'light' });
@@ -140,13 +141,16 @@ test.describe('ThemeToggle', () => {
     });
 
     test('should activate the focused option with Enter', async ({ mount, page }) => {
-        await page.emulateMedia({ colorScheme: 'light' });
+        // Start dark, so the option Radix focuses on open - the first one, Light - is not the mode already in force
+        // and the assertions below can only hold if Enter actually activated it.
+        await page.emulateMedia({ colorScheme: 'dark' });
         await mount(
             <ThemeProvider branding={unbranded}>
                 <ThemeToggle />
             </ThemeProvider>,
         );
         const trigger = page.getByTestId('theme-toggle').locator('button');
+        await expect(trigger).toHaveAttribute('aria-label', 'Theme: Dark');
 
         await trigger.focus();
         await page.keyboard.press('Enter');
@@ -155,6 +159,7 @@ test.describe('ThemeToggle', () => {
 
         await expect(trigger).toHaveAttribute('aria-expanded', 'false');
         await expect(trigger).toHaveAttribute('aria-label', 'Theme: Light');
+        await expect(page.locator('html')).not.toHaveClass(/dark/);
     });
 
     test('should dismiss with Escape without changing the theme', async ({ mount, page }) => {

--- a/src/components/ThemeToggle/index.tsx
+++ b/src/components/ThemeToggle/index.tsx
@@ -1,68 +1,39 @@
-import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
-import { Check, Moon, MoonStar, Sun, SunMedium } from 'lucide-react';
-import Dropdown from 'components/Dropdown';
+import Tooltip from 'components/Tooltip';
+import { Monitor, Moon, Sun } from 'lucide-react';
 import { useTheme } from 'components/ThemeProvider';
-import { isThemeMode, type ThemeMode } from 'utils/theme';
+import { nextMode, type ThemeMode } from 'utils/theme';
 
-const ICONS: Record<ThemeMode, typeof Sun> = {
+const ICONS: Record<ThemeMode, typeof Monitor> = {
+    system: Monitor,
     light: Sun,
     dark: Moon,
-    systemLight: SunMedium,
-    systemDark: MoonStar,
 };
 
 const LABELS: Record<ThemeMode, string> = {
+    system: 'System',
     light: 'Light',
     dark: 'Dark',
-    systemLight: 'System Light',
-    systemDark: 'System Dark',
 };
 
 function ThemeToggle() {
-    const { mode, setMode, modes } = useTheme();
+    const { mode, cycleMode } = useTheme();
 
     const Icon = ICONS[mode];
+    const current = LABELS[mode];
+    const upcoming = LABELS[nextMode(mode)];
 
     return (
-        <div data-testid="theme-toggle">
-            <Dropdown
-                title={<Icon size={24} data-theme-icon={mode} aria-hidden="true" />}
-                ariaLabel={`Theme: ${LABELS[mode]}`}
-                btnStyle="transparent"
-                hideArrow
-                className="text-content-on-brand"
-                menuClassName="min-w-48"
-                menu={
-                    <DropdownMenu.RadioGroup
-                        value={mode}
-                        onValueChange={(value) => {
-                            if (isThemeMode(value)) {
-                                setMode(value);
-                            }
-                        }}
-                    >
-                        {modes.map((option) => {
-                            const OptionIcon = ICONS[option];
-
-                            return (
-                                <DropdownMenu.RadioItem
-                                    key={option}
-                                    value={option}
-                                    data-testid={`theme-option-${option}`}
-                                    className="flex items-center gap-x-3 py-2 px-3 w-full text-left rounded-lg text-sm text-content hover:bg-surface-hover focus:outline-hidden focus:bg-surface-hover cursor-pointer"
-                                >
-                                    <OptionIcon size={16} aria-hidden="true" />
-                                    <span className="grow">{LABELS[option]}</span>
-                                    <DropdownMenu.ItemIndicator>
-                                        <Check size={16} className="text-brand" aria-hidden="true" />
-                                    </DropdownMenu.ItemIndicator>
-                                </DropdownMenu.RadioItem>
-                            );
-                        })}
-                    </DropdownMenu.RadioGroup>
-                }
-            />
-        </div>
+        <Tooltip content={`Theme: ${current}`}>
+            <button
+                type="button"
+                onClick={cycleMode}
+                aria-label={`Theme: ${current}. Switch to ${upcoming}.`}
+                data-testid="theme-toggle"
+                className="p-2 inline-flex items-center rounded-lg text-content-on-brand hover:bg-white/10 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-white"
+            >
+                <Icon size={24} data-theme-icon={mode} aria-hidden="true" />
+            </button>
+        </Tooltip>
     );
 }
 

--- a/src/components/ThemeToggle/index.tsx
+++ b/src/components/ThemeToggle/index.tsx
@@ -1,39 +1,68 @@
-import Tooltip from 'components/Tooltip';
-import { Monitor, Moon, Sun } from 'lucide-react';
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
+import { Check, Moon, MoonStar, Sun, SunMedium } from 'lucide-react';
+import Dropdown from 'components/Dropdown';
 import { useTheme } from 'components/ThemeProvider';
-import { nextMode, type ThemeMode } from 'utils/theme';
+import { isThemeMode, type ThemeMode } from 'utils/theme';
 
-const ICONS: Record<ThemeMode, typeof Monitor> = {
-    system: Monitor,
+const ICONS: Record<ThemeMode, typeof Sun> = {
     light: Sun,
     dark: Moon,
+    systemLight: SunMedium,
+    systemDark: MoonStar,
 };
 
 const LABELS: Record<ThemeMode, string> = {
-    system: 'System',
     light: 'Light',
     dark: 'Dark',
+    systemLight: 'System Light',
+    systemDark: 'System Dark',
 };
 
 function ThemeToggle() {
-    const { mode, cycleMode } = useTheme();
+    const { mode, setMode, modes } = useTheme();
 
     const Icon = ICONS[mode];
-    const current = LABELS[mode];
-    const upcoming = LABELS[nextMode(mode)];
 
     return (
-        <Tooltip content={`Theme: ${current}`}>
-            <button
-                type="button"
-                onClick={cycleMode}
-                aria-label={`Theme: ${current}. Switch to ${upcoming}.`}
-                data-testid="theme-toggle"
-                className="p-2 inline-flex items-center rounded-lg text-content-on-brand hover:bg-white/10 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-white"
-            >
-                <Icon size={24} data-theme-icon={mode} aria-hidden="true" />
-            </button>
-        </Tooltip>
+        <div data-testid="theme-toggle">
+            <Dropdown
+                title={<Icon size={24} data-theme-icon={mode} aria-hidden="true" />}
+                ariaLabel={`Theme: ${LABELS[mode]}`}
+                btnStyle="transparent"
+                hideArrow
+                className="text-content-on-brand"
+                menuClassName="min-w-48"
+                menu={
+                    <DropdownMenu.RadioGroup
+                        value={mode}
+                        onValueChange={(value) => {
+                            if (isThemeMode(value)) {
+                                setMode(value);
+                            }
+                        }}
+                    >
+                        {modes.map((option) => {
+                            const OptionIcon = ICONS[option];
+
+                            return (
+                                <DropdownMenu.RadioItem
+                                    key={option}
+                                    value={option}
+                                    data-testid={`theme-option-${option}`}
+                                    className="flex items-center gap-x-3 py-2 px-3 w-full text-left rounded-lg text-sm text-content hover:bg-surface-hover focus:outline-hidden focus:bg-surface-hover cursor-pointer"
+                                >
+                                    <OptionIcon size={16} aria-hidden="true" />
+                                    <span className="grow">{LABELS[option]}</span>
+                                    <DropdownMenu.ItemIndicator>
+                                        <Check size={16} className="text-brand" aria-hidden="true" />
+                                    </DropdownMenu.ItemIndicator>
+                                </DropdownMenu.RadioItem>
+                            );
+                        })}
+                    </DropdownMenu.RadioGroup>
+                }
+            />
+        </div>
     );
 }
 

--- a/src/ducks/branding.spec.ts
+++ b/src/ducks/branding.spec.ts
@@ -73,6 +73,20 @@ describe('branding slice', () => {
             expect(state.publicBranding?.configured).toBe(false);
             expect(state.error).toBe('offline');
         });
+
+        test('getPublicBrandingFailure records that the default is a fallback and not an answer', () => {
+            const state = reducer({ ...initialState }, actions.getPublicBrandingFailure({ error: 'offline' }));
+
+            expect(state.publicBrandingReadFailed).toBe(true);
+        });
+
+        test('getPublicBrandingSuccess clears the failure recorded by an earlier read', () => {
+            const branding = publicBranding({ configured: true });
+
+            const state = reducer({ ...initialState, publicBrandingReadFailed: true }, actions.getPublicBrandingSuccess({ branding }));
+
+            expect(state.publicBrandingReadFailed).toBe(false);
+        });
     });
 
     describe('updating', () => {
@@ -171,6 +185,7 @@ describe('branding slice', () => {
 
             expect(selectors.branding(store)).toEqual(populated.branding);
             expect(selectors.publicBranding(store)).toEqual(populated.publicBranding);
+            expect(selectors.publicBrandingReadFailed(store)).toBe(populated.publicBrandingReadFailed);
             expect(selectors.error(store)).toBe('stale');
             expect(selectors.isFetchingBranding(store)).toBe(false);
             expect(selectors.isFetchingPublicBranding(store)).toBe(false);
@@ -184,6 +199,7 @@ describe('branding slice', () => {
         test('tolerate the slice being absent from the store', () => {
             expect(selectors.branding({} as never)).toBeUndefined();
             expect(selectors.isFetchingBranding({} as never)).toBeUndefined();
+            expect(selectors.publicBrandingReadFailed({} as never)).toBe(false);
         });
     });
 });

--- a/src/ducks/branding.ts
+++ b/src/ducks/branding.ts
@@ -25,6 +25,12 @@ export type State = {
     /** The subset an unauthenticated caller may read, used by the login page before there is any session. */
     publicBranding?: PublicBrandingModel;
 
+    /**
+     * Whether the last anonymous read failed. Set because a failure still settles `publicBranding` on the platform
+     * default, which a consumer cannot otherwise tell apart from an instance that genuinely has no branding.
+     */
+    publicBrandingReadFailed: boolean;
+
     isFetchingBranding: boolean;
     isFetchingPublicBranding: boolean;
     isUpdatingBranding: boolean;
@@ -36,6 +42,7 @@ export type State = {
 };
 
 export const initialState: State = {
+    publicBrandingReadFailed: false,
     isFetchingBranding: false,
     isFetchingPublicBranding: false,
     isUpdatingBranding: false,
@@ -76,6 +83,7 @@ export const slice = createSlice({
 
         getPublicBrandingSuccess: (state, action: PayloadAction<{ branding: PublicBrandingModel }>) => {
             state.publicBranding = action.payload.branding;
+            state.publicBrandingReadFailed = false;
             state.isFetchingPublicBranding = false;
         },
 
@@ -85,6 +93,7 @@ export const slice = createSlice({
          */
         getPublicBrandingFailure: (state, action: PayloadAction<{ error: string | undefined }>) => {
             state.publicBranding = platformDefaultBranding;
+            state.publicBrandingReadFailed = true;
             state.isFetchingPublicBranding = false;
             state.error = action.payload.error;
         },
@@ -138,6 +147,7 @@ const state = (reduxStore: AppState): State => reduxStore?.[slice.name];
 
 const branding = createSelector(state, (state) => state?.branding);
 const publicBranding = createSelector(state, (state) => state?.publicBranding);
+const publicBrandingReadFailed = createSelector(state, (state) => state?.publicBrandingReadFailed ?? false);
 
 const isFetchingBranding = createSelector(state, (state) => state?.isFetchingBranding);
 const isFetchingPublicBranding = createSelector(state, (state) => state?.isFetchingPublicBranding);
@@ -151,6 +161,7 @@ export const selectors = {
     state,
     branding,
     publicBranding,
+    publicBrandingReadFailed,
 
     isFetchingBranding,
     isFetchingPublicBranding,

--- a/src/utils/theme.spec.ts
+++ b/src/utils/theme.spec.ts
@@ -1,13 +1,23 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { BrandingTheme } from 'types/branding';
 import {
     applyTheme,
+    availableModes,
+    brandedMode,
     DARK_SCHEME_QUERY,
+    initialMode,
+    isBrandedMode,
+    isResolvedTheme,
     isThemeMode,
-    nextMode,
+    OPERATOR_DEFAULT_STORAGE_KEY,
+    operatorDefaultTheme,
+    platformMode,
     prefersDarkScheme,
     readStoredMode,
+    readStoredOperatorDefault,
     resolveTheme,
     storeMode,
+    storeOperatorDefault,
     THEME_STORAGE_KEY,
 } from './theme';
 
@@ -32,31 +42,74 @@ describe('theme', () => {
     });
 
     describe('isThemeMode', () => {
-        test.each(['system', 'light', 'dark'])('should accept %s', (value) => {
+        test.each(['light', 'dark', 'systemLight', 'systemDark'])('should accept %s', (value) => {
             expect(isThemeMode(value)).toBe(true);
         });
 
-        test.each([null, undefined, 42, 'DARK', 'auto', ''])('should reject %s', (value) => {
+        test.each([null, undefined, 42, 'DARK', 'system', 'auto', ''])('should reject %s', (value) => {
             expect(isThemeMode(value)).toBe(false);
         });
     });
 
+    describe('isResolvedTheme', () => {
+        test.each(['light', 'dark'])('should accept %s', (value) => {
+            expect(isResolvedTheme(value)).toBe(true);
+        });
+
+        test.each([null, undefined, 'systemLight', 'systemDark', ''])('should reject %s', (value) => {
+            expect(isResolvedTheme(value)).toBe(false);
+        });
+    });
+
+    describe('isBrandedMode', () => {
+        test.each([
+            ['light', false],
+            ['dark', false],
+            ['systemLight', true],
+            ['systemDark', true],
+        ] as const)('should report %s as %s', (mode, expected) => {
+            expect(isBrandedMode(mode)).toBe(expected);
+        });
+    });
+
+    describe('brandedMode and platformMode', () => {
+        test('should map a resolved theme onto its branded composition', () => {
+            expect(brandedMode('light')).toBe('systemLight');
+            expect(brandedMode('dark')).toBe('systemDark');
+        });
+
+        test('should fall a branded mode back to the platform mode rendering the same theme', () => {
+            expect(platformMode('systemLight')).toBe('light');
+            expect(platformMode('systemDark')).toBe('dark');
+        });
+
+        test('should leave a platform mode alone', () => {
+            expect(platformMode('light')).toBe('light');
+            expect(platformMode('dark')).toBe('dark');
+        });
+    });
+
     describe('readStoredMode', () => {
-        test('should default to system when nothing is stored', () => {
-            expect(readStoredMode()).toBe('system');
+        test('should report no preference when nothing is stored', () => {
+            expect(readStoredMode()).toBeUndefined();
         });
 
         test('should return a valid stored mode', () => {
-            localStorage.setItem(THEME_STORAGE_KEY, 'dark');
-            expect(readStoredMode()).toBe('dark');
+            localStorage.setItem(THEME_STORAGE_KEY, 'systemDark');
+            expect(readStoredMode()).toBe('systemDark');
         });
 
-        test('should fall back to system for a corrupt stored value', () => {
+        test('should report no preference for a corrupt stored value', () => {
             localStorage.setItem(THEME_STORAGE_KEY, 'chartreuse');
-            expect(readStoredMode()).toBe('system');
+            expect(readStoredMode()).toBeUndefined();
         });
 
-        test('should fall back to system when storage throws', () => {
+        test('should report no preference for a mode retired with the three-mode model', () => {
+            localStorage.setItem(THEME_STORAGE_KEY, 'system');
+            expect(readStoredMode()).toBeUndefined();
+        });
+
+        test('should report no preference when storage throws', () => {
             // Stub the global rather than Storage.prototype: happy-dom wraps each Storage instance
             // in a Proxy that caches methods onto the instance on first access, so a prototype spy
             // installed after any earlier call never fires and the catch path is never reached.
@@ -65,15 +118,15 @@ describe('theme', () => {
             });
             vi.stubGlobal('localStorage', { getItem });
 
-            expect(readStoredMode()).toBe('system');
+            expect(readStoredMode()).toBeUndefined();
             expect(getItem).toHaveBeenCalledWith(THEME_STORAGE_KEY);
         });
     });
 
     describe('storeMode', () => {
         test('should persist the mode', () => {
-            storeMode('light');
-            expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('light');
+            storeMode('systemLight');
+            expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('systemLight');
         });
 
         test('should not throw when storage is unavailable', () => {
@@ -84,6 +137,69 @@ describe('theme', () => {
 
             expect(() => storeMode('dark')).not.toThrow();
             expect(setItem).toHaveBeenCalledWith(THEME_STORAGE_KEY, 'dark');
+        });
+    });
+
+    describe('readStoredOperatorDefault', () => {
+        test('should report nothing cached by default', () => {
+            expect(readStoredOperatorDefault()).toBeUndefined();
+        });
+
+        test('should return a valid cached default', () => {
+            localStorage.setItem(OPERATOR_DEFAULT_STORAGE_KEY, 'dark');
+            expect(readStoredOperatorDefault()).toBe('dark');
+        });
+
+        test('should reject a branded mode, which is not a resolved theme', () => {
+            localStorage.setItem(OPERATOR_DEFAULT_STORAGE_KEY, 'systemDark');
+            expect(readStoredOperatorDefault()).toBeUndefined();
+        });
+
+        test('should report nothing when storage throws', () => {
+            vi.stubGlobal('localStorage', {
+                getItem: vi.fn(() => {
+                    throw new Error('storage disabled');
+                }),
+            });
+
+            expect(readStoredOperatorDefault()).toBeUndefined();
+        });
+    });
+
+    describe('storeOperatorDefault', () => {
+        test('should cache the operator default', () => {
+            storeOperatorDefault('dark');
+            expect(localStorage.getItem(OPERATOR_DEFAULT_STORAGE_KEY)).toBe('dark');
+        });
+
+        test('should clear the cache when the operator has no default', () => {
+            localStorage.setItem(OPERATOR_DEFAULT_STORAGE_KEY, 'dark');
+            storeOperatorDefault(undefined);
+            expect(localStorage.getItem(OPERATOR_DEFAULT_STORAGE_KEY)).toBeNull();
+        });
+
+        test('should not throw when storage is unavailable', () => {
+            const setItem = vi.fn(() => {
+                throw new Error('storage disabled');
+            });
+            const removeItem = vi.fn(() => {
+                throw new Error('storage disabled');
+            });
+            vi.stubGlobal('localStorage', { setItem, removeItem });
+
+            expect(() => storeOperatorDefault('light')).not.toThrow();
+            expect(() => storeOperatorDefault(undefined)).not.toThrow();
+        });
+    });
+
+    describe('operatorDefaultTheme', () => {
+        test('should narrow the branding enum onto a resolved theme', () => {
+            expect(operatorDefaultTheme(BrandingTheme.Light)).toBe('light');
+            expect(operatorDefaultTheme(BrandingTheme.Dark)).toBe('dark');
+        });
+
+        test('should report no default when branding carries none', () => {
+            expect(operatorDefaultTheme(undefined)).toBeUndefined();
         });
     });
 
@@ -104,31 +220,49 @@ describe('theme', () => {
         });
     });
 
-    describe('resolveTheme', () => {
-        test.each([
-            ['light', true, 'light'],
-            ['light', false, 'light'],
-            ['dark', true, 'dark'],
-            ['dark', false, 'dark'],
-        ] as const)('should return %s regardless of the OS preference', (mode, prefersDark, expected) => {
-            expect(resolveTheme(mode, prefersDark)).toBe(expected);
+    describe('availableModes', () => {
+        test('should offer all four modes once branding is configured', () => {
+            expect(availableModes(true)).toEqual(['light', 'dark', 'systemLight', 'systemDark']);
         });
 
-        test('should follow the OS preference in system mode', () => {
-            expect(resolveTheme('system', true)).toBe('dark');
-            expect(resolveTheme('system', false)).toBe('light');
+        test('should offer only the platform modes without branding', () => {
+            expect(availableModes(false)).toEqual(['light', 'dark']);
         });
     });
 
-    describe('nextMode', () => {
-        test('should cycle system to light to dark and back to system', () => {
-            expect(nextMode('system')).toBe('light');
-            expect(nextMode('light')).toBe('dark');
-            expect(nextMode('dark')).toBe('system');
+    describe('initialMode', () => {
+        test.each([
+            // stored choice, operator default, OS prefers dark, expected
+            ['dark' as const, 'light' as const, false, 'dark'],
+            ['systemLight' as const, 'dark' as const, true, 'systemLight'],
+            ['light' as const, undefined, true, 'light'],
+        ])('should let the stored choice %s win over everything else', (stored, operator, prefersDark, expected) => {
+            expect(initialMode(stored, operator, prefersDark)).toBe(expected);
         });
 
-        test('should return to the starting mode after three steps', () => {
-            expect(nextMode(nextMode(nextMode('system')))).toBe('system');
+        test.each([
+            ['light' as const, true, 'systemLight'],
+            ['dark' as const, false, 'systemDark'],
+        ])('should apply the operator default %s over the OS preference', (operator, prefersDark, expected) => {
+            expect(initialMode(undefined, operator, prefersDark)).toBe(expected);
+        });
+
+        test.each([
+            [true, 'dark'],
+            [false, 'light'],
+        ])('should fall back to the OS preference when nothing else is set', (prefersDark, expected) => {
+            expect(initialMode(undefined, undefined, prefersDark)).toBe(expected);
+        });
+    });
+
+    describe('resolveTheme', () => {
+        test.each([
+            ['light' as const, 'light'],
+            ['dark' as const, 'dark'],
+            ['systemLight' as const, 'light'],
+            ['systemDark' as const, 'dark'],
+        ])('should resolve %s to %s', (mode, expected) => {
+            expect(resolveTheme(mode)).toBe(expected);
         });
     });
 

--- a/src/utils/theme.spec.ts
+++ b/src/utils/theme.spec.ts
@@ -2,16 +2,13 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { BrandingTheme } from 'types/branding';
 import {
     applyTheme,
-    availableModes,
-    brandedMode,
     DARK_SCHEME_QUERY,
     initialMode,
-    isBrandedMode,
     isResolvedTheme,
     isThemeMode,
+    nextMode,
     OPERATOR_DEFAULT_STORAGE_KEY,
     operatorDefaultTheme,
-    platformMode,
     prefersDarkScheme,
     readStoredMode,
     readStoredOperatorDefault,
@@ -42,11 +39,11 @@ describe('theme', () => {
     });
 
     describe('isThemeMode', () => {
-        test.each(['light', 'dark', 'systemLight', 'systemDark'])('should accept %s', (value) => {
+        test.each(['system', 'light', 'dark'])('should accept %s', (value) => {
             expect(isThemeMode(value)).toBe(true);
         });
 
-        test.each([null, undefined, 42, 'DARK', 'system', 'auto', ''])('should reject %s', (value) => {
+        test.each([null, undefined, 42, 'DARK', 'systemLight', 'systemDark', 'auto', ''])('should reject %s', (value) => {
             expect(isThemeMode(value)).toBe(false);
         });
     });
@@ -56,36 +53,8 @@ describe('theme', () => {
             expect(isResolvedTheme(value)).toBe(true);
         });
 
-        test.each([null, undefined, 'systemLight', 'systemDark', ''])('should reject %s', (value) => {
+        test.each([null, undefined, 'system', ''])('should reject %s', (value) => {
             expect(isResolvedTheme(value)).toBe(false);
-        });
-    });
-
-    describe('isBrandedMode', () => {
-        test.each([
-            ['light', false],
-            ['dark', false],
-            ['systemLight', true],
-            ['systemDark', true],
-        ] as const)('should report %s as %s', (mode, expected) => {
-            expect(isBrandedMode(mode)).toBe(expected);
-        });
-    });
-
-    describe('brandedMode and platformMode', () => {
-        test('should map a resolved theme onto its branded composition', () => {
-            expect(brandedMode('light')).toBe('systemLight');
-            expect(brandedMode('dark')).toBe('systemDark');
-        });
-
-        test('should fall a branded mode back to the platform mode rendering the same theme', () => {
-            expect(platformMode('systemLight')).toBe('light');
-            expect(platformMode('systemDark')).toBe('dark');
-        });
-
-        test('should leave a platform mode alone', () => {
-            expect(platformMode('light')).toBe('light');
-            expect(platformMode('dark')).toBe('dark');
         });
     });
 
@@ -95,8 +64,8 @@ describe('theme', () => {
         });
 
         test('should return a valid stored mode', () => {
-            localStorage.setItem(THEME_STORAGE_KEY, 'systemDark');
-            expect(readStoredMode()).toBe('systemDark');
+            localStorage.setItem(THEME_STORAGE_KEY, 'system');
+            expect(readStoredMode()).toBe('system');
         });
 
         test('should report no preference for a corrupt stored value', () => {
@@ -104,8 +73,13 @@ describe('theme', () => {
             expect(readStoredMode()).toBeUndefined();
         });
 
-        test('should report no preference for a mode retired with the three-mode model', () => {
-            localStorage.setItem(THEME_STORAGE_KEY, 'system');
+        /**
+         * A browser that saw the four-mode build has one of these stored. Reading it as "no preference" is what lets
+         * the operator default, and then the OS, take over again rather than pinning the user to a mode that no
+         * longer exists.
+         */
+        test.each(['systemLight', 'systemDark'])('should report no preference for the retired mode %s', (retired) => {
+            localStorage.setItem(THEME_STORAGE_KEY, retired);
             expect(readStoredMode()).toBeUndefined();
         });
 
@@ -125,8 +99,8 @@ describe('theme', () => {
 
     describe('storeMode', () => {
         test('should persist the mode', () => {
-            storeMode('systemLight');
-            expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('systemLight');
+            storeMode('system');
+            expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('system');
         });
 
         test('should not throw when storage is unavailable', () => {
@@ -150,8 +124,8 @@ describe('theme', () => {
             expect(readStoredOperatorDefault()).toBe('dark');
         });
 
-        test('should reject a branded mode, which is not a resolved theme', () => {
-            localStorage.setItem(OPERATOR_DEFAULT_STORAGE_KEY, 'systemDark');
+        test('should reject system, which is a mode rather than a resolved theme', () => {
+            localStorage.setItem(OPERATOR_DEFAULT_STORAGE_KEY, 'system');
             expect(readStoredOperatorDefault()).toBeUndefined();
         });
 
@@ -220,49 +194,59 @@ describe('theme', () => {
         });
     });
 
-    describe('availableModes', () => {
-        test('should offer all four modes once branding is configured', () => {
-            expect(availableModes(true)).toEqual(['light', 'dark', 'systemLight', 'systemDark']);
-        });
-
-        test('should offer only the platform modes without branding', () => {
-            expect(availableModes(false)).toEqual(['light', 'dark']);
+    describe('nextMode', () => {
+        test('should cycle system, light, dark and back', () => {
+            expect(nextMode('system')).toBe('light');
+            expect(nextMode('light')).toBe('dark');
+            expect(nextMode('dark')).toBe('system');
         });
     });
 
     describe('initialMode', () => {
         test.each([
-            // stored choice, operator default, OS prefers dark, expected
-            ['dark' as const, 'light' as const, false, 'dark'],
-            ['systemLight' as const, 'dark' as const, true, 'systemLight'],
-            ['light' as const, undefined, true, 'light'],
-        ])('should let the stored choice %s win over everything else', (stored, operator, prefersDark, expected) => {
-            expect(initialMode(stored, operator, prefersDark)).toBe(expected);
+            // stored choice, operator default, expected
+            ['dark' as const, 'light' as const, 'dark'],
+            ['light' as const, 'dark' as const, 'light'],
+            ['light' as const, undefined, 'light'],
+        ])('should let the stored choice %s win over the operator default', (stored, operator, expected) => {
+            expect(initialMode(stored, operator)).toBe(expected);
+        });
+
+        /**
+         * The whole point of storing "no preference" rather than defaulting to `system`: a user who has actually
+         * chosen System must outrank the operator and follow their own OS again.
+         */
+        test('should let an explicit system choice outrank the operator default', () => {
+            expect(initialMode('system', 'dark')).toBe('system');
         });
 
         test.each([
-            ['light' as const, true, 'systemLight'],
-            ['dark' as const, false, 'systemDark'],
-        ])('should apply the operator default %s over the OS preference', (operator, prefersDark, expected) => {
-            expect(initialMode(undefined, operator, prefersDark)).toBe(expected);
+            ['light' as const, 'light'],
+            ['dark' as const, 'dark'],
+        ])('should apply the operator default %s when the user has not chosen', (operator, expected) => {
+            expect(initialMode(undefined, operator)).toBe(expected);
         });
 
-        test.each([
-            [true, 'dark'],
-            [false, 'light'],
-        ])('should fall back to the OS preference when nothing else is set', (prefersDark, expected) => {
-            expect(initialMode(undefined, undefined, prefersDark)).toBe(expected);
+        test('should fall back to system when neither a choice nor an operator default exists', () => {
+            expect(initialMode(undefined, undefined)).toBe('system');
         });
     });
 
     describe('resolveTheme', () => {
         test.each([
-            ['light' as const, 'light'],
-            ['dark' as const, 'dark'],
-            ['systemLight' as const, 'light'],
-            ['systemDark' as const, 'dark'],
-        ])('should resolve %s to %s', (mode, expected) => {
-            expect(resolveTheme(mode)).toBe(expected);
+            ['light' as const, false, 'light'],
+            ['light' as const, true, 'light'],
+            ['dark' as const, true, 'dark'],
+            ['dark' as const, false, 'dark'],
+        ])('should render the explicit mode %s regardless of the OS preference', (mode, prefersDark, expected) => {
+            expect(resolveTheme(mode, prefersDark)).toBe(expected);
+        });
+
+        test.each([
+            [true, 'dark'],
+            [false, 'light'],
+        ])('should resolve system from the OS preference', (prefersDark, expected) => {
+            expect(resolveTheme('system', prefersDark)).toBe(expected);
         });
     });
 

--- a/src/utils/theme.spec.ts
+++ b/src/utils/theme.spec.ts
@@ -74,9 +74,9 @@ describe('theme', () => {
         });
 
         /**
-         * A browser that saw the four-mode build has one of these stored. Reading it as "no preference" is what lets
-         * the operator default, and then the OS, take over again rather than pinning the user to a mode that no
-         * longer exists.
+         * A retired mode is not one of the three supported preferences. Reading it as "no preference" is what lets the
+         * operator default, and then the OS, take over again rather than pinning the user to a mode that no longer
+         * exists.
          */
         test.each(['systemLight', 'systemDark'])('should report no preference for the retired mode %s', (retired) => {
             localStorage.setItem(THEME_STORAGE_KEY, retired);

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -1,20 +1,32 @@
-/** What the user selected. `system` follows the operating system preference. */
-export type ThemeMode = 'system' | 'light' | 'dark';
+/**
+ * What the user selected. `light` and `dark` are the platform's own themes; `systemLight` and `systemDark` are the
+ * operator's branded theme in its light and dark composition, and are only offered once branding is configured.
+ */
+export type ThemeMode = 'light' | 'dark' | 'systemLight' | 'systemDark';
 
-/** What is actually rendered once `system` has been resolved. */
+/** What is actually rendered. Both compositions of a branded theme still resolve to one of these. */
 export type ResolvedTheme = 'light' | 'dark';
 
 export const THEME_STORAGE_KEY = 'theme-mode';
+
+/**
+ * The operator's default theme, cached from the last branding read. It is server-held, so without a cache the
+ * pre-paint script in index.html has nothing to apply and the first paint of every load would fall back to the
+ * operating system preference.
+ */
+export const OPERATOR_DEFAULT_STORAGE_KEY = 'theme-operator-default';
+
 export const DARK_SCHEME_QUERY = '(prefers-color-scheme: dark)';
-export const THEME_MODES: readonly ThemeMode[] = ['system', 'light', 'dark'];
 
-const DEFAULT_MODE: ThemeMode = 'system';
+export const PLATFORM_MODES: readonly ThemeMode[] = ['light', 'dark'];
+export const BRANDED_MODES: readonly ThemeMode[] = ['systemLight', 'systemDark'];
+export const THEME_MODES: readonly ThemeMode[] = [...PLATFORM_MODES, ...BRANDED_MODES];
 
-/** Order of the header toggle: system, then light, then dark, then back to system. */
-const NEXT_MODE: Record<ThemeMode, ThemeMode> = {
-    system: 'light',
-    light: 'dark',
-    dark: 'system',
+const RESOLVED: Record<ThemeMode, ResolvedTheme> = {
+    light: 'light',
+    dark: 'dark',
+    systemLight: 'light',
+    systemDark: 'dark',
 };
 
 /** Drives the browser UI colour on mobile. Matches --surface-raised in each theme. */
@@ -26,13 +38,27 @@ const THEME_COLOR: Record<ResolvedTheme, string> = {
 export const isThemeMode = (value: unknown): value is ThemeMode =>
     typeof value === 'string' && (THEME_MODES as readonly string[]).includes(value);
 
-/** Reads the persisted mode, tolerating corrupt values and storage being unavailable. */
-export const readStoredMode = (): ThemeMode => {
+export const isResolvedTheme = (value: unknown): value is ResolvedTheme => value === 'light' || value === 'dark';
+
+/** Whether the mode asks for the operator's branded theme rather than the platform's own. */
+export const isBrandedMode = (mode: ThemeMode): boolean => (BRANDED_MODES as readonly string[]).includes(mode);
+
+/** The branded composition matching a resolved theme. */
+export const brandedMode = (theme: ResolvedTheme): ThemeMode => (theme === 'dark' ? 'systemDark' : 'systemLight');
+
+/**
+ * The platform mode a branded one falls back to. Used when a stored branded choice outlives the branding it referred
+ * to: both resolve to the same theme, so this only makes the control report what is actually being rendered.
+ */
+export const platformMode = (mode: ThemeMode): ThemeMode => RESOLVED[mode];
+
+/** Reads the persisted mode. Absent, corrupt and unreadable all mean "the user has expressed no preference". */
+export const readStoredMode = (): ThemeMode | undefined => {
     try {
         const stored = globalThis.localStorage?.getItem(THEME_STORAGE_KEY);
-        return isThemeMode(stored) ? stored : DEFAULT_MODE;
+        return isThemeMode(stored) ? stored : undefined;
     } catch {
-        return DEFAULT_MODE;
+        return undefined;
     }
 };
 
@@ -46,17 +72,60 @@ export const storeMode = (mode: ThemeMode): void => {
     }
 };
 
+export const readStoredOperatorDefault = (): ResolvedTheme | undefined => {
+    try {
+        const stored = globalThis.localStorage?.getItem(OPERATOR_DEFAULT_STORAGE_KEY);
+        return isResolvedTheme(stored) ? stored : undefined;
+    } catch {
+        return undefined;
+    }
+};
+
+/** Caches the operator default for the next load's pre-paint. `undefined` clears it, so unbranding takes effect. */
+export const storeOperatorDefault = (theme: ResolvedTheme | undefined): void => {
+    try {
+        if (theme === undefined) {
+            globalThis.localStorage?.removeItem(OPERATOR_DEFAULT_STORAGE_KEY);
+        } else {
+            globalThis.localStorage?.setItem(OPERATOR_DEFAULT_STORAGE_KEY, theme);
+        }
+    } catch {
+        // As in storeMode: the cache is an optimisation for the next load, never required for this one.
+    }
+};
+
+/**
+ * Narrows the branding contract's theme onto what the runtime uses. Taking a plain string rather than the generated
+ * enum keeps this module off the OpenAPI barrel, which the Playwright runner cannot resolve from a spec file.
+ */
+export const operatorDefaultTheme = (theme: string | undefined): ResolvedTheme | undefined => (isResolvedTheme(theme) ? theme : undefined);
+
 export const prefersDarkScheme = (): boolean => globalThis.matchMedia?.(DARK_SCHEME_QUERY).matches ?? false;
 
-export const resolveTheme = (mode: ThemeMode, prefersDark: boolean): ResolvedTheme => {
-    if (mode !== 'system') {
-        return mode;
+/** The modes the control may offer. Without branding the two branded ones are indistinguishable from the platform's. */
+export const availableModes = (brandingConfigured: boolean): readonly ThemeMode[] => (brandingConfigured ? THEME_MODES : PLATFORM_MODES);
+
+/**
+ * The mode in force, in precedence order: the user's own stored choice, then the operator's default, then the
+ * operating system preference. The system preference is therefore consulted only when neither of the first two exists.
+ */
+export const initialMode = (
+    storedMode: ThemeMode | undefined,
+    operatorDefault: ResolvedTheme | undefined,
+    prefersDark: boolean,
+): ThemeMode => {
+    if (storedMode !== undefined) {
+        return storedMode;
+    }
+
+    if (operatorDefault !== undefined) {
+        return brandedMode(operatorDefault);
     }
 
     return prefersDark ? 'dark' : 'light';
 };
 
-export const nextMode = (mode: ThemeMode): ThemeMode => NEXT_MODE[mode];
+export const resolveTheme = (mode: ThemeMode): ResolvedTheme => RESOLVED[mode];
 
 /**
  * Applies the theme to the document. Setting colorScheme is what makes native scrollbars,

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -1,10 +1,13 @@
-/**
- * What the user selected. `light` and `dark` are the platform's own themes; `systemLight` and `systemDark` are the
- * operator's branded theme in its light and dark composition, and are only offered once branding is configured.
- */
-export type ThemeMode = 'light' | 'dark' | 'systemLight' | 'systemDark';
+/** What the user selected. `system` follows the operating system preference. */
+export type ThemeMode = 'system' | 'light' | 'dark';
 
-/** What is actually rendered. Both compositions of a branded theme still resolve to one of these. */
+/**
+ * What is actually rendered once `system` has been resolved.
+ *
+ * Branding does not add to this. When the operator has configured branding, these two are the branded light and dark
+ * compositions; when they have not, they are the platform's own. Which palette the class resolves to is decided in the
+ * stylesheet, so nothing here has to know whether the instance is branded.
+ */
 export type ResolvedTheme = 'light' | 'dark';
 
 export const THEME_STORAGE_KEY = 'theme-mode';
@@ -18,15 +21,13 @@ export const OPERATOR_DEFAULT_STORAGE_KEY = 'theme-operator-default';
 
 export const DARK_SCHEME_QUERY = '(prefers-color-scheme: dark)';
 
-export const PLATFORM_MODES: readonly ThemeMode[] = ['light', 'dark'];
-export const BRANDED_MODES: readonly ThemeMode[] = ['systemLight', 'systemDark'];
-export const THEME_MODES: readonly ThemeMode[] = [...PLATFORM_MODES, ...BRANDED_MODES];
+export const THEME_MODES: readonly ThemeMode[] = ['system', 'light', 'dark'];
 
-const RESOLVED: Record<ThemeMode, ResolvedTheme> = {
-    light: 'light',
-    dark: 'dark',
-    systemLight: 'light',
-    systemDark: 'dark',
+/** Order of the header toggle: system, then light, then dark, then back to system. */
+const NEXT_MODE: Record<ThemeMode, ThemeMode> = {
+    system: 'light',
+    light: 'dark',
+    dark: 'system',
 };
 
 /** Drives the browser UI colour on mobile. Matches --surface-raised in each theme. */
@@ -40,19 +41,10 @@ export const isThemeMode = (value: unknown): value is ThemeMode =>
 
 export const isResolvedTheme = (value: unknown): value is ResolvedTheme => value === 'light' || value === 'dark';
 
-/** Whether the mode asks for the operator's branded theme rather than the platform's own. */
-export const isBrandedMode = (mode: ThemeMode): boolean => (BRANDED_MODES as readonly string[]).includes(mode);
-
-/** The branded composition matching a resolved theme. */
-export const brandedMode = (theme: ResolvedTheme): ThemeMode => (theme === 'dark' ? 'systemDark' : 'systemLight');
-
 /**
- * The platform mode a branded one falls back to. Used when a stored branded choice outlives the branding it referred
- * to: both resolve to the same theme, so this only makes the control report what is actually being rendered.
+ * Reads the persisted mode. Absent, corrupt and unreadable all mean "the user has expressed no preference", which is
+ * deliberately not the same as having chosen `system`: only the former lets the operator's default apply.
  */
-export const platformMode = (mode: ThemeMode): ThemeMode => RESOLVED[mode];
-
-/** Reads the persisted mode. Absent, corrupt and unreadable all mean "the user has expressed no preference". */
 export const readStoredMode = (): ThemeMode | undefined => {
     try {
         const stored = globalThis.localStorage?.getItem(THEME_STORAGE_KEY);
@@ -102,30 +94,25 @@ export const operatorDefaultTheme = (theme: string | undefined): ResolvedTheme |
 
 export const prefersDarkScheme = (): boolean => globalThis.matchMedia?.(DARK_SCHEME_QUERY).matches ?? false;
 
-/** The modes the control may offer. Without branding the two branded ones are indistinguishable from the platform's. */
-export const availableModes = (brandingConfigured: boolean): readonly ThemeMode[] => (brandingConfigured ? THEME_MODES : PLATFORM_MODES);
-
 /**
- * The mode in force, in precedence order: the user's own stored choice, then the operator's default, then the
- * operating system preference. The system preference is therefore consulted only when neither of the first two exists.
+ * The mode in force, in precedence order: the user's own stored choice, then the operator's default, then `system`.
+ *
+ * The operating system preference is deliberately not consulted here - it belongs to resolving `system`, not to
+ * choosing the mode. So an operator default of `dark` puts the control on Dark rather than leaving it on System
+ * showing a light theme, and a user who then picks System outranks the operator and follows their OS again.
  */
-export const initialMode = (
-    storedMode: ThemeMode | undefined,
-    operatorDefault: ResolvedTheme | undefined,
-    prefersDark: boolean,
-): ThemeMode => {
-    if (storedMode !== undefined) {
-        return storedMode;
-    }
+export const initialMode = (storedMode: ThemeMode | undefined, operatorDefault: ResolvedTheme | undefined): ThemeMode =>
+    storedMode ?? operatorDefault ?? 'system';
 
-    if (operatorDefault !== undefined) {
-        return brandedMode(operatorDefault);
+export const resolveTheme = (mode: ThemeMode, prefersDark: boolean): ResolvedTheme => {
+    if (mode !== 'system') {
+        return mode;
     }
 
     return prefersDark ? 'dark' : 'light';
 };
 
-export const resolveTheme = (mode: ThemeMode): ResolvedTheme => RESOLVED[mode];
+export const nextMode = (mode: ThemeMode): ThemeMode => NEXT_MODE[mode];
 
 /**
  * Applies the theme to the document. Setting colorScheme is what makes native scrollbars,


### PR DESCRIPTION
Adds the operator's branded default theme as a step in theme resolution, and leaves the existing three-mode header toggle exactly as it was.

## Three modes, and branding is orthogonal to them

`ThemeMode` stays `system | light | dark`, and the control stays the single header icon cycling System → Light → Dark → System.

An earlier revision of this PR introduced `systemLight` and `systemDark` and a dropdown. That was wrong, and it was raised in review: it conflated two independent questions — *which theme to render* and *whose palette to render it in* — and let branding change the shape of the control. Nothing needed that. Which palette `light` and `dark` resolve to is decided in the stylesheet's token layer (#2039), so the theme runtime never has to know whether the instance is branded. On an unbranded instance the toggle switches the platform's own light and dark; on a branded one it switches the operator's. Same three modes either way.

Removed with it: the dropdown, `availableModes`, `isBrandedMode`, `brandedMode`, `platformMode`, and the `modes` context value. `ThemeProvider` now takes only `defaultTheme` off branding rather than `configured` as well.

## What is actually new

The operator's default theme, as a precedence step. Resolution is two functions, and keeping them separate is what makes the model behave:

- `initialMode()` picks the mode — the user's own stored choice, then the operator's default, then `system`.
- `resolveTheme()` renders it, consulting the OS preference only for `system`, where the `matchMedia` listener keeps it moving live.

So an operator default of `dark` puts the control on Dark rather than leaving it on System showing a light page, and a user who then picks System outranks the operator and follows their own OS again.

Two consequences worth naming, because both look like odd choices otherwise:

- `readStoredMode()` returns `undefined` rather than defaulting to `system`. "Never chose" has to stay distinguishable from "chose System", or the operator default could never apply at all.
- The chosen mode is persisted in `setMode`/`cycleMode`, not in an effect on `mode`. An effect would also fire for the operator default and the `system` fallback, which would silently pin the user to whatever the operator set.

`cycleMode` advances from whatever is in force, so on a branded instance the first click moves off the operator's default rather than off `system`. It stays in the functional form, closing over only the fallback, so two clicks in one batch cannot both read the same mode.

## Pre-paint

The operator default is server-held, so the pre-paint script in `index.html` cannot await it. It is cached in `localStorage` under `theme-operator-default`, written only from a live branding response — writing it from the cache would keep a stale default alive forever, and writing it before any response would clear a default the instance still has.

The inline script mirrors `initialMode()` then `resolveTheme()`, including that an explicit `system` choice returns to the OS preference rather than keeping the operator default. It duplicates that logic deliberately, because it runs before any module has loaded.

## Migration

`readStoredMode()` rejects `systemLight` and `systemDark`. A browser that ran the earlier revision of this branch has one of them stored; reading it as "no preference" lets the operator default and then the OS take over, rather than pinning the user to a mode that no longer exists. Pinned in both the unit and the component suite.

## Kept from review

Two things from the earlier revision are unrelated to the mode model and stay:

- The `focus-visible` ring on the shared `Dropdown` trigger. That was a real gap for every dropdown in the app, not just the theme one.
- `publicBrandingReadFailed` on the branding duck. A failed anonymous read still settles the slice on the platform default, which is indistinguishable from a live "not branded" answer; `ConnectedThemeProvider` withholds branding in that case so a transient network error cannot clear the cached operator default.

## Tests

56 unit tests over `utils/theme.ts`: the mode predicates, both storage paths including the throwing-storage branches, the retired-mode migration, `nextMode`, and `initialMode`/`resolveTheme` separately — including that an explicit System choice outranks the operator default.

21 component tests: the toggle's full cycle, its icons and labels, keyboard operation and focus indicator, and starting on the operator default; plus the provider's precedence order, live OS tracking on the `system` path, that the OS is ignored once a mode is chosen, that an unchosen mode is not persisted, the retired-mode fallback, cycling on from the operator default, and all four operator-default cache paths.

Closes OmniTrustILM/fe-administrator#2037