### PR TITLE
Add the saved-view tab strip with create, duplicate, rename and delete

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -32,6 +32,7 @@ import {
     GlobalMetadataApi,
     InfoApi,
     InternalNotificationApi,
+    ListViewApi,
     LocationManagementApi,
     NotificationProfileInventoryApi,
     ProxyManagementApi,
@@ -110,6 +111,7 @@ export interface ApiClients {
     settings: SettingsApi;
     branding: BrandingApi;
     comments: CommentsApi;
+    listViews: ListViewApi;
     scheduler: ScheduledJobsManagementApi;
     approvalProfiles: ApprovalProfileInventoryApi;
     approvals: ApprovalInventoryApi;
@@ -178,6 +180,7 @@ const factories: Partial<{ [K in ApiClientKey]: () => ApiClients[K] }> = {
     settings: () => new SettingsApi(configuration),
     branding: () => new BrandingApi(configuration),
     comments: () => new CommentsApi(configuration),
+    listViews: () => new ListViewApi(configuration),
     scheduler: () => new ScheduledJobsManagementApi(configuration),
     approvalProfiles: () => new ApprovalProfileInventoryApi(configuration),
     approvals: () => new ApprovalInventoryApi(configuration),

--- a/src/components/ViewTabs/NameViewDialog.tsx
+++ b/src/components/ViewTabs/NameViewDialog.tsx
@@ -1,0 +1,72 @@
+import Dialog from 'components/Dialog';
+import TextInput from 'components/TextInput';
+import { useEffect, useState } from 'react';
+
+type Props = Readonly<{
+    isOpen: boolean;
+    caption: string;
+    confirmLabel: string;
+    /** The name the field opens with: the current one when renaming, a suggestion when creating. */
+    initialName: string;
+    /** Names already taken for this resource, which the API rejects a duplicate of. */
+    takenNames: readonly string[];
+    isBusy: boolean;
+    onClose: () => void;
+    onSubmit: (name: string) => void;
+    dataTestId: string;
+}>;
+
+/** Names a view, whether it is being created, duplicated into or renamed. */
+export default function NameViewDialog({
+    isOpen,
+    caption,
+    confirmLabel,
+    initialName,
+    takenNames,
+    isBusy,
+    onClose,
+    onSubmit,
+    dataTestId,
+}: Props) {
+    const [name, setName] = useState(initialName);
+
+    // Seeded on each open rather than on every render, so typing is not overwritten by a re-render
+    // that carries the same suggestion.
+    useEffect(() => {
+        if (isOpen) setName(initialName);
+    }, [isOpen, initialName]);
+
+    const trimmed = name.trim();
+    const isTaken = trimmed !== initialName.trim() && takenNames.some((taken) => taken === trimmed);
+    const error = trimmed === '' ? 'A view needs a name.' : isTaken ? 'A view of this name already exists.' : undefined;
+
+    return (
+        <Dialog
+            isOpen={isOpen}
+            toggle={onClose}
+            caption={caption}
+            size="sm"
+            dataTestId={dataTestId}
+            body={
+                <TextInput
+                    id={`${dataTestId}-name`}
+                    label="Name"
+                    required
+                    value={name}
+                    onChange={setName}
+                    error={name === initialName ? undefined : error}
+                    dataTestId={`${dataTestId}-input`}
+                />
+            }
+            buttons={[
+                { color: 'secondary', variant: 'outline', onClick: onClose, body: 'Cancel' },
+                {
+                    color: 'primary',
+                    onClick: () => onSubmit(trimmed),
+                    body: confirmLabel,
+                    disabled: isBusy || error !== undefined,
+                },
+            ]}
+        />
+    );
+}

--- a/src/components/ViewTabs/UnresolvedColumnsNotice.tsx
+++ b/src/components/ViewTabs/UnresolvedColumnsNotice.tsx
@@ -1,0 +1,53 @@
+import Button from 'components/Button';
+import { TriangleAlert } from 'lucide-react';
+import type { PickerColumn } from 'types/tableColumns';
+import { getColumnHeading } from 'utils/tableColumns';
+
+type Props = Readonly<{
+    unavailable: PickerColumn[];
+    /** How many columns the view stores in total, so the notice can say how much of it opened. */
+    storedCount: number;
+    /** Whether nothing resolved at all, so the table fell back to the platform column set. */
+    fellBackToStandard: boolean;
+    onReview?: () => void;
+    dataTestId: string;
+}>;
+
+const list = (columns: PickerColumn[]): string => {
+    const names = columns.map(getColumnHeading);
+    if (names.length === 1) return names[0];
+    return `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}`;
+};
+
+/**
+ * What a view says when one of its columns names a field the catalogue no longer publishes.
+ *
+ * Silently skipping the column is the tempting option and the wrong one: a heading vanishes with no
+ * explanation, and the user's next move is to hunt for a field that no longer exists. Nothing is
+ * deleted server-side either — the stored view keeps the column until someone removes it.
+ */
+export default function UnresolvedColumnsNotice({ unavailable, storedCount, fellBackToStandard, onReview, dataTestId }: Props) {
+    if (unavailable.length === 0) return null;
+
+    const shown = storedCount - unavailable.length;
+
+    return (
+        <div
+            className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-lg bg-warning-surface px-3 py-2 text-sm text-content"
+            role="status"
+            data-testid={dataTestId}
+        >
+            <TriangleAlert className="size-4 shrink-0 text-warning" aria-hidden="true" />
+            <span>
+                {fellBackToStandard
+                    ? `${list(unavailable)} ${unavailable.length === 1 ? 'is' : 'are'} no longer available, so this view is showing the standard columns.`
+                    : `${list(unavailable)} ${unavailable.length === 1 ? 'is' : 'are'} no longer available, so this view is showing ${shown} of its ${storedCount} columns.`}
+            </span>
+            {onReview && (
+                <Button variant="transparent" color="secondary" onClick={onReview} data-testid={`${dataTestId}-review`}>
+                    Review columns
+                </Button>
+            )}
+        </div>
+    );
+}

--- a/src/components/ViewTabs/UnresolvedColumnsNotice.tsx
+++ b/src/components/ViewTabs/UnresolvedColumnsNotice.tsx
@@ -4,10 +4,11 @@ import type { PickerColumn } from 'types/tableColumns';
 import { getColumnHeading } from 'utils/tableColumns';
 
 type Props = Readonly<{
+    /** The stored columns this table cannot render, which may be none even when it fell back. */
     unavailable: PickerColumn[];
-    /** How many columns the view stores in total, so the notice can say how much of it opened. */
+    /** How many columns the view arrived with, so the notice can say how much of it opened. */
     storedCount: number;
-    /** Whether nothing resolved at all, so the table fell back to the platform column set. */
+    /** Whether nothing could be rendered, so the table fell back to the platform column set. */
     fellBackToStandard: boolean;
     onReview?: () => void;
     dataTestId: string;
@@ -20,16 +21,28 @@ const list = (columns: PickerColumn[]): string => {
 };
 
 /**
- * What a view says when one of its columns names a field the catalogue no longer publishes.
+ * What a view says when a column it stores cannot be put on the table.
  *
- * Silently skipping the column is the tempting option and the wrong one: a heading vanishes with no
- * explanation, and the user's next move is to hunt for a field that no longer exists. Nothing is
- * deleted server-side either — the stored view keeps the column until someone removes it.
+ * Silently skipping it is the tempting option and the wrong one: a heading vanishes with no
+ * explanation, and the user's next move is to hunt for a field that is not there. Nothing is deleted
+ * server-side either — the stored view keeps the column until someone saves over it.
+ *
+ * Two shapes reach this, and only one of them can be named. `GET /v1/listViews` resolves the stored
+ * identifiers against the resource's own catalogue and omits what it cannot offer, so a field that was
+ * deleted never arrives and a view built entirely on deleted fields arrives with no columns at all —
+ * hence a fallback that has nothing to name. A column the *listing* cannot display (a secret's
+ * content, an encrypted value) does arrive: the catalogue the API validates views against carries no
+ * notion of `displayable`, so such a column can be stored by any client and comes back intact.
  */
 export default function UnresolvedColumnsNotice({ unavailable, storedCount, fellBackToStandard, onReview, dataTestId }: Props) {
-    if (unavailable.length === 0) return null;
+    if (unavailable.length === 0 && !fellBackToStandard) return null;
 
+    const named = unavailable.length > 0 ? list(unavailable) : undefined;
     const shown = storedCount - unavailable.length;
+
+    const message = fellBackToStandard
+        ? `${named ? `${named} cannot be shown` : "None of this view's columns can be shown"}, so it is showing the standard columns.`
+        : `${named} cannot be shown, so this view is showing ${shown} of its ${storedCount} columns.`;
 
     return (
         <div
@@ -38,11 +51,7 @@ export default function UnresolvedColumnsNotice({ unavailable, storedCount, fell
             data-testid={dataTestId}
         >
             <TriangleAlert className="size-4 shrink-0 text-warning" aria-hidden="true" />
-            <span>
-                {fellBackToStandard
-                    ? `${list(unavailable)} ${unavailable.length === 1 ? 'is' : 'are'} no longer available, so this view is showing the standard columns.`
-                    : `${list(unavailable)} ${unavailable.length === 1 ? 'is' : 'are'} no longer available, so this view is showing ${shown} of its ${storedCount} columns.`}
-            </span>
+            <span>{message}</span>
             {onReview && (
                 <Button variant="transparent" color="secondary" onClick={onReview} data-testid={`${dataTestId}-review`}>
                     Review columns

--- a/src/components/ViewTabs/UnresolvedColumnsNotice.tsx
+++ b/src/components/ViewTabs/UnresolvedColumnsNotice.tsx
@@ -27,12 +27,8 @@ const list = (columns: PickerColumn[]): string => {
  * explanation, and the user's next move is to hunt for a field that is not there. Nothing is deleted
  * server-side either — the stored view keeps the column until someone saves over it.
  *
- * Two shapes reach this, and only one of them can be named. `GET /v1/listViews` resolves the stored
- * identifiers against the resource's own catalogue and omits what it cannot offer, so a field that was
- * deleted never arrives and a view built entirely on deleted fields arrives with no columns at all —
- * hence a fallback that has nothing to name. A column the *listing* cannot display (a secret's
- * content, an encrypted value) does arrive: the catalogue the API validates views against carries no
- * notion of `displayable`, so such a column can be stored by any client and comes back intact.
+ * A fallback can reach this with nothing to name, so the two are worded separately. Which cases
+ * arrive, and why, is written down beside `resolveView`.
  */
 export default function UnresolvedColumnsNotice({ unavailable, storedCount, fellBackToStandard, onReview, dataTestId }: Props) {
     if (unavailable.length === 0 && !fellBackToStandard) return null;

--- a/src/components/ViewTabs/ViewSummaryBar.tsx
+++ b/src/components/ViewTabs/ViewSummaryBar.tsx
@@ -1,0 +1,56 @@
+import Button from 'components/Button';
+import { ArrowDown, ArrowUp } from 'lucide-react';
+import type { ColumnDefinition } from 'types/tableColumns';
+import { type ColumnSort, getColumnHeading, getSortKey } from 'utils/tableColumns';
+
+type Props = Readonly<{
+    columns: ColumnDefinition[];
+    sort?: ColumnSort;
+    /** Whether the table has drifted from what the active view stores. */
+    isDirty: boolean;
+    /** Standard has no stored row to save into, so the offer is Save as view… instead. */
+    isStandard: boolean;
+    isBusy: boolean;
+    onRevert: () => void;
+    onSave: () => void;
+    dataTestId: string;
+}>;
+
+/**
+ * The row under the tab strip: what the view is showing, and — once it has drifted — the offer to
+ * keep the change or drop it.
+ *
+ * The sort is named here as well as on its own header because the active sort has to stay legible
+ * after that header has scrolled out of a twelve-column table.
+ */
+export default function ViewSummaryBar({ columns, sort, isDirty, isStandard, isBusy, onRevert, onSave, dataTestId }: Props) {
+    const sorted = sort ? columns.find((column) => getSortKey(sort) === `${column.fieldSource}:${column.fieldIdentifier}`) : undefined;
+    const SortGlyph = sort?.direction === 'desc' ? ArrowDown : ArrowUp;
+
+    return (
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 px-1 py-2 text-sm text-content-subtle" data-testid={dataTestId}>
+            <span data-testid={`${dataTestId}-columns`}>{`${columns.length} ${columns.length === 1 ? 'column' : 'columns'}`}</span>
+
+            {sort && (
+                <span className="inline-flex items-center gap-x-1" data-testid={`${dataTestId}-sort`}>
+                    {`Sorted by ${sorted ? getColumnHeading(sorted) : sort.fieldIdentifier}`}
+                    <SortGlyph className="size-3.5" aria-label={sort.direction === 'desc' ? 'descending' : 'ascending'} />
+                </span>
+            )}
+
+            {isDirty && (
+                <div className="ml-auto flex items-center gap-x-3">
+                    <span className="text-content" data-testid={`${dataTestId}-unsaved`}>
+                        {isStandard ? 'Unsaved changes — Standard cannot hold them' : 'Unsaved changes to this view'}
+                    </span>
+                    <Button variant="transparent" color="secondary" onClick={onRevert} data-testid={`${dataTestId}-revert`}>
+                        Revert
+                    </Button>
+                    <Button color="primary" onClick={onSave} disabled={isBusy} data-testid={`${dataTestId}-save`}>
+                        {isStandard ? 'Save as view…' : 'Save to view'}
+                    </Button>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/ViewTabs/ViewTab.tsx
+++ b/src/components/ViewTabs/ViewTab.tsx
@@ -1,0 +1,58 @@
+import cn from 'classnames';
+import { Pin } from 'lucide-react';
+import type { ViewTab as ViewTabModel } from 'utils/listViews';
+
+type Props = Readonly<{
+    tab: ViewTabModel;
+    isActive: boolean;
+    /** Whether the table has drifted from what this view stores. Only ever true for the active tab. */
+    isDirty: boolean;
+    onSelect: () => void;
+    /** The tab's action menu, rendered beside the label rather than inside its button. */
+    menu?: React.ReactNode;
+    dataTestId: string;
+}>;
+
+/**
+ * One tab of the view strip.
+ *
+ * The action menu is a sibling of the tab button, not a child: a menu trigger nested inside a tab
+ * would be one interactive element inside another, which leaves both unreachable from the keyboard
+ * in the order they appear.
+ */
+export default function ViewTab({ tab, isActive, isDirty, onSelect, menu, dataTestId }: Props) {
+    return (
+        <div
+            className={cn('inline-flex items-center rounded-lg', {
+                'bg-surface-active': isActive,
+                'hover:bg-surface-hover': !isActive,
+            })}
+        >
+            <button
+                type="button"
+                role="tab"
+                id={`view-tab-${tab.id}`}
+                aria-selected={isActive}
+                tabIndex={isActive ? 0 : -1}
+                onClick={onSelect}
+                data-testid={dataTestId}
+                className={cn(
+                    'py-3 pl-4 inline-flex items-center gap-x-2 bg-transparent text-sm font-medium rounded-lg',
+                    'focus:outline-hidden whitespace-nowrap',
+                    menu ? 'pr-2' : 'pr-4',
+                    isActive ? 'text-content' : 'text-content-subtle hover:text-content',
+                )}
+            >
+                {tab.isPinned && <Pin className="size-3.5 shrink-0" aria-label="Opens by default" />}
+                {tab.name}
+                {isDirty && (
+                    <>
+                        <span className="size-1.5 shrink-0 rounded-full bg-brand" data-testid={`${dataTestId}-dirty`} aria-hidden="true" />
+                        <span className="sr-only">(unsaved changes)</span>
+                    </>
+                )}
+            </button>
+            {menu}
+        </div>
+    );
+}

--- a/src/components/ViewTabs/ViewTabs.spec.tsx
+++ b/src/components/ViewTabs/ViewTabs.spec.tsx
@@ -1,0 +1,520 @@
+import type { Page } from '@playwright/test';
+import type { SearchFilterModel } from 'types/certificate';
+import type { ListViewColumnModel, ListViewModel, ViewSlice } from 'types/listViews';
+import {
+    FilterConditionOperator,
+    FilterFieldSource,
+    FilterFieldType,
+    Resource,
+    type SearchFieldDataByGroupDto,
+    SortDirection,
+} from 'types/openapi';
+import type { ColumnDefinition } from 'types/tableColumns';
+import { expect, test } from '../../../playwright/ct-test';
+import ViewTabsWithStore from './ViewTabsWithStore';
+
+const field = (identifier: string, label: string, overrides: Record<string, unknown> = {}) => ({
+    fieldIdentifier: identifier,
+    fieldLabel: label,
+    type: FilterFieldType.String,
+    conditions: [],
+    displayable: true,
+    sortable: true,
+    ...overrides,
+});
+
+const catalogue = [
+    {
+        filterFieldSource: FilterFieldSource.Property,
+        searchFieldData: [field('COMMON_NAME', 'Common Name'), field('SERIAL_NUMBER', 'Serial Number'), field('NOT_AFTER', 'Expires At')],
+    },
+    {
+        filterFieldSource: FilterFieldSource.Custom,
+        searchFieldData: [field('environment', 'Environment', { sortable: false })],
+    },
+] as unknown as SearchFieldDataByGroupDto[];
+
+const column = (identifier: string, catalogueLabel: string, fieldSource = FilterFieldSource.Property): ColumnDefinition => ({
+    fieldSource,
+    fieldIdentifier: identifier,
+    catalogueLabel,
+});
+
+const commonName = column('COMMON_NAME', 'Common Name');
+const serialNumber = column('SERIAL_NUMBER', 'Serial Number');
+const standardColumns = [commonName, serialNumber];
+
+const stored = (identifier: string, fieldSource = FilterFieldSource.Property, label?: string): ListViewColumnModel => ({
+    fieldSource,
+    fieldIdentifier: identifier,
+    ...(label ? { label } : {}),
+});
+
+const stateFilter: SearchFilterModel = {
+    fieldSource: FilterFieldSource.Property,
+    fieldIdentifier: 'CERTIFICATE_STATE',
+    condition: FilterConditionOperator.Equals,
+    value: 'issued',
+};
+
+/** A view of the two columns the catalogue publishes, under a filter and an ordering of its own. */
+const expiryWatch = (overrides: Partial<ListViewModel> = {}): ListViewModel => ({
+    uuid: 'view-1',
+    name: 'Expiry watch',
+    resource: Resource.Certificates,
+    columns: [stored('COMMON_NAME'), stored('NOT_AFTER', FilterFieldSource.Property, 'Expires')],
+    filters: [stateFilter],
+    sort: { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'NOT_AFTER', direction: SortDirection.Asc },
+    defaultView: false,
+    ...overrides,
+});
+
+const audit = (overrides: Partial<ListViewModel> = {}): ListViewModel => ({
+    uuid: 'view-2',
+    name: 'Audit',
+    resource: Resource.Certificates,
+    columns: [stored('environment', FilterFieldSource.Custom)],
+    filters: [],
+    defaultView: false,
+    ...overrides,
+});
+
+type MountOptions = {
+    views?: ListViewModel[];
+    isMutating?: boolean;
+    driftColumn?: ColumnDefinition;
+    driftSort?: { fieldSource: FilterFieldSource; fieldIdentifier: string; direction: 'asc' | 'desc' };
+    driftFilter?: SearchFilterModel;
+};
+
+const strip = ({ views = [expiryWatch()], isMutating, driftColumn, driftSort, driftFilter }: MountOptions = {}) => (
+    <ViewTabsWithStore
+        resource={Resource.Certificates}
+        views={views}
+        catalogue={catalogue}
+        standardColumns={standardColumns}
+        isMutating={isMutating}
+        driftColumn={driftColumn}
+        driftSort={driftSort}
+        driftFilter={driftFilter}
+    />
+);
+
+type DispatchedAction = { type: string; payload?: Record<string, unknown> };
+
+const dispatchedActions = async (page: Page): Promise<DispatchedAction[]> =>
+    JSON.parse((await page.getByTestId('dispatched').textContent()) ?? '[]') as DispatchedAction[];
+
+const dispatchedTypes = async (page: Page): Promise<string[]> => (await dispatchedActions(page)).map((action) => action.type);
+
+const lastDispatched = async (page: Page, type: string): Promise<DispatchedAction | undefined> =>
+    (await dispatchedActions(page)).filter((action) => action.type === type).at(-1);
+
+const appliedSlice = async (page: Page): Promise<ViewSlice> =>
+    JSON.parse((await page.getByTestId('applied-slice').textContent()) ?? '{}') as ViewSlice;
+
+const openTabMenu = async (page: Page, name: string) => {
+    await page.getByRole('button', { name: `Actions for ${name}` }).click();
+};
+
+test.describe('ViewTabs', () => {
+    test('puts Standard first and pins it while no stored view opens by default', async ({ mount, page }) => {
+        await mount(strip({ views: [expiryWatch(), audit()] }));
+
+        const tabs = page.getByTestId('view-tabs-strip').getByRole('tab');
+        await expect(tabs).toHaveText(['Standard', 'Expiry watch', 'Audit']);
+
+        await expect(page.getByTestId('view-tabs-tab-standard')).toHaveAttribute('aria-selected', 'true');
+        await expect(page.getByTestId('view-tabs-tab-standard').getByLabel('Opens by default')).toBeVisible();
+        await expect(page.getByTestId('view-tabs-tab-view-1').getByLabel('Opens by default')).toHaveCount(0);
+    });
+
+    test('opens the pinned view on load with its columns, filters and ordering', async ({ mount, page }) => {
+        await mount(strip({ views: [expiryWatch({ defaultView: true }), audit()] }));
+
+        await expect(page.getByTestId('view-tabs-tab-view-1')).toHaveAttribute('aria-selected', 'true');
+        await expect(page.getByTestId('view-tabs-tab-view-1').getByLabel('Opens by default')).toBeVisible();
+        await expect(page.getByTestId('view-tabs-tab-standard').getByLabel('Opens by default')).toHaveCount(0);
+
+        const slice = await appliedSlice(page);
+        expect(slice.columns.map((each) => each.fieldIdentifier)).toEqual(['COMMON_NAME', 'NOT_AFTER']);
+        expect(slice.filters).toEqual([stateFilter]);
+        expect(slice.sort).toEqual({ fieldSource: FilterFieldSource.Property, fieldIdentifier: 'NOT_AFTER', direction: 'asc' });
+    });
+
+    test('opens Standard when no view is pinned, and applies a view when its tab is picked', async ({ mount, page }) => {
+        await mount(strip());
+
+        expect((await appliedSlice(page)).columns.map((each) => each.fieldIdentifier)).toEqual(['COMMON_NAME', 'SERIAL_NUMBER']);
+        expect((await appliedSlice(page)).filters).toEqual([]);
+
+        await page.getByTestId('view-tabs-tab-view-1').click();
+
+        await expect(page.getByTestId('view-tabs-tab-view-1')).toHaveAttribute('aria-selected', 'true');
+        const slice = await appliedSlice(page);
+        expect(slice.columns.map((each) => each.fieldIdentifier)).toEqual(['COMMON_NAME', 'NOT_AFTER']);
+        expect(slice.filters).toEqual([stateFilter]);
+    });
+
+    test("names a view's own heading override rather than the catalogue label", async ({ mount, page }) => {
+        await mount(strip({ views: [expiryWatch({ defaultView: true })] }));
+
+        const slice = await appliedSlice(page);
+        expect(slice.columns.map((each) => each.label ?? each.catalogueLabel)).toEqual(['Common Name', 'Expires']);
+    });
+
+    test('reduces the menu on Standard to Duplicate, which is the only action it can hold', async ({ mount, page }) => {
+        await mount(strip());
+
+        await openTabMenu(page, 'Standard');
+
+        await expect(page.getByRole('menuitem', { name: 'Duplicate' })).toBeVisible();
+        await expect(page.getByRole('menuitem', { name: 'Rename…' })).toHaveCount(0);
+        await expect(page.getByRole('menuitem', { name: 'Delete view' })).toHaveCount(0);
+        await expect(page.getByRole('menuitem', { name: 'Edit columns…' })).toHaveCount(0);
+    });
+
+    test('offers the full menu on a stored view', async ({ mount, page }) => {
+        await mount(strip());
+
+        await page.getByTestId('view-tabs-tab-view-1').click();
+        await openTabMenu(page, 'Expiry watch');
+
+        await expect(page.getByRole('menuitem', { name: 'Edit columns…' })).toBeVisible();
+        await expect(page.getByRole('menuitem', { name: 'Rename…' })).toBeVisible();
+        await expect(page.getByRole('menuitem', { name: 'Duplicate' })).toBeVisible();
+        await expect(page.getByRole('menuitem', { name: 'Open this view by default' })).toBeVisible();
+        await expect(page.getByRole('menuitem', { name: 'Delete view' })).toBeVisible();
+    });
+
+    test('drops the pin action from the menu of the view that is already pinned', async ({ mount, page }) => {
+        await mount(strip({ views: [expiryWatch({ defaultView: true })] }));
+
+        await openTabMenu(page, 'Expiry watch');
+
+        await expect(page.getByRole('menuitem', { name: 'Rename…' })).toBeVisible();
+        await expect(page.getByRole('menuitem', { name: 'Open this view by default' })).toHaveCount(0);
+    });
+
+    test('pins a view from its menu', async ({ mount, page }) => {
+        await mount(strip());
+
+        await page.getByTestId('view-tabs-tab-view-1').click();
+        await openTabMenu(page, 'Expiry watch');
+        await page.getByRole('menuitem', { name: 'Open this view by default' }).click();
+
+        await expect.poll(() => dispatchedTypes(page)).toContain('listViews/updateView');
+        const action = await lastDispatched(page, 'listViews/updateView');
+        expect(action?.payload).toMatchObject({ resource: Resource.Certificates, uuid: 'view-1', view: { defaultView: true } });
+    });
+
+    test('walks the strip with the arrow keys and with Home and End', async ({ mount, page }) => {
+        await mount(strip({ views: [expiryWatch(), audit()] }));
+
+        await page.getByTestId('view-tabs-tab-standard').focus();
+        await page.keyboard.press('ArrowRight');
+
+        await expect(page.getByTestId('view-tabs-tab-view-1')).toHaveAttribute('aria-selected', 'true');
+        expect((await appliedSlice(page)).filters).toEqual([stateFilter]);
+
+        await page.keyboard.press('End');
+        await expect(page.getByTestId('view-tabs-tab-view-2')).toHaveAttribute('aria-selected', 'true');
+
+        await page.keyboard.press('Home');
+        await expect(page.getByTestId('view-tabs-tab-standard')).toHaveAttribute('aria-selected', 'true');
+
+        // Wrapping is deliberate: the strip is a closed loop, so ArrowLeft from the first tab is the
+        // last one rather than a dead key.
+        await page.keyboard.press('ArrowLeft');
+        await expect(page.getByTestId('view-tabs-tab-view-2')).toHaveAttribute('aria-selected', 'true');
+    });
+
+    test('rolls the views past the visible cap into an overflow menu', async ({ mount, page }) => {
+        const many = [1, 2, 3, 4, 5, 6].map((index) => audit({ uuid: `view-${index}`, name: `View ${index}` }));
+        await mount(strip({ views: many }));
+
+        await expect(page.getByTestId('view-tabs-strip').getByRole('tab')).toHaveText(['Standard', 'View 1', 'View 2', 'View 3', 'View 4']);
+
+        await page.getByRole('button', { name: 'More saved views' }).click();
+        await page.getByRole('menuitem', { name: 'View 6' }).click();
+
+        // The selected tab is pulled onto the strip, displacing the last visible one — a tab picked
+        // from the overflow has to be the one the strip shows as active.
+        await expect(page.getByTestId('view-tabs-tab-view-6')).toHaveAttribute('aria-selected', 'true');
+        await expect(page.getByTestId('view-tabs-tab-view-4')).toHaveCount(0);
+    });
+
+    test('marks the tab and offers to save once the ordering drifts from the view', async ({ mount, page }) => {
+        await mount(strip({ driftSort: { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME', direction: 'desc' } }));
+
+        await page.getByTestId('view-tabs-tab-view-1').click();
+        await expect(page.getByTestId('view-tabs-tab-view-1-dirty')).toHaveCount(0);
+
+        await page.getByTestId('drift-sort').click();
+
+        await expect(page.getByTestId('view-tabs-tab-view-1-dirty')).toBeVisible();
+        await expect(page.getByTestId('view-tabs-summary-unsaved')).toHaveText('Unsaved changes to this view');
+        await expect(page.getByTestId('view-tabs-summary-sort')).toContainText('Sorted by Common Name');
+
+        await page.getByTestId('view-tabs-summary-save').click();
+
+        await expect.poll(() => dispatchedTypes(page)).toContain('listViews/updateView');
+        const action = await lastDispatched(page, 'listViews/updateView');
+        expect(action?.payload).toMatchObject({
+            uuid: 'view-1',
+            view: {
+                name: 'Expiry watch',
+                sort: { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME', direction: SortDirection.Desc },
+            },
+        });
+    });
+
+    test('reverts the drift back to what the view stores', async ({ mount, page }) => {
+        await mount(strip({ driftFilter: stateFilter, views: [expiryWatch({ filters: [] })] }));
+
+        await page.getByTestId('view-tabs-tab-view-1').click();
+        await page.getByTestId('drift-filter').click();
+
+        await expect(page.getByTestId('view-tabs-tab-view-1-dirty')).toBeVisible();
+
+        await page.getByTestId('view-tabs-summary-revert').click();
+
+        await expect(page.getByTestId('view-tabs-tab-view-1-dirty')).toHaveCount(0);
+        expect((await appliedSlice(page)).filters).toEqual([]);
+        expect(await dispatchedTypes(page)).not.toContain('listViews/updateView');
+    });
+
+    test('offers to keep a change to Standard as a new view, since Standard cannot hold it', async ({ mount, page }) => {
+        await mount(strip({ driftColumn: column('NOT_AFTER', 'Expires At') }));
+
+        await page.getByTestId('drift-columns').click();
+
+        await expect(page.getByTestId('view-tabs-summary-unsaved')).toHaveText('Unsaved changes — Standard cannot hold them');
+        await expect(page.getByTestId('view-tabs-summary-columns')).toHaveText('3 columns');
+
+        await page.getByTestId('view-tabs-summary-save').click();
+
+        await expect(page.getByTestId('view-tabs-create')).toBeVisible();
+        await page.getByTestId('view-tabs-create-input').click();
+        await page.getByTestId('view-tabs-create-input').fill('Expiring soon');
+        await page.getByTestId('view-tabs-create').getByRole('button', { name: 'Create view' }).click();
+
+        await expect.poll(() => dispatchedTypes(page)).toContain('listViews/createView');
+        const action = await lastDispatched(page, 'listViews/createView');
+        expect(action?.payload).toMatchObject({
+            resource: Resource.Certificates,
+            view: {
+                name: 'Expiring soon',
+                resource: Resource.Certificates,
+                columns: [
+                    { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME' },
+                    { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'SERIAL_NUMBER' },
+                    { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'NOT_AFTER' },
+                ],
+                defaultView: false,
+            },
+        });
+    });
+
+    test('creates a view from the current slice through the new-view tab', async ({ mount, page }) => {
+        await mount(strip());
+
+        await page.getByTestId('view-tabs-new').click();
+
+        await expect(page.getByTestId('view-tabs-create-input')).toHaveValue('Standard (copy)');
+
+        await page.getByTestId('view-tabs-create-input').click();
+        await page.getByTestId('view-tabs-create-input').fill('Everything');
+        await page.getByTestId('view-tabs-create').getByRole('button', { name: 'Create view' }).click();
+
+        await expect.poll(() => dispatchedTypes(page)).toContain('listViews/createView');
+        const action = await lastDispatched(page, 'listViews/createView');
+        expect(action?.payload).toMatchObject({ view: { name: 'Everything' } });
+    });
+
+    test('refuses a name that is empty or already taken', async ({ mount, page }) => {
+        await mount(strip());
+
+        await page.getByTestId('view-tabs-new').click();
+        const confirm = page.getByTestId('view-tabs-create').getByRole('button', { name: 'Create view' });
+
+        await page.getByTestId('view-tabs-create-input').click();
+        await page.getByTestId('view-tabs-create-input').fill('Expiry watch');
+
+        await expect(page.getByTestId('view-tabs-create')).toContainText('A view of this name already exists.');
+        await expect(confirm).toBeDisabled();
+
+        await page.getByTestId('view-tabs-create-input').fill('');
+
+        await expect(page.getByTestId('view-tabs-create')).toContainText('A view needs a name.');
+        await expect(confirm).toBeDisabled();
+
+        await page.getByTestId('view-tabs-create-input').fill('Expiring soon');
+
+        await expect(confirm).toBeEnabled();
+    });
+
+    test('duplicates the active tab under a name that is free', async ({ mount, page }) => {
+        await mount(strip({ views: [expiryWatch(), audit({ name: 'Expiry watch (copy)' })] }));
+
+        await page.getByTestId('view-tabs-tab-view-1').click();
+        await openTabMenu(page, 'Expiry watch');
+        await page.getByRole('menuitem', { name: 'Duplicate' }).click();
+
+        await expect.poll(() => dispatchedTypes(page)).toContain('listViews/createView');
+        const action = await lastDispatched(page, 'listViews/createView');
+        expect(action?.payload).toMatchObject({ view: { name: 'Expiry watch (copy) 2' } });
+    });
+
+    test('renames a view by sending the whole stored row back', async ({ mount, page }) => {
+        await mount(strip());
+
+        await page.getByTestId('view-tabs-tab-view-1').click();
+        await openTabMenu(page, 'Expiry watch');
+        await page.getByRole('menuitem', { name: 'Rename…' }).click();
+
+        await expect(page.getByTestId('view-tabs-rename-input')).toHaveValue('Expiry watch');
+
+        await page.getByTestId('view-tabs-rename-input').click();
+        await page.getByTestId('view-tabs-rename-input').fill('Expiring soon');
+        await page.getByTestId('view-tabs-rename').getByRole('button', { name: 'Rename' }).click();
+
+        await expect.poll(() => dispatchedTypes(page)).toContain('listViews/updateView');
+        const action = await lastDispatched(page, 'listViews/updateView');
+        // The API replaces the whole row, so a rename that dropped the columns would empty the view.
+        expect(action?.payload).toMatchObject({
+            uuid: 'view-1',
+            view: {
+                name: 'Expiring soon',
+                columns: [
+                    { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME' },
+                    { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'NOT_AFTER', label: 'Expires' },
+                ],
+                filters: [stateFilter],
+            },
+        });
+    });
+
+    test('names the view it is about to delete, and falls back to Standard', async ({ mount, page }) => {
+        await mount(strip());
+
+        await page.getByTestId('view-tabs-tab-view-1').click();
+        await openTabMenu(page, 'Expiry watch');
+        await page.getByRole('menuitem', { name: 'Delete view' }).click();
+
+        await expect(page.getByTestId('view-tabs-delete')).toContainText('"Expiry watch"');
+
+        await page.getByTestId('view-tabs-delete').getByRole('button', { name: 'Delete' }).click();
+
+        await expect.poll(() => dispatchedTypes(page)).toContain('listViews/deleteView');
+        const action = await lastDispatched(page, 'listViews/deleteView');
+        expect(action?.payload).toMatchObject({ resource: Resource.Certificates, uuid: 'view-1' });
+
+        await expect(page.getByTestId('view-tabs-tab-standard')).toHaveAttribute('aria-selected', 'true');
+        const slice = await appliedSlice(page);
+        expect(slice.columns.map((each) => each.fieldIdentifier)).toEqual(['COMMON_NAME', 'SERIAL_NUMBER']);
+        expect(slice.filters).toEqual([]);
+        expect(slice.sort).toBeUndefined();
+    });
+
+    test('says which stored column the catalogue no longer publishes', async ({ mount, page }) => {
+        const stale = expiryWatch({
+            defaultView: true,
+            columns: [stored('COMMON_NAME'), stored('retired', FilterFieldSource.Custom)],
+        });
+        await mount(strip({ views: [stale] }));
+
+        await expect(page.getByTestId('view-tabs-notice')).toContainText('retired is no longer available');
+        await expect(page.getByTestId('view-tabs-notice')).toContainText('showing 1 of its 2 columns');
+
+        // Nothing is dropped server-side, so the notice's offer is to open the picker over the stored
+        // list rather than to repair it silently.
+        await page.getByTestId('view-tabs-notice-review').click();
+
+        await expect(page.getByTestId('view-tabs-picker')).toBeVisible();
+        await expect(page.getByTestId('selected-column-custom:retired')).toContainText('Unavailable');
+    });
+
+    test('keeps the live filters and ordering when the columns are edited from the menu', async ({ mount, page }) => {
+        await mount(strip({ views: [expiryWatch({ defaultView: true })] }));
+
+        await openTabMenu(page, 'Expiry watch');
+        await page.getByRole('menuitem', { name: 'Edit columns…' }).click();
+
+        await page.getByTestId('add-field-property:SERIAL_NUMBER').click();
+        await page.getByTestId('view-tabs-picker').getByRole('button', { name: 'Save' }).click();
+
+        const slice = await appliedSlice(page);
+        expect(slice.columns.map((each) => each.fieldIdentifier)).toEqual(['COMMON_NAME', 'NOT_AFTER', 'SERIAL_NUMBER']);
+        expect(slice.filters).toEqual([stateFilter]);
+        expect(slice.sort).toEqual({ fieldSource: FilterFieldSource.Property, fieldIdentifier: 'NOT_AFTER', direction: 'asc' });
+
+        await expect.poll(() => dispatchedTypes(page)).toContain('listViews/updateView');
+        const action = await lastDispatched(page, 'listViews/updateView');
+        expect(action?.payload).toMatchObject({
+            view: {
+                columns: [
+                    { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME' },
+                    { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'NOT_AFTER', label: 'Expires' },
+                    { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'SERIAL_NUMBER' },
+                ],
+            },
+        });
+    });
+
+    test('shows the new tab before the API has answered, then follows the uuid it is given', async ({ mount, page }) => {
+        await mount(strip());
+
+        await page.getByTestId('view-tabs-new').click();
+        await page.getByTestId('view-tabs-create-input').click();
+        await page.getByTestId('view-tabs-create-input').fill('Everything');
+        await page.getByTestId('view-tabs-create').getByRole('button', { name: 'Create view' }).click();
+
+        // The tab appears the moment it is asked for, under the uuid the optimistic row carries.
+        await expect(page.getByTestId('view-tabs-tab-pending-view')).toContainText('Everything');
+        await expect(page.getByTestId('view-tabs-tab-pending-view')).toHaveAttribute('aria-selected', 'true');
+
+        await page.getByTestId('simulate-create-success').click();
+
+        await expect(page.getByTestId('view-tabs-tab-view-created')).toContainText('Everything');
+        await expect(page.getByTestId('view-tabs-tab-view-created')).toHaveAttribute('aria-selected', 'true');
+        await expect(page.getByTestId('view-tabs-tab-pending-view')).toHaveCount(0);
+    });
+
+    test('falls back to the standard columns when none of the stored ones resolve', async ({ mount, page }) => {
+        const stale = expiryWatch({
+            defaultView: true,
+            columns: [stored('retired', FilterFieldSource.Custom), stored('gone', FilterFieldSource.Custom)],
+        });
+        await mount(strip({ views: [stale] }));
+
+        await expect(page.getByTestId('view-tabs-notice')).toContainText(
+            'retired and gone are no longer available, so this view is showing the standard columns.',
+        );
+
+        const slice = await appliedSlice(page);
+        expect(slice.columns.map((each) => each.fieldIdentifier)).toEqual(['COMMON_NAME', 'SERIAL_NUMBER']);
+    });
+
+    test('names the ordering even when the column it orders by is not displayed', async ({ mount, page }) => {
+        const narrow = expiryWatch({
+            defaultView: true,
+            columns: [stored('COMMON_NAME')],
+            sort: { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'SERIAL_NUMBER', direction: SortDirection.Desc },
+        });
+        await mount(strip({ views: [narrow] }));
+
+        await expect(page.getByTestId('view-tabs-summary-columns')).toHaveText('1 column');
+        // The identifier stands in for a heading the table is not showing, so the ordering stays
+        // legible rather than reading as unsorted.
+        await expect(page.getByTestId('view-tabs-summary-sort')).toContainText('Sorted by SERIAL_NUMBER');
+        await expect(page.getByTestId('view-tabs-summary-sort').getByLabel('descending')).toBeVisible();
+    });
+
+    test('holds its own actions while a mutation is in flight', async ({ mount, page }) => {
+        await mount(strip({ isMutating: true }));
+
+        await expect(page.getByTestId('view-tabs-new')).toBeDisabled();
+        await expect(page.getByRole('button', { name: 'Actions for Standard' })).toBeDisabled();
+    });
+});

--- a/src/components/ViewTabs/ViewTabs.spec.tsx
+++ b/src/components/ViewTabs/ViewTabs.spec.tsx
@@ -650,6 +650,43 @@ test.describe('ViewTabs', () => {
         expect(JSON.stringify(action)).not.toContain('hunter2');
     });
 
+    test('drops a stored filter on secret content from a rename, and does not read it as drift', async ({ mount, page }) => {
+        // Such a view cannot be written by this client, but it can arrive from one that predates the
+        // rule. A rename sends the whole row back, so the plaintext would be rewritten on every one.
+        const legacy = expiryWatch({ filters: [stateFilter, secretFilter] });
+        await mount(strip({ fields: secretCatalogue, views: [legacy] }));
+
+        await page.getByTestId('view-tabs-tab-view-1').click();
+
+        // Drift is measured against what a save would keep, or the view reads as permanently drifted
+        // and offers a Save that changes nothing.
+        await expect(page.getByTestId('view-tabs-summary-unsaved')).toHaveCount(0);
+
+        await openTabMenu(page, 'Expiry watch');
+        await page.getByRole('menuitem', { name: 'Rename…' }).click();
+        await page.getByTestId('view-tabs-rename-input').click();
+        await page.getByTestId('view-tabs-rename-input').fill('Expiring soon');
+        await page.getByTestId('view-tabs-rename').getByRole('button', { name: 'Rename' }).click();
+
+        await expect.poll(() => dispatchedTypes(page)).toContain('listViews/updateView');
+        const action = await lastDispatched(page, 'listViews/updateView');
+        expect(action?.payload).toMatchObject({ view: { name: 'Expiring soon', filters: [stateFilter] } });
+        expect(JSON.stringify(action)).not.toContain('hunter2');
+    });
+
+    test('drops a stored filter on secret content from a pin, which names no filters at all', async ({ mount, page }) => {
+        await mount(strip({ fields: secretCatalogue, views: [expiryWatch({ filters: [secretFilter] })] }));
+
+        await page.getByTestId('view-tabs-tab-view-1').click();
+        await openTabMenu(page, 'Expiry watch');
+        await page.getByRole('menuitem', { name: 'Open this view by default' }).click();
+
+        await expect.poll(() => dispatchedTypes(page)).toContain('listViews/updateView');
+        const action = await lastDispatched(page, 'listViews/updateView');
+        expect(action?.payload).toMatchObject({ view: { defaultView: true, filters: [] } });
+        expect(JSON.stringify(action)).not.toContain('hunter2');
+    });
+
     test('keeps a column it cannot show when the ordering alone is saved', async ({ mount, page }) => {
         const stale = expiryWatch({
             defaultView: true,

--- a/src/components/ViewTabs/ViewTabs.spec.tsx
+++ b/src/components/ViewTabs/ViewTabs.spec.tsx
@@ -82,18 +82,30 @@ const audit = (overrides: Partial<ListViewModel> = {}): ListViewModel => ({
 type MountOptions = {
     views?: ListViewModel[];
     isMutating?: boolean;
+    hasLoaded?: boolean;
+    withheldCatalogue?: boolean;
     driftColumn?: ColumnDefinition;
     driftSort?: { fieldSource: FilterFieldSource; fieldIdentifier: string; direction: 'asc' | 'desc' };
     driftFilter?: SearchFilterModel;
 };
 
-const strip = ({ views = [expiryWatch()], isMutating, driftColumn, driftSort, driftFilter }: MountOptions = {}) => (
+const strip = ({
+    views = [expiryWatch()],
+    isMutating,
+    hasLoaded,
+    withheldCatalogue,
+    driftColumn,
+    driftSort,
+    driftFilter,
+}: MountOptions = {}) => (
     <ViewTabsWithStore
         resource={Resource.Certificates}
         views={views}
         catalogue={catalogue}
         standardColumns={standardColumns}
         isMutating={isMutating}
+        hasLoaded={hasLoaded}
+        withheldCatalogue={withheldCatalogue}
         driftColumn={driftColumn}
         driftSort={driftSort}
         driftFilter={driftFilter}
@@ -215,10 +227,14 @@ test.describe('ViewTabs', () => {
         await page.keyboard.press('ArrowRight');
 
         await expect(page.getByTestId('view-tabs-tab-view-1')).toHaveAttribute('aria-selected', 'true');
+        // Roving focus: the tab left behind becomes tabIndex={-1}, so focus has to travel with the
+        // selection or the next arrow key comes from an element the strip no longer tracks.
+        await expect(page.getByTestId('view-tabs-tab-view-1')).toBeFocused();
         expect((await appliedSlice(page)).filters).toEqual([stateFilter]);
 
         await page.keyboard.press('End');
         await expect(page.getByTestId('view-tabs-tab-view-2')).toHaveAttribute('aria-selected', 'true');
+        await expect(page.getByTestId('view-tabs-tab-view-2')).toBeFocused();
 
         await page.keyboard.press('Home');
         await expect(page.getByTestId('view-tabs-tab-standard')).toHaveAttribute('aria-selected', 'true');
@@ -417,14 +433,17 @@ test.describe('ViewTabs', () => {
         expect(slice.sort).toBeUndefined();
     });
 
-    test('says which stored column the catalogue no longer publishes', async ({ mount, page }) => {
+    test('names a stored column this listing cannot display, and keeps it reachable in the picker', async ({ mount, page }) => {
+        // Reachable because the catalogue the API validates a view against carries no notion of
+        // `displayable`: a column the listing cannot render can be stored by any client and comes back
+        // intact, unlike a deleted field, which the API omits on read.
         const stale = expiryWatch({
             defaultView: true,
             columns: [stored('COMMON_NAME'), stored('retired', FilterFieldSource.Custom)],
         });
         await mount(strip({ views: [stale] }));
 
-        await expect(page.getByTestId('view-tabs-notice')).toContainText('retired is no longer available');
+        await expect(page.getByTestId('view-tabs-notice')).toContainText('retired cannot be shown');
         await expect(page.getByTestId('view-tabs-notice')).toContainText('showing 1 of its 2 columns');
 
         // Nothing is dropped server-side, so the notice's offer is to open the picker over the stored
@@ -481,7 +500,7 @@ test.describe('ViewTabs', () => {
         await expect(page.getByTestId('view-tabs-tab-pending-view')).toHaveCount(0);
     });
 
-    test('falls back to the standard columns when none of the stored ones resolve', async ({ mount, page }) => {
+    test('falls back to the standard columns when none of the stored ones can be shown', async ({ mount, page }) => {
         const stale = expiryWatch({
             defaultView: true,
             columns: [stored('retired', FilterFieldSource.Custom), stored('gone', FilterFieldSource.Custom)],
@@ -489,11 +508,29 @@ test.describe('ViewTabs', () => {
         await mount(strip({ views: [stale] }));
 
         await expect(page.getByTestId('view-tabs-notice')).toContainText(
-            'retired and gone are no longer available, so this view is showing the standard columns.',
+            'retired and gone cannot be shown, so it is showing the standard columns.',
         );
 
         const slice = await appliedSlice(page);
         expect(slice.columns.map((each) => each.fieldIdentifier)).toEqual(['COMMON_NAME', 'SERIAL_NUMBER']);
+    });
+
+    test('falls back for a view that arrives carrying no columns at all', async ({ mount, page }) => {
+        // What the API returns once every field the view was built on has been deleted: it resolves the
+        // stored identifiers on read and omits the ones it cannot offer. Rendering that literally would
+        // leave a table with no columns, under a tab that still claims to be a view.
+        await mount(strip({ views: [expiryWatch({ defaultView: true, columns: [] })] }));
+
+        await expect(page.getByTestId('view-tabs-notice')).toContainText('so it is showing the standard columns.');
+
+        expect((await appliedSlice(page)).columns.map((each) => each.fieldIdentifier)).toEqual(['COMMON_NAME', 'SERIAL_NUMBER']);
+
+        // The dialog opens on what the table is showing, so Save writes a usable view rather than an
+        // empty one.
+        await page.getByTestId('view-tabs-notice-review').click();
+
+        await expect(page.getByTestId('selected-column-property:COMMON_NAME')).toBeVisible();
+        await expect(page.getByTestId('selected-column-property:SERIAL_NUMBER')).toBeVisible();
     });
 
     test('names the ordering even when the column it orders by is not displayed', async ({ mount, page }) => {
@@ -509,6 +546,49 @@ test.describe('ViewTabs', () => {
         // legible rather than reading as unsorted.
         await expect(page.getByTestId('view-tabs-summary-sort')).toContainText('Sorted by SERIAL_NUMBER');
         await expect(page.getByTestId('view-tabs-summary-sort').getByLabel('descending')).toBeVisible();
+    });
+
+    test('renders nothing until the view list has settled', async ({ mount, page }) => {
+        // An empty read is otherwise indistinguishable from one still in flight, and the strip would
+        // then read the first optimistic create as the initial result and throw the user off it.
+        await mount(strip({ hasLoaded: false }));
+
+        await expect(page.getByTestId('view-tabs')).toHaveCount(0);
+    });
+
+    test('waits for the catalogue before offering any tab', async ({ mount, page }) => {
+        await mount(strip({ views: [expiryWatch({ defaultView: true })], withheldCatalogue: true }));
+
+        // Without the catalogue every stored column resolves to nothing, so a tab applied now would
+        // show the platform columns under that view's name and stay there.
+        await expect(page.getByTestId('view-tabs')).toHaveCount(0);
+        expect((await appliedSlice(page)).columns.map((each) => each.fieldIdentifier)).toEqual(['COMMON_NAME', 'SERIAL_NUMBER']);
+
+        await page.getByTestId('release-catalogue').click();
+
+        await expect(page.getByTestId('view-tabs-tab-view-1')).toHaveAttribute('aria-selected', 'true');
+        expect((await appliedSlice(page)).columns.map((each) => each.fieldIdentifier)).toEqual(['COMMON_NAME', 'NOT_AFTER']);
+        await expect(page.getByTestId('view-tabs-notice')).toHaveCount(0);
+    });
+
+    test('puts the tab back when a create fails, without dropping what it was saving', async ({ mount, page }) => {
+        await mount(strip({ driftSort: { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME', direction: 'desc' } }));
+
+        await page.getByTestId('view-tabs-tab-view-1').click();
+        await page.getByTestId('view-tabs-new').click();
+        await page.getByTestId('view-tabs-create-input').click();
+        await page.getByTestId('view-tabs-create-input').fill('Everything');
+        await page.getByTestId('view-tabs-create').getByRole('button', { name: 'Create view' }).click();
+
+        await expect(page.getByTestId('view-tabs-tab-pending-view')).toHaveAttribute('aria-selected', 'true');
+
+        await page.getByTestId('simulate-create-failure').click();
+
+        // The rollback takes the optimistic row away, so the strip has to go back to the tab the create
+        // started from rather than leave every tab unselected.
+        await expect(page.getByTestId('view-tabs-tab-pending-view')).toHaveCount(0);
+        await expect(page.getByTestId('view-tabs-tab-view-1')).toHaveAttribute('aria-selected', 'true');
+        expect((await appliedSlice(page)).filters).toEqual([stateFilter]);
     });
 
     test('holds its own actions while a mutation is in flight', async ({ mount, page }) => {

--- a/src/components/ViewTabs/ViewTabs.spec.tsx
+++ b/src/components/ViewTabs/ViewTabs.spec.tsx
@@ -2,6 +2,7 @@ import type { Page } from '@playwright/test';
 import type { SearchFilterModel } from 'types/certificate';
 import type { ListViewColumnModel, ListViewModel, ViewSlice } from 'types/listViews';
 import {
+    AttributeContentType,
     FilterConditionOperator,
     FilterFieldSource,
     FilterFieldType,
@@ -57,6 +58,30 @@ const stateFilter: SearchFilterModel = {
     value: 'issued',
 };
 
+/** A catalogue that loaded successfully but publishes nothing the listing can show as a column. */
+const undisplayableCatalogue = [
+    {
+        filterFieldSource: FilterFieldSource.Property,
+        searchFieldData: [field('SIGNATURE', 'Signature', { displayable: false })],
+    },
+] as unknown as SearchFieldDataByGroupDto[];
+
+/** A catalogue whose custom source publishes a secret attribute, which the filter widget offers. */
+const secretCatalogue = [
+    ...catalogue,
+    {
+        filterFieldSource: FilterFieldSource.Custom,
+        searchFieldData: [field('vaultToken', 'Vault Token', { displayable: false, attributeContentType: AttributeContentType.Secret })],
+    },
+] as unknown as SearchFieldDataByGroupDto[];
+
+const secretFilter: SearchFilterModel = {
+    fieldSource: FilterFieldSource.Custom,
+    fieldIdentifier: 'vaultToken',
+    condition: FilterConditionOperator.Equals,
+    value: 'hunter2',
+};
+
 /** A view of the two columns the catalogue publishes, under a filter and an ordering of its own. */
 const expiryWatch = (overrides: Partial<ListViewModel> = {}): ListViewModel => ({
     uuid: 'view-1',
@@ -81,9 +106,11 @@ const audit = (overrides: Partial<ListViewModel> = {}): ListViewModel => ({
 
 type MountOptions = {
     views?: ListViewModel[];
+    fields?: SearchFieldDataByGroupDto[];
     isMutating?: boolean;
     hasLoaded?: boolean;
     withheldCatalogue?: boolean;
+    isCatalogueLoaded?: boolean;
     driftColumn?: ColumnDefinition;
     driftSort?: { fieldSource: FilterFieldSource; fieldIdentifier: string; direction: 'asc' | 'desc' };
     driftFilter?: SearchFilterModel;
@@ -91,9 +118,11 @@ type MountOptions = {
 
 const strip = ({
     views = [expiryWatch()],
+    fields = catalogue,
     isMutating,
     hasLoaded,
     withheldCatalogue,
+    isCatalogueLoaded,
     driftColumn,
     driftSort,
     driftFilter,
@@ -101,11 +130,12 @@ const strip = ({
     <ViewTabsWithStore
         resource={Resource.Certificates}
         views={views}
-        catalogue={catalogue}
+        catalogue={fields}
         standardColumns={standardColumns}
         isMutating={isMutating}
         hasLoaded={hasLoaded}
         withheldCatalogue={withheldCatalogue}
+        isCatalogueLoaded={isCatalogueLoaded}
         driftColumn={driftColumn}
         driftSort={driftSort}
         driftFilter={driftFilter}
@@ -489,7 +519,6 @@ test.describe('ViewTabs', () => {
         await page.getByTestId('view-tabs-create-input').fill('Everything');
         await page.getByTestId('view-tabs-create').getByRole('button', { name: 'Create view' }).click();
 
-        // The tab appears the moment it is asked for, under the uuid the optimistic row carries.
         await expect(page.getByTestId('view-tabs-tab-pending-view')).toContainText('Everything');
         await expect(page.getByTestId('view-tabs-tab-pending-view')).toHaveAttribute('aria-selected', 'true');
 
@@ -587,6 +616,83 @@ test.describe('ViewTabs', () => {
         // The rollback takes the optimistic row away, so the strip has to go back to the tab the create
         // started from rather than leave every tab unselected.
         await expect(page.getByTestId('view-tabs-tab-pending-view')).toHaveCount(0);
+        await expect(page.getByTestId('view-tabs-tab-view-1')).toHaveAttribute('aria-selected', 'true');
+        expect((await appliedSlice(page)).filters).toEqual([stateFilter]);
+    });
+
+    test('opens on a catalogue that loaded carrying nothing the listing can show', async ({ mount, page }) => {
+        // A settled read that published only non-displayable fields is not a read still in flight, and
+        // Standard needs no catalogue field of its own — gating on the displayable ones would hide the
+        // strip for good on such a resource.
+        await mount(strip({ fields: undisplayableCatalogue, views: [] }));
+
+        await expect(page.getByTestId('view-tabs-tab-standard')).toHaveAttribute('aria-selected', 'true');
+        await expect(page.getByTestId('view-tabs-new')).toBeEnabled();
+    });
+
+    test('keeps a filter on secret content out of the view it saves', async ({ mount, page }) => {
+        await mount(strip({ fields: secretCatalogue, views: [], driftFilter: secretFilter }));
+
+        await page.getByTestId('drift-filter').click();
+
+        // A view is stored verbatim by Core and read back by every client that opens it, so the value
+        // must not reach the request — and, since the view cannot hold it, it is not drift either.
+        await expect(page.getByTestId('view-tabs-summary-unsaved')).toHaveCount(0);
+
+        await page.getByTestId('view-tabs-new').click();
+        await page.getByTestId('view-tabs-create-input').click();
+        await page.getByTestId('view-tabs-create-input').fill('Everything');
+        await page.getByTestId('view-tabs-create').getByRole('button', { name: 'Create view' }).click();
+
+        await expect.poll(() => dispatchedTypes(page)).toContain('listViews/createView');
+        const action = await lastDispatched(page, 'listViews/createView');
+        expect(action?.payload).toMatchObject({ view: { filters: [] } });
+        expect(JSON.stringify(action)).not.toContain('hunter2');
+    });
+
+    test('keeps a column it cannot show when the ordering alone is saved', async ({ mount, page }) => {
+        const stale = expiryWatch({
+            defaultView: true,
+            columns: [stored('COMMON_NAME'), stored('retired', FilterFieldSource.Custom)],
+        });
+        await mount(
+            strip({
+                views: [stale],
+                driftSort: { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME', direction: 'desc' },
+            }),
+        );
+
+        await page.getByTestId('drift-sort').click();
+        await page.getByTestId('view-tabs-summary-save').click();
+
+        // The table never showed the column, so the user was never offered the choice to drop it. Only
+        // the picker removes one, because it is the only place one is shown.
+        await expect.poll(() => dispatchedTypes(page)).toContain('listViews/updateView');
+        const action = await lastDispatched(page, 'listViews/updateView');
+        expect(action?.payload).toMatchObject({
+            view: {
+                columns: [
+                    { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME' },
+                    { fieldSource: FilterFieldSource.Custom, fieldIdentifier: 'retired' },
+                ],
+            },
+        });
+    });
+
+    test('puts the tab back when a delete fails, and the rows with it', async ({ mount, page }) => {
+        await mount(strip());
+
+        await page.getByTestId('view-tabs-tab-view-1').click();
+        await openTabMenu(page, 'Expiry watch');
+        await page.getByRole('menuitem', { name: 'Delete view' }).click();
+        await page.getByTestId('view-tabs-delete').getByRole('button', { name: 'Delete' }).click();
+
+        await expect(page.getByTestId('view-tabs-tab-standard')).toHaveAttribute('aria-selected', 'true');
+
+        await page.getByTestId('simulate-delete-failure').click();
+
+        // The row is back, so the tab has to come back with it: reporting a failed delete while leaving
+        // the user on another view's rows says the deletion happened.
         await expect(page.getByTestId('view-tabs-tab-view-1')).toHaveAttribute('aria-selected', 'true');
         expect((await appliedSlice(page)).filters).toEqual([stateFilter]);
     });

--- a/src/components/ViewTabs/ViewTabsWithStore.tsx
+++ b/src/components/ViewTabs/ViewTabsWithStore.tsx
@@ -18,6 +18,10 @@ type Props = Readonly<{
     standardColumns: ColumnDefinition[];
     /** Preloads a mutation as in flight, which is what holds the strip's own actions. */
     isMutating?: boolean;
+    /** Preloads the list read as still in flight, which is what the strip waits for before rendering. */
+    hasLoaded?: boolean;
+    /** Withholds the catalogue until released, so a test can make it land after the views did. */
+    withheldCatalogue?: boolean;
     /** What the drift buttons below change, i.e. an edit the page made outside the view. */
     driftColumn?: ColumnDefinition;
     driftSort?: ColumnSort;
@@ -45,6 +49,8 @@ export default function ViewTabsWithStore({
     catalogue,
     standardColumns,
     isMutating = false,
+    hasLoaded = true,
+    withheldCatalogue = false,
     driftColumn,
     driftSort,
     driftFilter,
@@ -52,20 +58,21 @@ export default function ViewTabsWithStore({
     const [store] = useState(() =>
         createMockStore({
             listViews: {
-                byResource: { [resource]: { views, isFetching: false, isMutating } },
+                byResource: { [resource]: { views, isFetching: !hasLoaded, hasLoaded, isMutating } },
                 dispatched: [],
             },
         }),
     );
 
     const [slice, setSlice] = useState<ViewSlice>({ columns: standardColumns, filters: [], sort: undefined });
+    const [isCatalogueReleased, setIsCatalogueReleased] = useState(!withheldCatalogue);
 
     return (
         <Provider store={store}>
             <MemoryRouter initialEntries={['/certificates']}>
                 <ViewTabs
                     resource={resource}
-                    catalogue={catalogue}
+                    catalogue={isCatalogueReleased ? catalogue : []}
                     standardColumns={standardColumns}
                     columns={slice.columns}
                     filters={slice.filters}
@@ -77,8 +84,12 @@ export default function ViewTabsWithStore({
                 <div data-testid="applied-slice">{JSON.stringify(slice)}</div>
                 <DispatchedActions />
 
+                <button type="button" data-testid="release-catalogue" onClick={() => setIsCatalogueReleased(true)}>
+                    release the catalogue
+                </button>
+
                 {/* Stands in for the epic (a component test runs none): answers the create in flight
-                    with the uuid the API would have assigned. */}
+                    with the uuid the API would have assigned, or with the failure that rolls it back. */}
                 <button
                     type="button"
                     data-testid="simulate-create-success"
@@ -93,6 +104,19 @@ export default function ViewTabsWithStore({
                     }}
                 >
                     answer the create
+                </button>
+
+                <button
+                    type="button"
+                    data-testid="simulate-create-failure"
+                    onClick={() =>
+                        store.dispatch({
+                            type: 'listViews/createViewFailure',
+                            payload: { resource, error: 'Name already used' },
+                        })
+                    }
+                >
+                    fail the create
                 </button>
 
                 <button

--- a/src/components/ViewTabs/ViewTabsWithStore.tsx
+++ b/src/components/ViewTabs/ViewTabsWithStore.tsx
@@ -22,6 +22,8 @@ type Props = Readonly<{
     hasLoaded?: boolean;
     /** Withholds the catalogue until released, so a test can make it land after the views did. */
     withheldCatalogue?: boolean;
+    /** Passed straight through, so a test can say the catalogue read has settled on nothing. */
+    isCatalogueLoaded?: boolean;
     /** What the drift buttons below change, i.e. an edit the page made outside the view. */
     driftColumn?: ColumnDefinition;
     driftSort?: ColumnSort;
@@ -51,6 +53,7 @@ export default function ViewTabsWithStore({
     isMutating = false,
     hasLoaded = true,
     withheldCatalogue = false,
+    isCatalogueLoaded,
     driftColumn,
     driftSort,
     driftFilter,
@@ -73,6 +76,7 @@ export default function ViewTabsWithStore({
                 <ViewTabs
                     resource={resource}
                     catalogue={isCatalogueReleased ? catalogue : []}
+                    isCatalogueLoaded={isCatalogueReleased ? isCatalogueLoaded : false}
                     standardColumns={standardColumns}
                     columns={slice.columns}
                     filters={slice.filters}
@@ -117,6 +121,19 @@ export default function ViewTabsWithStore({
                     }
                 >
                     fail the create
+                </button>
+
+                <button
+                    type="button"
+                    data-testid="simulate-delete-failure"
+                    onClick={() =>
+                        store.dispatch({
+                            type: 'listViews/deleteViewFailure',
+                            payload: { resource, error: 'Could not be deleted' },
+                        })
+                    }
+                >
+                    fail the delete
                 </button>
 
                 <button

--- a/src/components/ViewTabs/ViewTabsWithStore.tsx
+++ b/src/components/ViewTabs/ViewTabsWithStore.tsx
@@ -1,0 +1,118 @@
+import type { ListViewsTestState } from 'ducks/test-reducers';
+import { useState } from 'react';
+import { Provider, useSelector } from 'react-redux';
+import { MemoryRouter } from 'react-router';
+import type { SearchFilterModel } from 'types/certificate';
+import type { ListViewModel, ViewSlice } from 'types/listViews';
+import type { Resource, SearchFieldDataByGroupDto } from 'types/openapi';
+import type { ColumnDefinition } from 'types/tableColumns';
+import type { ColumnSort } from 'utils/tableColumns';
+import { createMockStore } from 'utils/test-helpers';
+import ViewTabs from './index';
+
+type Props = Readonly<{
+    resource: Resource;
+    /** The stored views of the resource, preloaded because a component test runs no epics. */
+    views: ListViewModel[];
+    catalogue: SearchFieldDataByGroupDto[];
+    standardColumns: ColumnDefinition[];
+    /** Preloads a mutation as in flight, which is what holds the strip's own actions. */
+    isMutating?: boolean;
+    /** What the drift buttons below change, i.e. an edit the page made outside the view. */
+    driftColumn?: ColumnDefinition;
+    driftSort?: ColumnSort;
+    driftFilter?: SearchFilterModel;
+}>;
+
+/** The listViews actions the strip has dispatched, which is all a no-epic test can observe of them. */
+function DispatchedActions() {
+    const dispatched = useSelector((state: { listViews: ListViewsTestState }) => state.listViews.dispatched);
+
+    return <div data-testid="dispatched">{JSON.stringify(dispatched)}</div>;
+}
+
+/**
+ * Stands in for the list page around {@link ViewTabs}: it owns the slice the table is showing, hands
+ * it back to the strip as props, and adopts whatever a view applies.
+ *
+ * The store is built here rather than in the test body because only serializable props cross into the
+ * browser — a store created in Node arrives with none of its preloaded state. Holding it in `useState`
+ * keeps one store across the re-renders applying a view causes, so the dispatched log survives them.
+ */
+export default function ViewTabsWithStore({
+    resource,
+    views,
+    catalogue,
+    standardColumns,
+    isMutating = false,
+    driftColumn,
+    driftSort,
+    driftFilter,
+}: Props) {
+    const [store] = useState(() =>
+        createMockStore({
+            listViews: {
+                byResource: { [resource]: { views, isFetching: false, isMutating } },
+                dispatched: [],
+            },
+        }),
+    );
+
+    const [slice, setSlice] = useState<ViewSlice>({ columns: standardColumns, filters: [], sort: undefined });
+
+    return (
+        <Provider store={store}>
+            <MemoryRouter initialEntries={['/certificates']}>
+                <ViewTabs
+                    resource={resource}
+                    catalogue={catalogue}
+                    standardColumns={standardColumns}
+                    columns={slice.columns}
+                    filters={slice.filters}
+                    sort={slice.sort}
+                    onApply={setSlice}
+                    resourceLabel="Certificates"
+                />
+
+                <div data-testid="applied-slice">{JSON.stringify(slice)}</div>
+                <DispatchedActions />
+
+                {/* Stands in for the epic (a component test runs none): answers the create in flight
+                    with the uuid the API would have assigned. */}
+                <button
+                    type="button"
+                    data-testid="simulate-create-success"
+                    onClick={() => {
+                        const pending = store.getState().listViews.byResource[resource]?.views.find((view) => view.uuid === 'pending-view');
+                        if (pending) {
+                            store.dispatch({
+                                type: 'listViews/createViewSuccess',
+                                payload: { resource, view: { ...pending, uuid: 'view-created' } },
+                            });
+                        }
+                    }}
+                >
+                    answer the create
+                </button>
+
+                <button
+                    type="button"
+                    data-testid="drift-columns"
+                    onClick={() => setSlice((current) => ({ ...current, columns: [...current.columns, driftColumn as ColumnDefinition] }))}
+                >
+                    add a column
+                </button>
+                <button type="button" data-testid="drift-sort" onClick={() => setSlice((current) => ({ ...current, sort: driftSort }))}>
+                    sort the table
+                </button>
+                <button
+                    type="button"
+                    data-testid="drift-filter"
+                    onClick={() => setSlice((current) => ({ ...current, filters: [driftFilter as SearchFilterModel] }))}
+                >
+                    filter the table
+                </button>
+            </MemoryRouter>
+        </Provider>
+    );
+}

--- a/src/components/ViewTabs/index.tsx
+++ b/src/components/ViewTabs/index.tsx
@@ -130,10 +130,20 @@ export default function ViewTabs({
         [activeView, fields, standardColumns],
     );
 
-    const storedSlice = useMemo(
-        () => (activeView ? toViewSlice(activeView, fields, standardColumns) : toStandardSlice(standardColumns)),
-        [activeView, fields, standardColumns],
-    );
+    /**
+     * The slice behind the active tab, which drift is measured against.
+     *
+     * Its filters are put through the same sieve as the live ones. A stored view can carry a filter
+     * this client would never write — one from a client that predates the rule — and comparing the
+     * sieved live filters against unsieved stored ones would report that view as permanently drifted,
+     * offering a Save that changes nothing.
+     */
+    const storedSlice = useMemo(() => {
+        if (!activeView) return toStandardSlice(standardColumns);
+
+        const slice = toViewSlice(activeView, fields, standardColumns);
+        return { ...slice, filters: toStorableFilters(slice.filters, catalogue) };
+    }, [activeView, fields, standardColumns, catalogue]);
 
     /** The stored columns this table cannot render, which the notice names and the picker can remove. */
     const unavailable = useMemo(() => resolved?.columns.filter((column) => !column.available) ?? [], [resolved]);
@@ -234,11 +244,11 @@ export default function ViewTabs({
     );
 
     const patchActive = useCallback(
-        (patch: Parameters<typeof toUpdateRequest>[1]) => {
+        (patch: Parameters<typeof toUpdateRequest>[2]) => {
             if (!activeView) return;
-            dispatch(listViewActions.updateView({ resource, uuid: activeView.uuid, view: toUpdateRequest(activeView, patch) }));
+            dispatch(listViewActions.updateView({ resource, uuid: activeView.uuid, view: toUpdateRequest(activeView, catalogue, patch) }));
         },
-        [dispatch, resource, activeView],
+        [dispatch, resource, activeView, catalogue],
     );
 
     // The view a delete took off the strip, and the tab the strip moved to instead. A delete is

--- a/src/components/ViewTabs/index.tsx
+++ b/src/components/ViewTabs/index.tsx
@@ -105,6 +105,12 @@ export default function ViewTabs({
         [activeView, fields, standardColumns],
     );
 
+    // The picker edits what the view *stores*, which is not what the table renders: a column whose
+    // field the catalogue has dropped is skipped on render, and handing the picker the rendered list
+    // would leave the stale column unreachable — invisible in the dialog the notice sends the user
+    // to, and silently discarded by the next save.
+    const pickerColumns = useMemo<ColumnDefinition[]>(() => resolved?.columns ?? storedSlice.columns, [resolved, storedSlice]);
+
     const currentSlice = useMemo<ViewSlice>(() => ({ columns, filters, sort }), [columns, filters, sort]);
     const isDirty = isSliceDirty(storedSlice, currentSlice);
 
@@ -332,7 +338,7 @@ export default function ViewTabs({
                 onClose={() => setIsPickerOpen(false)}
                 onSave={onColumnsSaved}
                 catalogue={catalogue}
-                columns={storedSlice.columns}
+                columns={pickerColumns}
                 standardColumns={standardColumns}
                 resourceLabel={resourceLabel}
                 getSourceLabel={getSourceLabel}

--- a/src/components/ViewTabs/index.tsx
+++ b/src/components/ViewTabs/index.tsx
@@ -20,7 +20,9 @@ import {
     splitTabs,
     toCreateRequest,
     toStandardSlice,
+    toStorableFilters,
     toStoredColumns,
+    toStoredColumnsKeepingUnavailable,
     toStoredSort,
     toTabs,
     toUpdateRequest,
@@ -36,6 +38,16 @@ export type ViewTabsProps = Readonly<{
     resource: Resource;
     /** The column catalogue for the resource, i.e. `GET /v1/{resource}/search`. */
     catalogue: SearchFieldDataByGroupDto[];
+    /**
+     * Whether the catalogue read has settled. The strip waits for it, because until then every stored
+     * column resolves to nothing.
+     *
+     * A page that tracks its own fetch state should say so here. The fallback reads a non-empty
+     * catalogue as an arrived one, which cannot tell a read still in flight from a resource that
+     * publishes no filter fields at all — but a catalogue that arrived carrying only fields the
+     * listing cannot display is a settled read either way, and the strip must not hide behind it.
+     */
+    isCatalogueLoaded?: boolean;
     /** The platform default column set for this page, which is what the Standard tab shows. */
     standardColumns: ColumnDefinition[];
     /** The columns the table is showing, which a saved view may since have drifted from. */
@@ -59,8 +71,8 @@ export type ViewTabsProps = Readonly<{
 type PendingDialog = 'rename' | 'create' | 'delete';
 
 /**
- * The saved-view tab strip: one tab per view, above the filter widget because a view now contains
- * its filter rather than sitting inside it.
+ * The saved-view tab strip: one tab per view, above the filter widget because filters are part of
+ * each view.
  *
  * The first tab is Standard — the platform column set the page ships with. It is deliberately not a
  * stored row, which is what makes "always present and never removable" fall out of the model rather
@@ -69,6 +81,7 @@ type PendingDialog = 'rename' | 'create' | 'delete';
 export default function ViewTabs({
     resource,
     catalogue,
+    isCatalogueLoaded,
     standardColumns,
     columns,
     filters,
@@ -99,8 +112,13 @@ export default function ViewTabs({
      * indistinguishable from one still in flight, so the first optimistic create would be mistaken for
      * the initial result. Without the catalogue, every stored column resolves to nothing, so applying
      * a view would show the platform columns under that view's name and stay there.
+     *
+     * The catalogue half is gated on the read having settled and not on it having produced anything:
+     * a resource whose catalogue publishes only fields the listing cannot display resolves to no
+     * displayable fields at all, and gating on those would hide the strip for good — Standard needs
+     * none of them.
      */
-    const isReady = hasLoaded && fields.length > 0;
+    const isReady = hasLoaded && (isCatalogueLoaded ?? catalogue.length > 0);
 
     const activeView = useMemo(() => views.find((view) => view.uuid === activeId), [views, activeId]);
     const tabs = useMemo(() => toTabs(views), [views]);
@@ -134,7 +152,14 @@ export default function ViewTabs({
         return resolved.fellBackToStandard ? resolved.renderable : resolved.columns;
     }, [resolved, storedSlice]);
 
-    const currentSlice = useMemo<ViewSlice>(() => ({ columns, filters, sort }), [columns, filters, sort]);
+    /**
+     * The live filters minus the ones a view must not carry, which is what a view is compared against
+     * and what a save writes back. See {@link toStorableFilters}: a filter value typed against secret
+     * content would otherwise be copied into storage that does not protect it.
+     */
+    const storableFilters = useMemo(() => toStorableFilters(filters, catalogue), [filters, catalogue]);
+
+    const currentSlice = useMemo<ViewSlice>(() => ({ columns, filters: storableFilters, sort }), [columns, storableFilters, sort]);
     const isDirty = isSliceDirty(storedSlice, currentSlice);
 
     // `onApply` is typically an inline callback, so holding it in a ref keeps the load effect below
@@ -216,6 +241,32 @@ export default function ViewTabs({
         [dispatch, resource, activeView],
     );
 
+    // The view a delete took off the strip, and the tab the strip moved to instead. A delete is
+    // optimistic, so a failure puts the row back — and the tab under the cursor has to go back with
+    // it rather than leave the user on another view's rows under a message saying nothing was deleted.
+    const pendingDelete = useRef<{ uuid: string; fallbackId: string } | undefined>(undefined);
+
+    useEffect(() => {
+        const pending = pendingDelete.current;
+        if (!pending) return;
+
+        const restored = views.find((view) => view.uuid === pending.uuid);
+        if (!restored) {
+            // Gone once the mutation settles is a delete that succeeded; while it is in flight the row
+            // is only optimistically absent, and the rollback may still bring it back.
+            if (!isMutating) pendingDelete.current = undefined;
+            return;
+        }
+
+        pendingDelete.current = undefined;
+        // Only if the strip is still where the delete left it: a tab the user has since picked is
+        // their choice, not the fallback's.
+        if (activeId !== pending.fallbackId) return;
+
+        setActiveId(restored.uuid);
+        applyRef.current(toViewSlice(restored, fields, standardColumns));
+    }, [views, activeId, isMutating, fields, standardColumns]);
+
     const onDelete = useCallback(() => {
         if (!activeView) return;
 
@@ -225,6 +276,7 @@ export default function ViewTabs({
         // Never to an empty table: the pinned view if one survives, otherwise Standard.
         const remaining = views.filter((view) => view.uuid !== activeView.uuid);
         const fallback = resolveInitialViewId(remaining);
+        pendingDelete.current = { uuid: activeView.uuid, fallbackId: fallback };
         setActiveId(fallback);
         apply(remaining.find((view) => view.uuid === fallback));
     }, [dispatch, resource, activeView, views, apply]);
@@ -247,8 +299,14 @@ export default function ViewTabs({
             return;
         }
 
-        patchActive({ columns: toStoredColumns(columns), filters, sort: toStoredSort(sort) });
-    }, [activeView, patchActive, columns, filters, sort]);
+        // The stored columns this table cannot render go back in: the user never saw them, so saving a
+        // filter or an ordering is not the moment to drop them. The picker is where they are removed.
+        patchActive({
+            columns: toStoredColumnsKeepingUnavailable(columns, resolved?.columns ?? []),
+            filters: storableFilters,
+            sort: toStoredSort(sort),
+        });
+    }, [activeView, patchActive, columns, resolved, storableFilters, sort]);
 
     const takenNames = useMemo(() => views.map((view) => view.name), [views]);
 

--- a/src/components/ViewTabs/index.tsx
+++ b/src/components/ViewTabs/index.tsx
@@ -81,6 +81,7 @@ export default function ViewTabs({
     const dispatch = useDispatch();
 
     const views = useSelector(listViewSelectors.views(resource));
+    const hasLoaded = useSelector(listViewSelectors.hasLoaded(resource));
     const isMutating = useSelector(listViewSelectors.isMutating(resource));
     const createdUuid = useSelector(listViewSelectors.createdUuid(resource));
 
@@ -89,6 +90,17 @@ export default function ViewTabs({
     const [dialog, setDialog] = useState<PendingDialog | undefined>(undefined);
 
     const fields = useMemo(() => toCatalogueFields(catalogue), [catalogue]);
+
+    /**
+     * The strip is held back until the view list has settled and the catalogue has arrived, and shows
+     * nothing at all until then.
+     *
+     * Both halves are load-order bugs waiting to happen otherwise. Without the list, an empty read is
+     * indistinguishable from one still in flight, so the first optimistic create would be mistaken for
+     * the initial result. Without the catalogue, every stored column resolves to nothing, so applying
+     * a view would show the platform columns under that view's name and stay there.
+     */
+    const isReady = hasLoaded && fields.length > 0;
 
     const activeView = useMemo(() => views.find((view) => view.uuid === activeId), [views, activeId]);
     const tabs = useMemo(() => toTabs(views), [views]);
@@ -105,11 +117,22 @@ export default function ViewTabs({
         [activeView, fields, standardColumns],
     );
 
-    // The picker edits what the view *stores*, which is not what the table renders: a column whose
-    // field the catalogue has dropped is skipped on render, and handing the picker the rendered list
-    // would leave the stale column unreachable — invisible in the dialog the notice sends the user
-    // to, and silently discarded by the next save.
-    const pickerColumns = useMemo<ColumnDefinition[]>(() => resolved?.columns ?? storedSlice.columns, [resolved, storedSlice]);
+    /** The stored columns this table cannot render, which the notice names and the picker can remove. */
+    const unavailable = useMemo(() => resolved?.columns.filter((column) => !column.available) ?? [], [resolved]);
+
+    /**
+     * What the column dialog edits.
+     *
+     * The stored list, unavailable columns included — handing over only what the table renders would
+     * leave a column the listing cannot display unreachable in the very dialog the notice about it
+     * sends the user to, and it would then be dropped by the next save without ever being shown.
+     * Except when nothing rendered at all: the table is showing the platform set, so that is what the
+     * dialog opens with, and Save produces a usable view rather than an empty one.
+     */
+    const pickerColumns = useMemo<ColumnDefinition[]>(() => {
+        if (!resolved) return storedSlice.columns;
+        return resolved.fellBackToStandard ? resolved.renderable : resolved.columns;
+    }, [resolved, storedSlice]);
 
     const currentSlice = useMemo<ViewSlice>(() => ({ columns, filters, sort }), [columns, filters, sort]);
     const isDirty = isSliceDirty(storedSlice, currentSlice);
@@ -142,7 +165,7 @@ export default function ViewTabs({
     // after a rename, say — must not throw the user back to the tab they started on.
     const hasOpened = useRef<Resource | undefined>(undefined);
     useEffect(() => {
-        if (hasOpened.current === resource || views.length === 0) return;
+        if (hasOpened.current === resource || !isReady) return;
         hasOpened.current = resource;
 
         const initial = resolveInitialViewId(views);
@@ -152,20 +175,37 @@ export default function ViewTabs({
                 ? toStandardSlice(standardColumns)
                 : toViewSlice(views.find((view) => view.uuid === initial) as ListViewModel, fields, standardColumns),
         );
-    }, [resource, views, fields, standardColumns]);
+    }, [resource, isReady, views, fields, standardColumns]);
+
+    // The tab the strip was on when a create started, so a create that fails has somewhere to go back
+    // to instead of leaving the strip pointing at a row the rollback has taken away.
+    const tabBeforeCreate = useRef(STANDARD_VIEW_ID);
 
     // A created view arrives with the uuid the API gave it, replacing the optimistic row the strip
-    // has been showing. The tab under the cursor has to follow it rather than vanish.
+    // has been showing, and the tab under the cursor has to follow it rather than vanish. A failed
+    // create takes that row away instead, which would leave every tab unselected.
     useEffect(() => {
-        if (activeId === PENDING_VIEW_UUID && createdUuid) setActiveId(createdUuid);
-    }, [activeId, createdUuid]);
+        if (activeId !== PENDING_VIEW_UUID) return;
+
+        if (createdUuid) {
+            setActiveId(createdUuid);
+            return;
+        }
+
+        if (!views.some((view) => view.uuid === PENDING_VIEW_UUID)) {
+            // The slice is deliberately not re-applied: the columns, filters and ordering the create
+            // was trying to keep are still on the table, and a failure is not a reason to drop them.
+            setActiveId(views.some((view) => view.uuid === tabBeforeCreate.current) ? tabBeforeCreate.current : STANDARD_VIEW_ID);
+        }
+    }, [activeId, createdUuid, views]);
 
     const createFromCurrent = useCallback(
         (name: string) => {
+            tabBeforeCreate.current = activeId;
             dispatch(listViewActions.createView({ resource, view: toCreateRequest(name, resource, currentSlice) }));
             setActiveId(PENDING_VIEW_UUID);
         },
-        [dispatch, resource, currentSlice],
+        [dispatch, resource, currentSlice, activeId],
     );
 
     const patchActive = useCallback(
@@ -231,6 +271,17 @@ export default function ViewTabs({
         ];
     }, [activeView, activeTab, takenNames, createFromCurrent, patchActive]);
 
+    // Roving focus: the tab being left becomes `tabIndex={-1}`, so focus has to travel with the
+    // selection. Left behind, it sits on an element the strip no longer treats as reachable, and what
+    // a screen reader reports then disagrees with `aria-selected`.
+    const selectByKeyboard = useCallback(
+        (id: string) => {
+            select(id);
+            document.getElementById(`view-tab-${id}`)?.focus();
+        },
+        [select],
+    );
+
     const onStripKeyDown = useCallback(
         (event: React.KeyboardEvent) => {
             const keys: Record<string, number | undefined> = {
@@ -242,17 +293,19 @@ export default function ViewTabs({
 
             if (step !== undefined && index !== -1) {
                 event.preventDefault();
-                select(visible[(index + step + visible.length) % visible.length].id);
+                selectByKeyboard(visible[(index + step + visible.length) % visible.length].id);
                 return;
             }
 
             if (event.key === 'Home' || event.key === 'End') {
                 event.preventDefault();
-                select(event.key === 'Home' ? visible[0].id : visible[visible.length - 1].id);
+                selectByKeyboard(event.key === 'Home' ? visible[0].id : visible[visible.length - 1].id);
             }
         },
-        [visible, activeId, select],
+        [visible, activeId, selectByKeyboard],
     );
+
+    if (!isReady) return null;
 
     return (
         <div className="flex flex-col gap-y-1" data-testid={dataTestId}>
@@ -314,7 +367,7 @@ export default function ViewTabs({
 
             {resolved && (
                 <UnresolvedColumnsNotice
-                    unavailable={resolved.unavailable}
+                    unavailable={unavailable}
                     storedCount={resolved.columns.length}
                     fellBackToStandard={resolved.fellBackToStandard}
                     onReview={() => setIsPickerOpen(true)}

--- a/src/components/ViewTabs/index.tsx
+++ b/src/components/ViewTabs/index.tsx
@@ -1,0 +1,386 @@
+import ColumnPicker from 'components/ColumnPicker';
+import Dialog from 'components/Dialog';
+import Dropdown, { type DropdownItem } from 'components/Dropdown';
+import SimpleBar from 'components/SimpleBar';
+import { actions as listViewActions, PENDING_VIEW_UUID, selectors as listViewSelectors } from 'ducks/listViews';
+import { ChevronDown, Plus } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import type { SearchFilterModel } from 'types/certificate';
+import type { ListViewModel, ViewSlice } from 'types/listViews';
+import type { FilterFieldSource, Resource, SearchFieldDataByGroupDto } from 'types/openapi';
+import type { ColumnDefinition } from 'types/tableColumns';
+import { toCatalogueFields } from 'utils/columnPicker';
+import {
+    STANDARD_VIEW_ID,
+    duplicateName,
+    isSliceDirty,
+    resolveInitialViewId,
+    resolveView,
+    splitTabs,
+    toCreateRequest,
+    toStandardSlice,
+    toStoredColumns,
+    toStoredSort,
+    toTabs,
+    toUpdateRequest,
+    toViewSlice,
+} from 'utils/listViews';
+import type { ColumnSort } from 'utils/tableColumns';
+import NameViewDialog from './NameViewDialog';
+import UnresolvedColumnsNotice from './UnresolvedColumnsNotice';
+import ViewSummaryBar from './ViewSummaryBar';
+import ViewTab from './ViewTab';
+
+export type ViewTabsProps = Readonly<{
+    resource: Resource;
+    /** The column catalogue for the resource, i.e. `GET /v1/{resource}/search`. */
+    catalogue: SearchFieldDataByGroupDto[];
+    /** The platform default column set for this page, which is what the Standard tab shows. */
+    standardColumns: ColumnDefinition[];
+    /** The columns the table is showing, which a saved view may since have drifted from. */
+    columns: ColumnDefinition[];
+    /** The filters the table is listing under. A view carries its filters, so they can drift too. */
+    filters: SearchFilterModel[];
+    /** The ordering the table is listing under. */
+    sort?: ColumnSort;
+    /**
+     * Applies a view: its columns, its filters and its ordering, together. The caller is expected to
+     * return to page 1 and clear its row selection — the filters change which rows exist, so a
+     * carried-over selection would span rows the user can no longer see.
+     */
+    onApply: (slice: ViewSlice) => void;
+    /** Named in the column dialog's caption, e.g. "Certificates". */
+    resourceLabel?: string;
+    getSourceLabel?: (source: FilterFieldSource) => string;
+    dataTestId?: string;
+}>;
+
+type PendingDialog = 'rename' | 'create' | 'delete';
+
+/**
+ * The saved-view tab strip: one tab per view, above the filter widget because a view now contains
+ * its filter rather than sitting inside it.
+ *
+ * The first tab is Standard — the platform column set the page ships with. It is deliberately not a
+ * stored row, which is what makes "always present and never removable" fall out of the model rather
+ * than needing a protected-row rule: there is nothing to delete, and nothing to hold a rename.
+ */
+export default function ViewTabs({
+    resource,
+    catalogue,
+    standardColumns,
+    columns,
+    filters,
+    sort,
+    onApply,
+    resourceLabel,
+    getSourceLabel,
+    dataTestId = 'view-tabs',
+}: ViewTabsProps) {
+    const dispatch = useDispatch();
+
+    const views = useSelector(listViewSelectors.views(resource));
+    const isMutating = useSelector(listViewSelectors.isMutating(resource));
+    const createdUuid = useSelector(listViewSelectors.createdUuid(resource));
+
+    const [activeId, setActiveId] = useState(STANDARD_VIEW_ID);
+    const [isPickerOpen, setIsPickerOpen] = useState(false);
+    const [dialog, setDialog] = useState<PendingDialog | undefined>(undefined);
+
+    const fields = useMemo(() => toCatalogueFields(catalogue), [catalogue]);
+
+    const activeView = useMemo(() => views.find((view) => view.uuid === activeId), [views, activeId]);
+    const tabs = useMemo(() => toTabs(views), [views]);
+    const { visible, overflow } = useMemo(() => splitTabs(tabs, activeId), [tabs, activeId]);
+    const activeTab = useMemo(() => tabs.find((tab) => tab.id === activeId) ?? tabs[0], [tabs, activeId]);
+
+    const resolved = useMemo(
+        () => (activeView ? resolveView(activeView.columns, fields, standardColumns) : undefined),
+        [activeView, fields, standardColumns],
+    );
+
+    const storedSlice = useMemo(
+        () => (activeView ? toViewSlice(activeView, fields, standardColumns) : toStandardSlice(standardColumns)),
+        [activeView, fields, standardColumns],
+    );
+
+    const currentSlice = useMemo<ViewSlice>(() => ({ columns, filters, sort }), [columns, filters, sort]);
+    const isDirty = isSliceDirty(storedSlice, currentSlice);
+
+    // `onApply` is typically an inline callback, so holding it in a ref keeps the load effect below
+    // from re-running — and re-applying the view — on every render of the page around it.
+    const applyRef = useRef(onApply);
+    applyRef.current = onApply;
+
+    const apply = useCallback(
+        (view: ListViewModel | undefined) => {
+            applyRef.current(view ? toViewSlice(view, fields, standardColumns) : toStandardSlice(standardColumns));
+        },
+        [fields, standardColumns],
+    );
+
+    const select = useCallback(
+        (id: string) => {
+            setActiveId(id);
+            apply(views.find((view) => view.uuid === id));
+        },
+        [apply, views],
+    );
+
+    useEffect(() => {
+        dispatch(listViewActions.listViews({ resource }));
+    }, [dispatch, resource]);
+
+    // The pinned view opens on load, and Standard when none is pinned. Once only: a later list read —
+    // after a rename, say — must not throw the user back to the tab they started on.
+    const hasOpened = useRef<Resource | undefined>(undefined);
+    useEffect(() => {
+        if (hasOpened.current === resource || views.length === 0) return;
+        hasOpened.current = resource;
+
+        const initial = resolveInitialViewId(views);
+        setActiveId(initial);
+        applyRef.current(
+            initial === STANDARD_VIEW_ID
+                ? toStandardSlice(standardColumns)
+                : toViewSlice(views.find((view) => view.uuid === initial) as ListViewModel, fields, standardColumns),
+        );
+    }, [resource, views, fields, standardColumns]);
+
+    // A created view arrives with the uuid the API gave it, replacing the optimistic row the strip
+    // has been showing. The tab under the cursor has to follow it rather than vanish.
+    useEffect(() => {
+        if (activeId === PENDING_VIEW_UUID && createdUuid) setActiveId(createdUuid);
+    }, [activeId, createdUuid]);
+
+    const createFromCurrent = useCallback(
+        (name: string) => {
+            dispatch(listViewActions.createView({ resource, view: toCreateRequest(name, resource, currentSlice) }));
+            setActiveId(PENDING_VIEW_UUID);
+        },
+        [dispatch, resource, currentSlice],
+    );
+
+    const patchActive = useCallback(
+        (patch: Parameters<typeof toUpdateRequest>[1]) => {
+            if (!activeView) return;
+            dispatch(listViewActions.updateView({ resource, uuid: activeView.uuid, view: toUpdateRequest(activeView, patch) }));
+        },
+        [dispatch, resource, activeView],
+    );
+
+    const onDelete = useCallback(() => {
+        if (!activeView) return;
+
+        dispatch(listViewActions.deleteView({ resource, uuid: activeView.uuid }));
+        setDialog(undefined);
+
+        // Never to an empty table: the pinned view if one survives, otherwise Standard.
+        const remaining = views.filter((view) => view.uuid !== activeView.uuid);
+        const fallback = resolveInitialViewId(remaining);
+        setActiveId(fallback);
+        apply(remaining.find((view) => view.uuid === fallback));
+    }, [dispatch, resource, activeView, views, apply]);
+
+    const onColumnsSaved = useCallback(
+        (saved: ColumnDefinition[]) => {
+            setIsPickerOpen(false);
+            patchActive({ columns: toStoredColumns(saved) });
+            // The live filters and ordering are kept: the dialog edits the columns of the view, and
+            // re-applying the stored slice here would silently drop an unsaved filter beside it.
+            applyRef.current({ columns: saved, filters, sort });
+        },
+        [patchActive, filters, sort],
+    );
+
+    const onSaveDrift = useCallback(() => {
+        if (!activeView) {
+            // Standard has nothing to save into, so the offer is to keep the change as a new view.
+            setDialog('create');
+            return;
+        }
+
+        patchActive({ columns: toStoredColumns(columns), filters, sort: toStoredSort(sort) });
+    }, [activeView, patchActive, columns, filters, sort]);
+
+    const takenNames = useMemo(() => views.map((view) => view.name), [views]);
+
+    const menuItems = useMemo<DropdownItem[]>(() => {
+        const duplicate: DropdownItem = {
+            title: 'Duplicate',
+            onClick: () => createFromCurrent(duplicateName(activeTab.name, takenNames)),
+        };
+
+        // On Standard the rest are absent rather than disabled: they will never become available,
+        // because Standard has no stored row to rename, pin, edit or delete.
+        if (!activeView) return [duplicate];
+
+        return [
+            { title: 'Edit columns…', onClick: () => setIsPickerOpen(true) },
+            { title: 'Rename…', onClick: () => setDialog('rename') },
+            duplicate,
+            ...(activeView.defaultView ? [] : [{ title: 'Open this view by default', onClick: () => patchActive({ defaultView: true }) }]),
+            { title: 'Delete view', color: 'danger' as const, onClick: () => setDialog('delete') },
+        ];
+    }, [activeView, activeTab, takenNames, createFromCurrent, patchActive]);
+
+    const onStripKeyDown = useCallback(
+        (event: React.KeyboardEvent) => {
+            const keys: Record<string, number | undefined> = {
+                ArrowLeft: -1,
+                ArrowRight: 1,
+            };
+            const step = keys[event.key];
+            const index = visible.findIndex((tab) => tab.id === activeId);
+
+            if (step !== undefined && index !== -1) {
+                event.preventDefault();
+                select(visible[(index + step + visible.length) % visible.length].id);
+                return;
+            }
+
+            if (event.key === 'Home' || event.key === 'End') {
+                event.preventDefault();
+                select(event.key === 'Home' ? visible[0].id : visible[visible.length - 1].id);
+            }
+        },
+        [visible, activeId, select],
+    );
+
+    return (
+        <div className="flex flex-col gap-y-1" data-testid={dataTestId}>
+            <SimpleBar forceVisible="x">
+                <div
+                    role="tablist"
+                    aria-label="Saved views"
+                    className="flex items-center gap-x-1"
+                    onKeyDown={onStripKeyDown}
+                    data-testid={`${dataTestId}-strip`}
+                >
+                    {visible.map((tab) => (
+                        <ViewTab
+                            key={tab.id}
+                            tab={tab}
+                            isActive={tab.id === activeId}
+                            isDirty={tab.id === activeId && isDirty}
+                            onSelect={() => select(tab.id)}
+                            dataTestId={`${dataTestId}-tab-${tab.id}`}
+                            menu={
+                                tab.id === activeId ? (
+                                    <Dropdown
+                                        btnStyle="transparent"
+                                        hideArrow
+                                        disabled={isMutating}
+                                        ariaLabel={`Actions for ${tab.name}`}
+                                        className="pr-1"
+                                        title={<ChevronDown className="size-4" />}
+                                        items={menuItems}
+                                    />
+                                ) : undefined
+                            }
+                        />
+                    ))}
+
+                    {overflow.length > 0 && (
+                        <Dropdown
+                            btnStyle="transparent"
+                            ariaLabel="More saved views"
+                            title={`${overflow.length} more`}
+                            menuClassName="max-h-80 overflow-y-auto"
+                            items={overflow.map((tab) => ({ title: tab.name, onClick: () => select(tab.id) }))}
+                        />
+                    )}
+
+                    <button
+                        type="button"
+                        onClick={() => setDialog('create')}
+                        disabled={isMutating}
+                        aria-label="New view"
+                        title="New view"
+                        data-testid={`${dataTestId}-new`}
+                        className="inline-flex items-center rounded-lg p-3 text-content-subtle hover:bg-surface-hover hover:text-content focus:outline-hidden disabled:opacity-50"
+                    >
+                        <Plus className="size-4" />
+                    </button>
+                </div>
+            </SimpleBar>
+
+            {resolved && (
+                <UnresolvedColumnsNotice
+                    unavailable={resolved.unavailable}
+                    storedCount={resolved.columns.length}
+                    fellBackToStandard={resolved.fellBackToStandard}
+                    onReview={() => setIsPickerOpen(true)}
+                    dataTestId={`${dataTestId}-notice`}
+                />
+            )}
+
+            <ViewSummaryBar
+                columns={columns}
+                sort={sort}
+                isDirty={isDirty}
+                isStandard={activeView === undefined}
+                isBusy={isMutating}
+                onRevert={() => apply(activeView)}
+                onSave={onSaveDrift}
+                dataTestId={`${dataTestId}-summary`}
+            />
+
+            <ColumnPicker
+                isOpen={isPickerOpen}
+                onClose={() => setIsPickerOpen(false)}
+                onSave={onColumnsSaved}
+                catalogue={catalogue}
+                columns={storedSlice.columns}
+                standardColumns={standardColumns}
+                resourceLabel={resourceLabel}
+                getSourceLabel={getSourceLabel}
+                dataTestId={`${dataTestId}-picker`}
+            />
+
+            <NameViewDialog
+                isOpen={dialog === 'create'}
+                caption="New view"
+                confirmLabel="Create view"
+                initialName={duplicateName(activeTab.name, takenNames)}
+                takenNames={takenNames}
+                isBusy={isMutating}
+                onClose={() => setDialog(undefined)}
+                onSubmit={(name) => {
+                    setDialog(undefined);
+                    createFromCurrent(name);
+                }}
+                dataTestId={`${dataTestId}-create`}
+            />
+
+            <NameViewDialog
+                isOpen={dialog === 'rename'}
+                caption="Rename view"
+                confirmLabel="Rename"
+                initialName={activeTab.name}
+                takenNames={takenNames}
+                isBusy={isMutating}
+                onClose={() => setDialog(undefined)}
+                onSubmit={(name) => {
+                    setDialog(undefined);
+                    patchActive({ name });
+                }}
+                dataTestId={`${dataTestId}-rename`}
+            />
+
+            <Dialog
+                isOpen={dialog === 'delete'}
+                toggle={() => setDialog(undefined)}
+                caption="Delete view"
+                icon="delete"
+                body={`You are about to delete the view "${activeTab.name}". Is this what you want to do?`}
+                dataTestId={`${dataTestId}-delete`}
+                buttons={[
+                    { color: 'secondary', variant: 'outline', onClick: () => setDialog(undefined), body: 'Cancel' },
+                    { color: 'danger', onClick: onDelete, body: 'Delete' },
+                ]}
+            />
+        </div>
+    );
+}

--- a/src/ducks/index.ts
+++ b/src/ducks/index.ts
@@ -33,6 +33,7 @@ import enumsEpics from './enums-epics';
 import filtersEpics from './filters-epics';
 import globalMetadataEpics from './globalMetadata-epics';
 import infoEpics from './info-epics';
+import listViewsEpics from './listViews-epics';
 import locationsEpics from './locations-epics';
 import notificationsEpics from './notifications-epics';
 import notificationProfilesEpics from './notification-profiles-epics';
@@ -105,6 +106,7 @@ export const epics = combineEpics(
     ...credentialsEpics,
     ...entitiesEpics,
     ...filtersEpics,
+    ...listViewsEpics,
     ...locationsEpics,
     ...auditLogsEpics,
     ...customAttributesEpics,

--- a/src/ducks/listViews-epics.spec.ts
+++ b/src/ducks/listViews-epics.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
-import { Observable, firstValueFrom, of, throwError } from 'rxjs';
+import { Observable, firstValueFrom, from, of, throwError } from 'rxjs';
 import { AjaxError } from 'rxjs/ajax';
-import { take, toArray } from 'rxjs/operators';
+import { delay, take, toArray } from 'rxjs/operators';
 import type { ListViewModel } from 'types/listViews';
 import { FilterFieldSource, Resource } from 'types/openapi';
 import { actions as alertActions } from './alerts';
@@ -56,6 +56,14 @@ async function run(index: number, action: unknown, deps: unknown, expected: numb
     return firstValueFrom(epic(of(action), of({}), deps).pipe(take(expected), toArray()));
 }
 
+/** Both reads dispatched back to back, which is what a page mounting two strips at once does. */
+async function readBoth(actionsToDispatch: unknown[], deps: unknown, expected = 2) {
+    const epic = epics[LIST] as unknown as EpicUnderTest;
+    return firstValueFrom(epic(from(actionsToDispatch), of({}), deps).pipe(take(expected), toArray()));
+}
+
+const resourceOf = (action: { payload?: unknown }) => (action.payload as { resource: Resource }).resource;
+
 describe('listViews', () => {
     test('answers a read with the stored views', async () => {
         const [emitted] = await run(LIST, actions.listViews({ resource: Resource.Certificates }), createDeps(), 1);
@@ -78,6 +86,35 @@ describe('listViews', () => {
         expect(failure.type).toBe(actions.listViewsFailure.type);
         expect(alert.type).toBe(alertActions.error.type);
         expect(alert.payload).toContain('Failed to get saved views');
+    });
+
+    test('a read of one resource does not cancel a read of another still in flight', async () => {
+        // The slower answer is the one asked for first, so an ungrouped switch would drop it: a
+        // cancelled read emits neither success nor failure, and its strip would wait for ever.
+        const deps = createDeps({
+            listViews: ({ resource }) => (resource === Resource.Certificates ? of([stored]).pipe(delay(20)) : of([]).pipe(delay(1))),
+        });
+
+        const emitted = await readBoth(
+            [actions.listViews({ resource: Resource.Certificates }), actions.listViews({ resource: Resource.Secrets })],
+            deps,
+        );
+
+        expect(emitted.map((action) => action.type)).toEqual([actions.listViewsSuccess.type, actions.listViewsSuccess.type]);
+        expect(emitted.map(resourceOf).sort()).toEqual([Resource.Certificates, Resource.Secrets]);
+    });
+
+    test('a second read of the same resource still supersedes the first', async () => {
+        const answers = [of([stored]).pipe(delay(20)), of([]).pipe(delay(1))];
+        const deps = createDeps({ listViews: () => answers.shift() ?? of([]) });
+
+        const [emitted] = await readBoth(
+            [actions.listViews({ resource: Resource.Certificates }), actions.listViews({ resource: Resource.Certificates })],
+            deps,
+            1,
+        );
+
+        expect(emitted).toEqual(actions.listViewsSuccess({ resource: Resource.Certificates, views: [] }));
     });
 });
 

--- a/src/ducks/listViews-epics.spec.ts
+++ b/src/ducks/listViews-epics.spec.ts
@@ -1,0 +1,169 @@
+import { describe, expect, test } from 'vitest';
+import { type Observable, firstValueFrom, of, throwError } from 'rxjs';
+import { AjaxError } from 'rxjs/ajax';
+import { take, toArray } from 'rxjs/operators';
+import type { ListViewModel } from 'types/listViews';
+import { FilterFieldSource, Resource } from 'types/openapi';
+import { actions as alertActions } from './alerts';
+import epics from './listViews-epics';
+import { actions } from './listViews';
+
+const columns = [{ fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME' }];
+
+const stored: ListViewModel = {
+    uuid: 'a',
+    name: 'Expiry watch',
+    resource: Resource.Certificates,
+    columns,
+    defaultView: false,
+};
+
+/** Same shape `app-redirect.spec.ts` uses: an `AjaxError` cannot be constructed without a real XHR. */
+const ajaxError = (status: number, message: string): AjaxError => {
+    const err = Object.assign(new Error(message), { name: 'AjaxError', status });
+    Object.setPrototypeOf(err, AjaxError.prototype);
+    return err as unknown as AjaxError;
+};
+
+type ListViewApiStubs = {
+    listViews: (args: { resource: Resource }) => unknown;
+    createView: (args: { listViewRequestDto: unknown }) => unknown;
+    editView: (args: { uuid: string; listViewUpdateRequestDto: unknown }) => unknown;
+    deleteView: (args: { uuid: string }) => unknown;
+};
+
+function createDeps(overrides: Partial<ListViewApiStubs> = {}) {
+    return {
+        apiClients: {
+            listViews: {
+                listViews: () => of([stored]),
+                createView: () => of(stored),
+                editView: () => of(stored),
+                deleteView: () => of(undefined),
+                ...overrides,
+            },
+        },
+    };
+}
+
+const [LIST, CREATE, UPDATE, DELETE] = [0, 1, 2, 3];
+
+type EpicUnderTest = (action$: unknown, state$: unknown, deps: unknown) => Observable<{ type: string; payload?: never }>;
+
+async function run(index: number, action: unknown, deps: unknown, expected: number) {
+    const epic = epics[index] as unknown as EpicUnderTest;
+    return firstValueFrom(epic(of(action), of({}), deps).pipe(take(expected), toArray()));
+}
+
+describe('listViews', () => {
+    test('answers a read with the stored views', async () => {
+        const [emitted] = await run(LIST, actions.listViews({ resource: Resource.Certificates }), createDeps(), 1);
+
+        expect(emitted).toEqual(actions.listViewsSuccess({ resource: Resource.Certificates, views: [stored] }));
+    });
+
+    test('a failed read reports the error against the resource it was for', async () => {
+        const deps = createDeps({ listViews: () => throwError(() => ajaxError(500, 'boom')) });
+        const [emitted] = await run(LIST, actions.listViews({ resource: Resource.Certificates }), deps, 1);
+
+        expect(emitted.type).toBe(actions.listViewsFailure.type);
+        expect(emitted).toMatchObject({ payload: { resource: Resource.Certificates } });
+    });
+
+    test('a read is not paired with an alert; the strip simply shows Standard alone', async () => {
+        const deps = createDeps({ listViews: () => throwError(() => ajaxError(500, 'boom')) });
+        const emitted = await firstValueFrom(
+            (epics[LIST] as unknown as EpicUnderTest)(of(actions.listViews({ resource: Resource.Certificates })), of({}), deps).pipe(
+                toArray(),
+            ),
+        );
+
+        expect(emitted).toHaveLength(1);
+    });
+});
+
+describe('createView', () => {
+    const request = { name: 'Expiry watch', resource: Resource.Certificates, columns };
+
+    test('sends the request body through and carries the stored row back', async () => {
+        let sent: unknown;
+        const deps = createDeps({
+            createView: (args) => {
+                sent = args.listViewRequestDto;
+                return of(stored);
+            },
+        });
+
+        const [emitted] = await run(CREATE, actions.createView({ resource: Resource.Certificates, view: request }), deps, 1);
+
+        expect(sent).toEqual(request);
+        expect(emitted).toEqual(actions.createViewSuccess({ resource: Resource.Certificates, view: stored }));
+    });
+
+    test('a failure both rolls the strip back and surfaces the message', async () => {
+        const deps = createDeps({ createView: () => throwError(() => ajaxError(409, 'Name already used')) });
+        const [failure, alert] = await run(CREATE, actions.createView({ resource: Resource.Certificates, view: request }), deps, 2);
+
+        expect(failure.type).toBe(actions.createViewFailure.type);
+        expect(alert.type).toBe(alertActions.error.type);
+        expect(alert.payload).toContain('Failed to create the view');
+        expect(alert.payload).toContain('Name already used');
+    });
+});
+
+describe('updateView', () => {
+    const update = { name: 'Renamed', columns };
+
+    test('addresses the stored view by uuid and carries the answer back', async () => {
+        let sent: { uuid: string; listViewUpdateRequestDto: unknown } | undefined;
+        const deps = createDeps({
+            editView: (args) => {
+                sent = args;
+                return of(stored);
+            },
+        });
+
+        const [emitted] = await run(UPDATE, actions.updateView({ resource: Resource.Certificates, uuid: 'a', view: update }), deps, 1);
+
+        expect(sent).toEqual({ uuid: 'a', listViewUpdateRequestDto: update });
+        expect(emitted).toEqual(actions.updateViewSuccess({ resource: Resource.Certificates, view: stored }));
+    });
+
+    test('a failure rolls back and surfaces the message', async () => {
+        const deps = createDeps({ editView: () => throwError(() => ajaxError(500, 'boom')) });
+        const [failure, alert] = await run(
+            UPDATE,
+            actions.updateView({ resource: Resource.Certificates, uuid: 'a', view: update }),
+            deps,
+            2,
+        );
+
+        expect(failure.type).toBe(actions.updateViewFailure.type);
+        expect(alert.payload).toContain('Failed to save the view');
+    });
+});
+
+describe('deleteView', () => {
+    test('confirms the deletion of the uuid it was given, since the API answers with nothing', async () => {
+        let sent: unknown;
+        const deps = createDeps({
+            deleteView: (args) => {
+                sent = args;
+                return of(undefined);
+            },
+        });
+
+        const [emitted] = await run(DELETE, actions.deleteView({ resource: Resource.Certificates, uuid: 'a' }), deps, 1);
+
+        expect(sent).toEqual({ uuid: 'a' });
+        expect(emitted).toEqual(actions.deleteViewSuccess({ resource: Resource.Certificates, uuid: 'a' }));
+    });
+
+    test('a failure rolls back and surfaces the message', async () => {
+        const deps = createDeps({ deleteView: () => throwError(() => ajaxError(404, 'Gone')) });
+        const [failure, alert] = await run(DELETE, actions.deleteView({ resource: Resource.Certificates, uuid: 'a' }), deps, 2);
+
+        expect(failure.type).toBe(actions.deleteViewFailure.type);
+        expect(alert.payload).toContain('Failed to delete the view');
+    });
+});

--- a/src/ducks/listViews-epics.spec.ts
+++ b/src/ducks/listViews-epics.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { type Observable, firstValueFrom, of, throwError } from 'rxjs';
+import { Observable, firstValueFrom, of, throwError } from 'rxjs';
 import { AjaxError } from 'rxjs/ajax';
 import { take, toArray } from 'rxjs/operators';
 import type { ListViewModel } from 'types/listViews';
@@ -46,7 +46,8 @@ function createDeps(overrides: Partial<ListViewApiStubs> = {}) {
     };
 }
 
-const [LIST, CREATE, UPDATE, DELETE] = [0, 1, 2, 3];
+// Every mutation shares one epic, because they share one rollback snapshot per resource.
+const [LIST, MUTATE] = [0, 1];
 
 type EpicUnderTest = (action$: unknown, state$: unknown, deps: unknown) => Observable<{ type: string; payload?: never }>;
 
@@ -70,15 +71,13 @@ describe('listViews', () => {
         expect(emitted).toMatchObject({ payload: { resource: Resource.Certificates } });
     });
 
-    test('a read is not paired with an alert; the strip simply shows Standard alone', async () => {
+    test('a failed read is surfaced, since an unread list is otherwise indistinguishable from an empty one', async () => {
         const deps = createDeps({ listViews: () => throwError(() => ajaxError(500, 'boom')) });
-        const emitted = await firstValueFrom(
-            (epics[LIST] as unknown as EpicUnderTest)(of(actions.listViews({ resource: Resource.Certificates })), of({}), deps).pipe(
-                toArray(),
-            ),
-        );
+        const [failure, alert] = await run(LIST, actions.listViews({ resource: Resource.Certificates }), deps, 2);
 
-        expect(emitted).toHaveLength(1);
+        expect(failure.type).toBe(actions.listViewsFailure.type);
+        expect(alert.type).toBe(alertActions.error.type);
+        expect(alert.payload).toContain('Failed to get saved views');
     });
 });
 
@@ -94,7 +93,7 @@ describe('createView', () => {
             },
         });
 
-        const [emitted] = await run(CREATE, actions.createView({ resource: Resource.Certificates, view: request }), deps, 1);
+        const [emitted] = await run(MUTATE, actions.createView({ resource: Resource.Certificates, view: request }), deps, 1);
 
         expect(sent).toEqual(request);
         expect(emitted).toEqual(actions.createViewSuccess({ resource: Resource.Certificates, view: stored }));
@@ -102,7 +101,7 @@ describe('createView', () => {
 
     test('a failure both rolls the strip back and surfaces the message', async () => {
         const deps = createDeps({ createView: () => throwError(() => ajaxError(409, 'Name already used')) });
-        const [failure, alert] = await run(CREATE, actions.createView({ resource: Resource.Certificates, view: request }), deps, 2);
+        const [failure, alert] = await run(MUTATE, actions.createView({ resource: Resource.Certificates, view: request }), deps, 2);
 
         expect(failure.type).toBe(actions.createViewFailure.type);
         expect(alert.type).toBe(alertActions.error.type);
@@ -123,7 +122,7 @@ describe('updateView', () => {
             },
         });
 
-        const [emitted] = await run(UPDATE, actions.updateView({ resource: Resource.Certificates, uuid: 'a', view: update }), deps, 1);
+        const [emitted] = await run(MUTATE, actions.updateView({ resource: Resource.Certificates, uuid: 'a', view: update }), deps, 1);
 
         expect(sent).toEqual({ uuid: 'a', listViewUpdateRequestDto: update });
         expect(emitted).toEqual(actions.updateViewSuccess({ resource: Resource.Certificates, view: stored }));
@@ -132,7 +131,7 @@ describe('updateView', () => {
     test('a failure rolls back and surfaces the message', async () => {
         const deps = createDeps({ editView: () => throwError(() => ajaxError(500, 'boom')) });
         const [failure, alert] = await run(
-            UPDATE,
+            MUTATE,
             actions.updateView({ resource: Resource.Certificates, uuid: 'a', view: update }),
             deps,
             2,
@@ -153,7 +152,7 @@ describe('deleteView', () => {
             },
         });
 
-        const [emitted] = await run(DELETE, actions.deleteView({ resource: Resource.Certificates, uuid: 'a' }), deps, 1);
+        const [emitted] = await run(MUTATE, actions.deleteView({ resource: Resource.Certificates, uuid: 'a' }), deps, 1);
 
         expect(sent).toEqual({ uuid: 'a' });
         expect(emitted).toEqual(actions.deleteViewSuccess({ resource: Resource.Certificates, uuid: 'a' }));
@@ -161,9 +160,81 @@ describe('deleteView', () => {
 
     test('a failure rolls back and surfaces the message', async () => {
         const deps = createDeps({ deleteView: () => throwError(() => ajaxError(404, 'Gone')) });
-        const [failure, alert] = await run(DELETE, actions.deleteView({ resource: Resource.Certificates, uuid: 'a' }), deps, 2);
+        const [failure, alert] = await run(MUTATE, actions.deleteView({ resource: Resource.Certificates, uuid: 'a' }), deps, 2);
 
         expect(failure.type).toBe(actions.deleteViewFailure.type);
         expect(alert.payload).toContain('Failed to delete the view');
+    });
+});
+
+describe('serialising the mutations', () => {
+    test('a create and the delete behind it do not run at once, whatever their kinds', async () => {
+        const log: string[] = [];
+
+        const answer = <T>(name: string, value: T): Observable<T> =>
+            new Observable<T>((subscriber) => {
+                log.push(`${name}:start`);
+                setTimeout(() => {
+                    log.push(`${name}:end`);
+                    subscriber.next(value);
+                    subscriber.complete();
+                }, 0);
+            });
+
+        const deps = createDeps({
+            createView: () => answer('create', stored),
+            deleteView: () => answer('delete', undefined),
+        });
+
+        const emitted = await firstValueFrom(
+            (epics[MUTATE] as unknown as EpicUnderTest)(
+                of(
+                    actions.createView({
+                        resource: Resource.Certificates,
+                        view: { name: 'Expiry watch', resource: Resource.Certificates, columns },
+                    }),
+                    actions.deleteView({ resource: Resource.Certificates, uuid: 'a' }),
+                ),
+                of({}),
+                deps,
+            ).pipe(take(2), toArray()),
+        );
+
+        // The reducer holds one rollback snapshot and one `isMutating` flag per resource, so the second
+        // write must not start until the first has settled — even though it is a different operation.
+        expect(log).toEqual(['create:start', 'create:end', 'delete:start', 'delete:end']);
+        expect(emitted.map((action) => action.type)).toEqual([actions.createViewSuccess.type, actions.deleteViewSuccess.type]);
+    });
+
+    test('two resources are not held up by one another', async () => {
+        const inFlight: string[] = [];
+
+        const deps = createDeps({
+            createView: (args) => {
+                const { name } = args.listViewRequestDto as { name: string };
+                return new Observable((subscriber) => {
+                    inFlight.push(name);
+                    // Never settles: a second resource must still be able to start.
+                    return () => subscriber.complete();
+                });
+            },
+        });
+
+        (epics[MUTATE] as unknown as EpicUnderTest)(
+            of(
+                actions.createView({
+                    resource: Resource.Certificates,
+                    view: { name: 'certificates', resource: Resource.Certificates, columns },
+                }),
+                actions.createView({
+                    resource: Resource.Cryptographickeys,
+                    view: { name: 'keys', resource: Resource.Cryptographickeys, columns },
+                }),
+            ),
+            of({}),
+            deps,
+        ).subscribe();
+
+        expect(inFlight).toEqual(['certificates', 'keys']);
     });
 });

--- a/src/ducks/listViews-epics.ts
+++ b/src/ducks/listViews-epics.ts
@@ -25,18 +25,31 @@ function requestFailed(action: FailureAction, resource: Resource, err: Error, fa
     return of(action({ resource, error }), alertActions.error(error));
 }
 
+/**
+ * The saved views of one resource, re-read whenever the strip asks.
+ *
+ * `switchMap` within a `groupBy`, for the same reason the mutations are grouped: the fetch flags are
+ * keyed per resource. Superseding a read of the same resource is the point — a stale answer must not
+ * land after the one that replaced it — but cancelling emits neither success nor failure, so
+ * switching across resources would strand the resource left behind on `isFetching`, and a strip
+ * mounted for it would never become ready.
+ */
 const listViews: AppEpic = (action$, state$, deps) => {
     return action$.pipe(
         filter(slice.actions.listViews.match),
-        // switchMap: the strip reads one resource at a time, and a superseded read must not land
-        // after the one that replaced it.
-        switchMap((action) =>
-            deps.apiClients.listViews.listViews({ resource: action.payload.resource }).pipe(
-                map((views) => slice.actions.listViewsSuccess({ resource: action.payload.resource, views })),
-                catchError((err) =>
-                    // Without the alert a failed read is indistinguishable from a user who has saved
-                    // nothing: the strip settles on Standard alone and offers to create beside it.
-                    requestFailed(slice.actions.listViewsFailure, action.payload.resource, err, 'Failed to get saved views'),
+        groupBy((action) => action.payload.resource),
+        mergeMap((perResource) =>
+            perResource.pipe(
+                switchMap((action) =>
+                    deps.apiClients.listViews.listViews({ resource: action.payload.resource }).pipe(
+                        map((views) => slice.actions.listViewsSuccess({ resource: action.payload.resource, views })),
+                        catchError((err) =>
+                            // Without the alert a failed read is indistinguishable from a user who has
+                            // saved nothing: the strip settles on Standard alone and offers to create
+                            // beside it.
+                            requestFailed(slice.actions.listViewsFailure, action.payload.resource, err, 'Failed to get saved views'),
+                        ),
+                    ),
                 ),
             ),
         ),

--- a/src/ducks/listViews-epics.ts
+++ b/src/ducks/listViews-epics.ts
@@ -1,22 +1,26 @@
 import type { AppEpic } from 'ducks';
 import { type Observable, of } from 'rxjs';
-import { catchError, concatMap, filter, map, switchMap } from 'rxjs/operators';
+import { catchError, concatMap, filter, groupBy, map, mergeMap, switchMap } from 'rxjs/operators';
 import type { UnknownAction } from 'redux';
 import type { Resource } from 'types/openapi';
 import { extractError } from 'utils/net';
 import { actions as alertActions } from './alerts';
 import { slice } from './listViews';
 
+type Dependencies = Parameters<AppEpic>[2];
+
 type FailureAction = (payload: { resource: Resource; error: string }) => UnknownAction;
 
 /**
- * A failed mutation both rolls the strip back and says so.
+ * A failed request both settles the strip and says so.
  *
  * The message goes to an alert rather than to `appRedirectActions.fetchError`, which the sibling
- * ducks use for a read: the tab the user just created has already disappeared again, so the failure
- * has to be readable beside the strip that undid it rather than on a page they were sent to.
+ * ducks use for a read: the strip is one widget on a page that lists rows of its own, so sending the
+ * whole page to an error screen because its saved views could not be read is out of proportion — and
+ * for a mutation, the tab the user just created has already disappeared again, so the failure has to
+ * be readable beside the strip that undid it rather than on a page they were sent to.
  */
-function mutationFailed(action: FailureAction, resource: Resource, err: Error, fallback: string): Observable<UnknownAction> {
+function requestFailed(action: FailureAction, resource: Resource, err: Error, fallback: string): Observable<UnknownAction> {
     const error = extractError(err, fallback);
     return of(action({ resource, error }), alertActions.error(error));
 }
@@ -30,62 +34,65 @@ const listViews: AppEpic = (action$, state$, deps) => {
             deps.apiClients.listViews.listViews({ resource: action.payload.resource }).pipe(
                 map((views) => slice.actions.listViewsSuccess({ resource: action.payload.resource, views })),
                 catchError((err) =>
-                    of(
-                        slice.actions.listViewsFailure({
-                            resource: action.payload.resource,
-                            error: extractError(err, 'Failed to get saved views'),
-                        }),
-                    ),
+                    // Without the alert a failed read is indistinguishable from a user who has saved
+                    // nothing: the strip settles on Standard alone and offers to create beside it.
+                    requestFailed(slice.actions.listViewsFailure, action.payload.resource, err, 'Failed to get saved views'),
                 ),
             ),
         ),
     );
 };
 
-const createView: AppEpic = (action$, state$, deps) => {
+type MutationAction =
+    | ReturnType<typeof slice.actions.createView>
+    | ReturnType<typeof slice.actions.updateView>
+    | ReturnType<typeof slice.actions.deleteView>;
+
+function isMutation(action: UnknownAction): action is MutationAction {
+    return slice.actions.createView.match(action) || slice.actions.updateView.match(action) || slice.actions.deleteView.match(action);
+}
+
+function runMutation(action: MutationAction, deps: Dependencies): Observable<UnknownAction> {
+    const { resource } = action.payload;
+
+    if (slice.actions.createView.match(action)) {
+        return deps.apiClients.listViews.createView({ listViewRequestDto: action.payload.view }).pipe(
+            map((view) => slice.actions.createViewSuccess({ resource, view })),
+            catchError((err) => requestFailed(slice.actions.createViewFailure, resource, err, 'Failed to create the view')),
+        );
+    }
+
+    if (slice.actions.updateView.match(action)) {
+        return deps.apiClients.listViews.editView({ uuid: action.payload.uuid, listViewUpdateRequestDto: action.payload.view }).pipe(
+            map((view) => slice.actions.updateViewSuccess({ resource, view })),
+            catchError((err) => requestFailed(slice.actions.updateViewFailure, resource, err, 'Failed to save the view')),
+        );
+    }
+
+    const { uuid } = action.payload;
+    return deps.apiClients.listViews.deleteView({ uuid }).pipe(
+        map(() => slice.actions.deleteViewSuccess({ resource, uuid })),
+        catchError((err) => requestFailed(slice.actions.deleteViewFailure, resource, err, 'Failed to delete the view')),
+    );
+}
+
+/**
+ * Every create, edit and delete of one resource, run one at a time.
+ *
+ * They share a pipeline rather than owning one each because the rollback snapshot and the
+ * `isMutating` flag are single per resource: two writes in flight together — of any kinds, not only
+ * two of the same kind — would let the second snapshot the first one's optimistic state and then
+ * restore or clear it. `groupBy` keeps the serialisation per resource, which is the granularity the
+ * state is keyed at, so one resource's slow write does not hold up another's.
+ */
+const mutateViews: AppEpic = (action$, state$, deps) => {
     return action$.pipe(
-        filter(slice.actions.createView.match),
-        // concatMap on every mutation: the strip holds a single rollback snapshot, so two writes in
-        // flight at once would leave the second able to roll back over the first one's result.
-        concatMap((action) =>
-            deps.apiClients.listViews.createView({ listViewRequestDto: action.payload.view }).pipe(
-                map((view) => slice.actions.createViewSuccess({ resource: action.payload.resource, view })),
-                catchError((err) =>
-                    mutationFailed(slice.actions.createViewFailure, action.payload.resource, err, 'Failed to create the view'),
-                ),
-            ),
-        ),
+        filter(isMutation),
+        groupBy((action) => action.payload.resource),
+        mergeMap((perResource) => perResource.pipe(concatMap((action) => runMutation(action, deps)))),
     );
 };
 
-const updateView: AppEpic = (action$, state$, deps) => {
-    return action$.pipe(
-        filter(slice.actions.updateView.match),
-        concatMap((action) =>
-            deps.apiClients.listViews.editView({ uuid: action.payload.uuid, listViewUpdateRequestDto: action.payload.view }).pipe(
-                map((view) => slice.actions.updateViewSuccess({ resource: action.payload.resource, view })),
-                catchError((err) =>
-                    mutationFailed(slice.actions.updateViewFailure, action.payload.resource, err, 'Failed to save the view'),
-                ),
-            ),
-        ),
-    );
-};
-
-const deleteView: AppEpic = (action$, state$, deps) => {
-    return action$.pipe(
-        filter(slice.actions.deleteView.match),
-        concatMap((action) =>
-            deps.apiClients.listViews.deleteView({ uuid: action.payload.uuid }).pipe(
-                map(() => slice.actions.deleteViewSuccess({ resource: action.payload.resource, uuid: action.payload.uuid })),
-                catchError((err) =>
-                    mutationFailed(slice.actions.deleteViewFailure, action.payload.resource, err, 'Failed to delete the view'),
-                ),
-            ),
-        ),
-    );
-};
-
-const epics = [listViews, createView, updateView, deleteView];
+const epics = [listViews, mutateViews];
 
 export default epics;

--- a/src/ducks/listViews-epics.ts
+++ b/src/ducks/listViews-epics.ts
@@ -1,0 +1,91 @@
+import type { AppEpic } from 'ducks';
+import { type Observable, of } from 'rxjs';
+import { catchError, concatMap, filter, map, switchMap } from 'rxjs/operators';
+import type { UnknownAction } from 'redux';
+import type { Resource } from 'types/openapi';
+import { extractError } from 'utils/net';
+import { actions as alertActions } from './alerts';
+import { slice } from './listViews';
+
+type FailureAction = (payload: { resource: Resource; error: string }) => UnknownAction;
+
+/**
+ * A failed mutation both rolls the strip back and says so.
+ *
+ * The message goes to an alert rather than to `appRedirectActions.fetchError`, which the sibling
+ * ducks use for a read: the tab the user just created has already disappeared again, so the failure
+ * has to be readable beside the strip that undid it rather than on a page they were sent to.
+ */
+function mutationFailed(action: FailureAction, resource: Resource, err: Error, fallback: string): Observable<UnknownAction> {
+    const error = extractError(err, fallback);
+    return of(action({ resource, error }), alertActions.error(error));
+}
+
+const listViews: AppEpic = (action$, state$, deps) => {
+    return action$.pipe(
+        filter(slice.actions.listViews.match),
+        // switchMap: the strip reads one resource at a time, and a superseded read must not land
+        // after the one that replaced it.
+        switchMap((action) =>
+            deps.apiClients.listViews.listViews({ resource: action.payload.resource }).pipe(
+                map((views) => slice.actions.listViewsSuccess({ resource: action.payload.resource, views })),
+                catchError((err) =>
+                    of(
+                        slice.actions.listViewsFailure({
+                            resource: action.payload.resource,
+                            error: extractError(err, 'Failed to get saved views'),
+                        }),
+                    ),
+                ),
+            ),
+        ),
+    );
+};
+
+const createView: AppEpic = (action$, state$, deps) => {
+    return action$.pipe(
+        filter(slice.actions.createView.match),
+        // concatMap on every mutation: the strip holds a single rollback snapshot, so two writes in
+        // flight at once would leave the second able to roll back over the first one's result.
+        concatMap((action) =>
+            deps.apiClients.listViews.createView({ listViewRequestDto: action.payload.view }).pipe(
+                map((view) => slice.actions.createViewSuccess({ resource: action.payload.resource, view })),
+                catchError((err) =>
+                    mutationFailed(slice.actions.createViewFailure, action.payload.resource, err, 'Failed to create the view'),
+                ),
+            ),
+        ),
+    );
+};
+
+const updateView: AppEpic = (action$, state$, deps) => {
+    return action$.pipe(
+        filter(slice.actions.updateView.match),
+        concatMap((action) =>
+            deps.apiClients.listViews.editView({ uuid: action.payload.uuid, listViewUpdateRequestDto: action.payload.view }).pipe(
+                map((view) => slice.actions.updateViewSuccess({ resource: action.payload.resource, view })),
+                catchError((err) =>
+                    mutationFailed(slice.actions.updateViewFailure, action.payload.resource, err, 'Failed to save the view'),
+                ),
+            ),
+        ),
+    );
+};
+
+const deleteView: AppEpic = (action$, state$, deps) => {
+    return action$.pipe(
+        filter(slice.actions.deleteView.match),
+        concatMap((action) =>
+            deps.apiClients.listViews.deleteView({ uuid: action.payload.uuid }).pipe(
+                map(() => slice.actions.deleteViewSuccess({ resource: action.payload.resource, uuid: action.payload.uuid })),
+                catchError((err) =>
+                    mutationFailed(slice.actions.deleteViewFailure, action.payload.resource, err, 'Failed to delete the view'),
+                ),
+            ),
+        ),
+    );
+};
+
+const epics = [listViews, createView, updateView, deleteView];
+
+export default epics;

--- a/src/ducks/listViews.spec.ts
+++ b/src/ducks/listViews.spec.ts
@@ -30,7 +30,7 @@ const certificates = (state: State) => selectors.resourceViews(Resource.Certific
 
 describe('reading the saved views', () => {
     test('a resource with nothing stored reads as an empty strip rather than undefined', () => {
-        expect(certificates(initialState)).toEqual({ views: [], isFetching: false, isMutating: false });
+        expect(certificates(initialState)).toEqual({ views: [], isFetching: false, hasLoaded: false, isMutating: false });
     });
 
     test('a read reports itself in flight and then settles on the views', () => {
@@ -41,6 +41,35 @@ describe('reading the saved views', () => {
         expect(certificates(settled)).toMatchObject({ isFetching: false, views: [view('a', 'One')] });
     });
 
+    test('an empty read still counts as loaded, so a strip can tell it apart from one in flight', () => {
+        const fetching = reduce(initialState, actions.listViews({ resource: Resource.Certificates }));
+        expect(certificates(fetching).hasLoaded).toBe(false);
+
+        const settled = reduce(fetching, actions.listViewsSuccess({ resource: Resource.Certificates, views: [] }));
+        expect(certificates(settled)).toMatchObject({ hasLoaded: true, views: [] });
+    });
+
+    test('a read that overlapped a mutation is discarded rather than committed over it', () => {
+        // The read was in flight before the create, so its payload predates the optimistic row.
+        // Committing it would drop that row, and would leave the rollback snapshot describing a list
+        // the read has since replaced.
+        const creating = reduceAll(
+            [
+                actions.createView({
+                    resource: Resource.Certificates,
+                    view: { name: 'New', resource: Resource.Certificates, columns, defaultView: false },
+                }),
+            ],
+            listed([view('a', 'One')]),
+        );
+
+        const raced = reduce(creating, actions.listViewsSuccess({ resource: Resource.Certificates, views: [view('a', 'One')] }));
+
+        expect(raced.byResource[Resource.Certificates]?.views.map((v) => v.uuid)).toEqual(['a', PENDING_VIEW_UUID]);
+        expect(certificates(raced).hasLoaded).toBe(true);
+        expect(certificates(raced).isFetching).toBe(false);
+    });
+
     test('a failed read stops being in flight and reports the error', () => {
         const failed = reduceAll([
             actions.listViews({ resource: Resource.Certificates }),
@@ -48,6 +77,9 @@ describe('reading the saved views', () => {
         ]);
 
         expect(certificates(failed).isFetching).toBe(false);
+        // Loaded in the sense the strip needs: the read has settled, so Standard opens rather than the
+        // strip waiting for a list that is not coming.
+        expect(certificates(failed).hasLoaded).toBe(true);
         expect(selectors.error({ [slice.name]: failed } as never)).toBe('nope');
     });
 
@@ -225,11 +257,13 @@ describe('selectors', () => {
 
         expect(selectors.isMutating(Resource.Certificates)(store as never)).toBe(true);
         expect(selectors.isFetching(Resource.Certificates)(store as never)).toBe(false);
+        expect(selectors.hasLoaded(Resource.Certificates)(store as never)).toBe(true);
         expect(selectors.createdUuid(Resource.Certificates)(store as never)).toBeUndefined();
     });
 
     test('survive a store that has not built the slice yet', () => {
         expect(selectors.views(Resource.Certificates)({} as never)).toEqual([]);
+        expect(selectors.hasLoaded(Resource.Certificates)({} as never)).toBe(false);
         expect(selectors.error({} as never)).toBeUndefined();
     });
 });

--- a/src/ducks/listViews.spec.ts
+++ b/src/ducks/listViews.spec.ts
@@ -30,7 +30,13 @@ const certificates = (state: State) => selectors.resourceViews(Resource.Certific
 
 describe('reading the saved views', () => {
     test('a resource with nothing stored reads as an empty strip rather than undefined', () => {
-        expect(certificates(initialState)).toEqual({ views: [], isFetching: false, hasLoaded: false, isMutating: false });
+        expect(certificates(initialState)).toEqual({
+            views: [],
+            isFetching: false,
+            hasLoaded: false,
+            isMutating: false,
+            mutationEpoch: 0,
+        });
     });
 
     test('a read reports itself in flight and then settles on the views', () => {
@@ -68,6 +74,50 @@ describe('reading the saved views', () => {
         expect(raced.byResource[Resource.Certificates]?.views.map((v) => v.uuid)).toEqual(['a', PENDING_VIEW_UUID]);
         expect(certificates(raced).hasLoaded).toBe(true);
         expect(certificates(raced).isFetching).toBe(false);
+    });
+
+    test('a read that started before a write is discarded even once that write has settled', () => {
+        // The write settles first, so `isMutating` is already false when the older list lands. Nothing
+        // but the epoch it was issued under can tell that it predates a confirmed change — and
+        // committing it would put the pre-update rows back, ready to be sent to Core by the next
+        // full-row edit.
+        const reading = reduce(listed([view('a', 'One')]), actions.listViews({ resource: Resource.Certificates }));
+
+        const written = reduceAll(
+            [
+                actions.updateView({ resource: Resource.Certificates, uuid: 'a', view: { name: 'Renamed', columns } }),
+                actions.updateViewSuccess({ resource: Resource.Certificates, view: view('a', 'Renamed') }),
+            ],
+            reading,
+        );
+
+        expect(certificates(written).isMutating).toBe(false);
+
+        const raced = reduce(written, actions.listViewsSuccess({ resource: Resource.Certificates, views: [view('a', 'One')] }));
+
+        expect(certificates(raced).views.map((v) => v.name)).toEqual(['Renamed']);
+        expect(certificates(raced).hasLoaded).toBe(true);
+        expect(certificates(raced).isFetching).toBe(false);
+    });
+
+    test('a read issued after the last write settled is committed', () => {
+        const written = reduceAll(
+            [
+                actions.updateView({ resource: Resource.Certificates, uuid: 'a', view: { name: 'Renamed', columns } }),
+                actions.updateViewSuccess({ resource: Resource.Certificates, view: view('a', 'Renamed') }),
+            ],
+            listed([view('a', 'One')]),
+        );
+
+        const reread = reduceAll(
+            [
+                actions.listViews({ resource: Resource.Certificates }),
+                actions.listViewsSuccess({ resource: Resource.Certificates, views: [view('a', 'Renamed'), view('b', 'Two')] }),
+            ],
+            written,
+        );
+
+        expect(certificates(reread).views.map((v) => v.uuid)).toEqual(['a', 'b']);
     });
 
     test('a failed read stops being in flight and reports the error', () => {

--- a/src/ducks/listViews.spec.ts
+++ b/src/ducks/listViews.spec.ts
@@ -1,0 +1,235 @@
+import { describe, expect, test } from 'vitest';
+import type { ListViewModel } from 'types/listViews';
+import { FilterFieldSource, Resource } from 'types/openapi';
+import { PENDING_VIEW_UUID, actions, initialState, selectors, slice } from './listViews';
+import type { State } from './listViews';
+
+const columns = [{ fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME' }];
+
+const view = (uuid: string, name: string, overrides: Partial<ListViewModel> = {}): ListViewModel => ({
+    uuid,
+    name,
+    resource: Resource.Certificates,
+    columns,
+    defaultView: false,
+    ...overrides,
+});
+
+const reduce = (state: State, action: { type: string; payload?: unknown }): State =>
+    slice.reducer(state, action as Parameters<typeof slice.reducer>[1]);
+
+const reduceAll = (actionList: { type: string; payload?: unknown }[], from: State = initialState): State => actionList.reduce(reduce, from);
+
+const listed = (views: ListViewModel[]): State =>
+    reduceAll([
+        actions.listViews({ resource: Resource.Certificates }),
+        actions.listViewsSuccess({ resource: Resource.Certificates, views }),
+    ]);
+
+const certificates = (state: State) => selectors.resourceViews(Resource.Certificates)({ [slice.name]: state } as never);
+
+describe('reading the saved views', () => {
+    test('a resource with nothing stored reads as an empty strip rather than undefined', () => {
+        expect(certificates(initialState)).toEqual({ views: [], isFetching: false, isMutating: false });
+    });
+
+    test('a read reports itself in flight and then settles on the views', () => {
+        const fetching = reduce(initialState, actions.listViews({ resource: Resource.Certificates }));
+        expect(certificates(fetching).isFetching).toBe(true);
+
+        const settled = reduce(fetching, actions.listViewsSuccess({ resource: Resource.Certificates, views: [view('a', 'One')] }));
+        expect(certificates(settled)).toMatchObject({ isFetching: false, views: [view('a', 'One')] });
+    });
+
+    test('a failed read stops being in flight and reports the error', () => {
+        const failed = reduceAll([
+            actions.listViews({ resource: Resource.Certificates }),
+            actions.listViewsFailure({ resource: Resource.Certificates, error: 'nope' }),
+        ]);
+
+        expect(certificates(failed).isFetching).toBe(false);
+        expect(selectors.error({ [slice.name]: failed } as never)).toBe('nope');
+    });
+
+    test('resources hold their views apart', () => {
+        const both = reduceAll(
+            [actions.listViewsSuccess({ resource: Resource.Cryptographickeys, views: [view('k', 'Keys view')] })],
+            listed([view('a', 'One')]),
+        );
+
+        expect(certificates(both).views.map((v) => v.uuid)).toEqual(['a']);
+        expect(
+            selectors
+                .views(Resource.Cryptographickeys)({ [slice.name]: both } as never)
+                .map((v) => v.uuid),
+        ).toEqual(['k']);
+    });
+});
+
+describe('creating a view', () => {
+    const request = { name: 'Expiry watch', resource: Resource.Certificates, columns };
+
+    test('the tab appears before the API answers', () => {
+        const optimistic = reduce(listed([view('a', 'One')]), actions.createView({ resource: Resource.Certificates, view: request }));
+
+        expect(certificates(optimistic).views.map((v) => v.uuid)).toEqual(['a', PENDING_VIEW_UUID]);
+        expect(certificates(optimistic).isMutating).toBe(true);
+    });
+
+    test('the stored view replaces the pending one in place, and the strip is told which uuid to follow', () => {
+        const created = reduceAll(
+            [
+                actions.createView({ resource: Resource.Certificates, view: request }),
+                actions.createViewSuccess({ resource: Resource.Certificates, view: view('new', 'Expiry watch') }),
+            ],
+            listed([view('a', 'One')]),
+        );
+
+        expect(certificates(created).views.map((v) => v.uuid)).toEqual(['a', 'new']);
+        expect(certificates(created)).toMatchObject({ isMutating: false, createdUuid: 'new' });
+    });
+
+    test('a create that succeeded without an optimistic row still lands', () => {
+        const created = reduce(
+            listed([view('a', 'One')]),
+            actions.createViewSuccess({ resource: Resource.Certificates, view: view('new', 'Expiry watch') }),
+        );
+
+        expect(certificates(created).views.map((v) => v.uuid)).toEqual(['a', 'new']);
+    });
+
+    test('a failed create rolls the tab back off the strip', () => {
+        const failed = reduceAll(
+            [
+                actions.createView({ resource: Resource.Certificates, view: request }),
+                actions.createViewFailure({ resource: Resource.Certificates, error: 'nope' }),
+            ],
+            listed([view('a', 'One')]),
+        );
+
+        expect(certificates(failed).views.map((v) => v.uuid)).toEqual(['a']);
+        expect(certificates(failed)).toMatchObject({ isMutating: false, rollback: undefined });
+        expect(selectors.error({ [slice.name]: failed } as never)).toBe('nope');
+    });
+
+    test('creating a pinned view un-pins the one that held it', () => {
+        const pinnedElsewhere = listed([view('a', 'One', { defaultView: true })]);
+        const optimistic = reduce(
+            pinnedElsewhere,
+            actions.createView({ resource: Resource.Certificates, view: { ...request, defaultView: true } }),
+        );
+
+        expect(certificates(optimistic).views.map((v) => v.defaultView)).toEqual([false, true]);
+    });
+});
+
+describe('editing a view', () => {
+    const stored = [view('a', 'One'), view('b', 'Two')];
+    const rename = { name: 'Renamed', columns };
+
+    test('the rename shows before the API answers, and survives the answer', () => {
+        const optimistic = reduce(listed(stored), actions.updateView({ resource: Resource.Certificates, uuid: 'a', view: rename }));
+        expect(certificates(optimistic).views[0].name).toBe('Renamed');
+
+        const settled = reduce(optimistic, actions.updateViewSuccess({ resource: Resource.Certificates, view: view('a', 'Renamed') }));
+        expect(certificates(settled).views[0].name).toBe('Renamed');
+        expect(certificates(settled).isMutating).toBe(false);
+    });
+
+    test('a failed rename puts the old name back', () => {
+        const failed = reduceAll(
+            [
+                actions.updateView({ resource: Resource.Certificates, uuid: 'a', view: rename }),
+                actions.updateViewFailure({ resource: Resource.Certificates, error: 'nope' }),
+            ],
+            listed(stored),
+        );
+
+        expect(certificates(failed).views.map((v) => v.name)).toEqual(['One', 'Two']);
+    });
+
+    test('an edit naming a view that is gone changes nothing but still settles', () => {
+        const missing = reduce(listed(stored), actions.updateView({ resource: Resource.Certificates, uuid: 'gone', view: rename }));
+
+        expect(certificates(missing).views).toEqual(stored);
+        expect(certificates(missing).isMutating).toBe(true);
+    });
+
+    test('pinning a view un-pins the one that held it, in the same render', () => {
+        const optimistic = reduce(
+            listed([view('a', 'One', { defaultView: true }), view('b', 'Two')]),
+            actions.updateView({ resource: Resource.Certificates, uuid: 'b', view: { ...rename, name: 'Two', defaultView: true } }),
+        );
+
+        expect(certificates(optimistic).views.map((v) => v.defaultView)).toEqual([false, true]);
+    });
+
+    test('the same invariant holds on what the API returns', () => {
+        const settled = reduce(
+            listed([view('a', 'One', { defaultView: true }), view('b', 'Two')]),
+            actions.updateViewSuccess({ resource: Resource.Certificates, view: view('b', 'Two', { defaultView: true }) }),
+        );
+
+        expect(certificates(settled).views.map((v) => v.defaultView)).toEqual([false, true]);
+    });
+});
+
+describe('deleting a view', () => {
+    const stored = [view('a', 'One'), view('b', 'Two')];
+
+    test('the tab goes before the API answers', () => {
+        const optimistic = reduce(listed(stored), actions.deleteView({ resource: Resource.Certificates, uuid: 'a' }));
+
+        expect(certificates(optimistic).views.map((v) => v.uuid)).toEqual(['b']);
+        expect(certificates(optimistic).isMutating).toBe(true);
+    });
+
+    test('a failed delete brings the tab back', () => {
+        const failed = reduceAll(
+            [
+                actions.deleteView({ resource: Resource.Certificates, uuid: 'a' }),
+                actions.deleteViewFailure({ resource: Resource.Certificates, error: 'nope' }),
+            ],
+            listed(stored),
+        );
+
+        expect(certificates(failed).views.map((v) => v.uuid)).toEqual(['a', 'b']);
+        expect(selectors.error({ [slice.name]: failed } as never)).toBe('nope');
+    });
+
+    test('success settles the strip', () => {
+        const settled = reduceAll(
+            [
+                actions.deleteView({ resource: Resource.Certificates, uuid: 'a' }),
+                actions.deleteViewSuccess({ resource: Resource.Certificates, uuid: 'a' }),
+            ],
+            listed(stored),
+        );
+
+        expect(certificates(settled)).toMatchObject({ views: [view('b', 'Two')], isMutating: false, rollback: undefined });
+    });
+});
+
+describe('resetState', () => {
+    test('drops every resource', () => {
+        const cleared = reduce(listed([view('a', 'One')]), actions.resetState());
+        expect(cleared).toEqual(initialState);
+    });
+});
+
+describe('selectors', () => {
+    test('report the flags the strip gates its actions on', () => {
+        const store = {
+            [slice.name]: reduce(listed([view('a', 'One')]), actions.deleteView({ resource: Resource.Certificates, uuid: 'a' })),
+        };
+
+        expect(selectors.isMutating(Resource.Certificates)(store as never)).toBe(true);
+        expect(selectors.isFetching(Resource.Certificates)(store as never)).toBe(false);
+        expect(selectors.createdUuid(Resource.Certificates)(store as never)).toBeUndefined();
+    });
+
+    test('survive a store that has not built the slice yet', () => {
+        expect(selectors.views(Resource.Certificates)({} as never)).toEqual([]);
+        expect(selectors.error({} as never)).toBeUndefined();
+    });
+});

--- a/src/ducks/listViews.ts
+++ b/src/ducks/listViews.ts
@@ -1,0 +1,210 @@
+import { createSelector, createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import type { AppState } from 'ducks';
+import { resetSliceState } from 'ducks/reducerUtils';
+import type { ListViewModel, ListViewRequestModel, ListViewUpdateRequestModel } from 'types/listViews';
+import type { Resource } from 'types/openapi';
+
+/**
+ * The uuid a view carries while its create is in flight.
+ *
+ * A tab appears the moment it is asked for rather than a round trip later, so the optimistic row
+ * needs an identity before the API has given it one. A single constant is enough because the strip
+ * gates its own actions on {@link State} `isMutating`, so there is never a second create in flight —
+ * and a constant, unlike a generated uuid, keeps the reducer a pure function of its input.
+ */
+export const PENDING_VIEW_UUID = 'pending-view';
+
+/** The saved views of one resource, and what is currently happening to them. */
+export interface ResourceViews {
+    views: ListViewModel[];
+    isFetching: boolean;
+    /** Whether a create, edit or delete is in flight. The strip's actions are held while it is. */
+    isMutating: boolean;
+    /**
+     * The view list as it stood before the in-flight mutation, restored if the mutation fails. The
+     * optimistic edit is applied to `views` directly, so this is the only way back.
+     */
+    rollback?: ListViewModel[];
+    /** The uuid the last create was given, so the strip can follow the tab it opened. */
+    createdUuid?: string;
+}
+
+export type State = {
+    byResource: Partial<Record<Resource, ResourceViews>>;
+    error?: string;
+};
+
+export const initialState: State = {
+    byResource: {},
+};
+
+const EMPTY_RESOURCE_VIEWS: ResourceViews = {
+    views: [],
+    isFetching: false,
+    isMutating: false,
+};
+
+function forResource(state: State, resource: Resource): ResourceViews {
+    state.byResource[resource] ??= { ...EMPTY_RESOURCE_VIEWS };
+    return state.byResource[resource];
+}
+
+/**
+ * One pinned view per user and resource, which is what Core stores. Mirroring the invariant locally
+ * means pinning a view un-pins the previous one in the same render the click happened, rather than
+ * showing two pins until the next list read.
+ */
+function keepOnePinned(views: ListViewModel[], pinnedUuid: string): void {
+    for (const view of views) {
+        if (view.uuid !== pinnedUuid) view.defaultView = false;
+    }
+}
+
+/** Starts a mutation: snapshots the list so a failure has something to roll back to. */
+function beginMutation(state: State, resource: Resource): ResourceViews {
+    const entry = forResource(state, resource);
+    entry.rollback = entry.views.map((view) => ({ ...view }));
+    entry.isMutating = true;
+    entry.createdUuid = undefined;
+    state.error = undefined;
+    return entry;
+}
+
+function endMutation(entry: ResourceViews): void {
+    entry.isMutating = false;
+    entry.rollback = undefined;
+}
+
+/** Restores the snapshot the failed mutation was applied over. */
+function rollBack(state: State, resource: Resource, error: string | undefined): void {
+    const entry = forResource(state, resource);
+    if (entry.rollback) entry.views = entry.rollback;
+    endMutation(entry);
+    state.error = error;
+}
+
+export const slice = createSlice({
+    name: 'listViews',
+
+    initialState,
+
+    reducers: {
+        resetState: (state, action: PayloadAction<void>) => {
+            resetSliceState(state, initialState);
+        },
+
+        listViews: (state, action: PayloadAction<{ resource: Resource }>) => {
+            const entry = forResource(state, action.payload.resource);
+            entry.isFetching = true;
+            state.error = undefined;
+        },
+
+        listViewsSuccess: (state, action: PayloadAction<{ resource: Resource; views: ListViewModel[] }>) => {
+            const entry = forResource(state, action.payload.resource);
+            entry.views = action.payload.views;
+            entry.isFetching = false;
+        },
+
+        listViewsFailure: (state, action: PayloadAction<{ resource: Resource; error: string | undefined }>) => {
+            const entry = forResource(state, action.payload.resource);
+            entry.isFetching = false;
+            state.error = action.payload.error;
+        },
+
+        createView: (state, action: PayloadAction<{ resource: Resource; view: ListViewRequestModel }>) => {
+            const entry = beginMutation(state, action.payload.resource);
+            const { view } = action.payload;
+
+            entry.views.push({
+                uuid: PENDING_VIEW_UUID,
+                name: view.name,
+                resource: action.payload.resource,
+                columns: view.columns,
+                defaultView: view.defaultView === true,
+                filters: view.filters,
+                sort: view.sort,
+            });
+
+            if (view.defaultView === true) keepOnePinned(entry.views, PENDING_VIEW_UUID);
+        },
+
+        createViewSuccess: (state, action: PayloadAction<{ resource: Resource; view: ListViewModel }>) => {
+            const entry = forResource(state, action.payload.resource);
+            const pending = entry.views.findIndex((view) => view.uuid === PENDING_VIEW_UUID);
+
+            if (pending === -1) entry.views.push(action.payload.view);
+            else entry.views[pending] = action.payload.view;
+
+            if (action.payload.view.defaultView) keepOnePinned(entry.views, action.payload.view.uuid);
+
+            entry.createdUuid = action.payload.view.uuid;
+            endMutation(entry);
+        },
+
+        createViewFailure: (state, action: PayloadAction<{ resource: Resource; error: string | undefined }>) => {
+            rollBack(state, action.payload.resource, action.payload.error);
+        },
+
+        updateView: (state, action: PayloadAction<{ resource: Resource; uuid: string; view: ListViewUpdateRequestModel }>) => {
+            const entry = beginMutation(state, action.payload.resource);
+            const stored = entry.views.find((view) => view.uuid === action.payload.uuid);
+            if (!stored) return;
+
+            Object.assign(stored, action.payload.view, { defaultView: action.payload.view.defaultView === true });
+            if (stored.defaultView) keepOnePinned(entry.views, stored.uuid);
+        },
+
+        updateViewSuccess: (state, action: PayloadAction<{ resource: Resource; view: ListViewModel }>) => {
+            const entry = forResource(state, action.payload.resource);
+            const index = entry.views.findIndex((view) => view.uuid === action.payload.view.uuid);
+
+            if (index !== -1) entry.views[index] = action.payload.view;
+            if (action.payload.view.defaultView) keepOnePinned(entry.views, action.payload.view.uuid);
+
+            endMutation(entry);
+        },
+
+        updateViewFailure: (state, action: PayloadAction<{ resource: Resource; error: string | undefined }>) => {
+            rollBack(state, action.payload.resource, action.payload.error);
+        },
+
+        deleteView: (state, action: PayloadAction<{ resource: Resource; uuid: string }>) => {
+            const entry = beginMutation(state, action.payload.resource);
+            entry.views = entry.views.filter((view) => view.uuid !== action.payload.uuid);
+        },
+
+        deleteViewSuccess: (state, action: PayloadAction<{ resource: Resource; uuid: string }>) => {
+            const entry = forResource(state, action.payload.resource);
+            entry.views = entry.views.filter((view) => view.uuid !== action.payload.uuid);
+            endMutation(entry);
+        },
+
+        deleteViewFailure: (state, action: PayloadAction<{ resource: Resource; error: string | undefined }>) => {
+            rollBack(state, action.payload.resource, action.payload.error);
+        },
+    },
+});
+
+const state = (reduxStore: AppState): State => reduxStore?.[slice.name];
+
+const resourceViews = (resource: Resource) => createSelector(state, (state) => state?.byResource?.[resource] ?? EMPTY_RESOURCE_VIEWS);
+
+const views = (resource: Resource) => createSelector(resourceViews(resource), (entry) => entry.views);
+const isFetching = (resource: Resource) => createSelector(resourceViews(resource), (entry) => entry.isFetching);
+const isMutating = (resource: Resource) => createSelector(resourceViews(resource), (entry) => entry.isMutating);
+const createdUuid = (resource: Resource) => createSelector(resourceViews(resource), (entry) => entry.createdUuid);
+const error = createSelector(state, (state) => state?.error);
+
+export const selectors = {
+    state,
+    resourceViews,
+    views,
+    isFetching,
+    isMutating,
+    createdUuid,
+    error,
+};
+
+export const actions = slice.actions;
+
+export default slice.reducer;

--- a/src/ducks/listViews.ts
+++ b/src/ducks/listViews.ts
@@ -33,6 +33,16 @@ export interface ResourceViews {
     rollback?: ListViewModel[];
     /** The uuid the last create was given, so the strip can follow the tab it opened. */
     createdUuid?: string;
+    /**
+     * Counts the mutation boundaries this resource has crossed: one step when a write starts, another
+     * when it settles. It is what lets a list response be dated against the writes around it.
+     */
+    mutationEpoch: number;
+    /**
+     * The epoch the read now in flight was issued under, or nothing when no read is in flight. Reads
+     * are superseded rather than queued — the epic runs them under `switchMap` — so one is enough.
+     */
+    readEpoch?: number;
 }
 
 export type State = {
@@ -49,6 +59,7 @@ const EMPTY_RESOURCE_VIEWS: ResourceViews = {
     isFetching: false,
     hasLoaded: false,
     isMutating: false,
+    mutationEpoch: 0,
 };
 
 function forResource(state: State, resource: Resource): ResourceViews {
@@ -73,6 +84,7 @@ function beginMutation(state: State, resource: Resource): ResourceViews {
     entry.rollback = entry.views.map((view) => ({ ...view }));
     entry.isMutating = true;
     entry.createdUuid = undefined;
+    entry.mutationEpoch += 1;
     state.error = undefined;
     return entry;
 }
@@ -80,6 +92,7 @@ function beginMutation(state: State, resource: Resource): ResourceViews {
 function endMutation(entry: ResourceViews): void {
     entry.isMutating = false;
     entry.rollback = undefined;
+    entry.mutationEpoch += 1;
 }
 
 /** Restores the snapshot the failed mutation was applied over. */
@@ -103,6 +116,7 @@ export const slice = createSlice({
         listViews: (state, action: PayloadAction<{ resource: Resource }>) => {
             const entry = forResource(state, action.payload.resource);
             entry.isFetching = true;
+            entry.readEpoch = entry.mutationEpoch;
             state.error = undefined;
         },
 
@@ -111,10 +125,20 @@ export const slice = createSlice({
             entry.isFetching = false;
             entry.hasLoaded = true;
 
-            // A read that was in flight while a write started predates that write, so committing it
-            // would drop the optimistic row — and leave `rollback` holding a snapshot the read has
-            // since replaced, so a failure would roll back to the wrong list too.
-            if (entry.isMutating) return;
+            const issuedUnder = entry.readEpoch;
+            entry.readEpoch = undefined;
+
+            // A read is committed only if no write started or settled while it was in flight. Rejecting
+            // it merely while `isMutating` holds is not enough: a write that started after the read and
+            // settled before it would let the older list land on top of a confirmed change, and the
+            // next full-row edit would then send those stale rows back to Core. A read that overlapped
+            // a write the other way round would drop the optimistic row instead, and leave `rollback`
+            // describing a list the read has since replaced.
+            //
+            // No recorded epoch means the request this answers is not one this slice saw — the state
+            // was reset under it, or the views were seeded directly — and there is nothing to date it
+            // against.
+            if (entry.isMutating || (issuedUnder !== undefined && issuedUnder !== entry.mutationEpoch)) return;
 
             entry.views = action.payload.views;
         },

--- a/src/ducks/listViews.ts
+++ b/src/ducks/listViews.ts
@@ -18,6 +18,12 @@ export const PENDING_VIEW_UUID = 'pending-view';
 export interface ResourceViews {
     views: ListViewModel[];
     isFetching: boolean;
+    /**
+     * Whether the list read has settled, successfully or not. Distinct from `views.length > 0`, which
+     * cannot tell a user with no saved views from a read still in flight — and would then read the
+     * first optimistic create as the initial result.
+     */
+    hasLoaded: boolean;
     /** Whether a create, edit or delete is in flight. The strip's actions are held while it is. */
     isMutating: boolean;
     /**
@@ -41,6 +47,7 @@ export const initialState: State = {
 const EMPTY_RESOURCE_VIEWS: ResourceViews = {
     views: [],
     isFetching: false,
+    hasLoaded: false,
     isMutating: false,
 };
 
@@ -101,13 +108,23 @@ export const slice = createSlice({
 
         listViewsSuccess: (state, action: PayloadAction<{ resource: Resource; views: ListViewModel[] }>) => {
             const entry = forResource(state, action.payload.resource);
-            entry.views = action.payload.views;
             entry.isFetching = false;
+            entry.hasLoaded = true;
+
+            // A read that was in flight while a write started predates that write, so committing it
+            // would drop the optimistic row — and leave `rollback` holding a snapshot the read has
+            // since replaced, so a failure would roll back to the wrong list too.
+            if (entry.isMutating) return;
+
+            entry.views = action.payload.views;
         },
 
         listViewsFailure: (state, action: PayloadAction<{ resource: Resource; error: string | undefined }>) => {
             const entry = forResource(state, action.payload.resource);
             entry.isFetching = false;
+            // Loaded in the sense the strip needs: the read has settled, so Standard opens rather than
+            // the strip waiting forever for a list that is not coming.
+            entry.hasLoaded = true;
             state.error = action.payload.error;
         },
 
@@ -191,6 +208,7 @@ const resourceViews = (resource: Resource) => createSelector(state, (state) => s
 
 const views = (resource: Resource) => createSelector(resourceViews(resource), (entry) => entry.views);
 const isFetching = (resource: Resource) => createSelector(resourceViews(resource), (entry) => entry.isFetching);
+const hasLoaded = (resource: Resource) => createSelector(resourceViews(resource), (entry) => entry.hasLoaded);
 const isMutating = (resource: Resource) => createSelector(resourceViews(resource), (entry) => entry.isMutating);
 const createdUuid = (resource: Resource) => createSelector(resourceViews(resource), (entry) => entry.createdUuid);
 const error = createSelector(state, (state) => state?.error);
@@ -200,6 +218,7 @@ export const selectors = {
     resourceViews,
     views,
     isFetching,
+    hasLoaded,
     isMutating,
     createdUuid,
     error,

--- a/src/ducks/reducers.ts
+++ b/src/ducks/reducers.ts
@@ -55,6 +55,7 @@ import { slice as tokenSlice } from './tokens';
 import { slice as tablePaginationSlice } from './table-pagination';
 import { slice as listFiltersSlice } from './list-filters';
 import { slice as listScopesSlice } from './list-scopes';
+import { slice as listViewsSlice } from './listViews';
 import { slice as trustedCertificatesSlice } from './trusted-certificates';
 import { slice as usersSlice } from './users';
 import { slice as utilsActuatorSlice } from './utilsActuator';
@@ -123,6 +124,7 @@ export const reducers = combineReducers({
     [tablePaginationSlice.name]: tablePaginationSlice.reducer,
     [listFiltersSlice.name]: listFiltersSlice.reducer,
     [listScopesSlice.name]: listScopesSlice.reducer,
+    [listViewsSlice.name]: listViewsSlice.reducer,
     [trustedCertificatesSlice.name]: trustedCertificatesSlice.reducer,
     [cryptographicKeySlice.name]: cryptographicKeySlice.reducer,
     [cryptographicOperationsSlice.name]: cryptographicOperationsSlice.reducer,

--- a/src/ducks/test-reducers.ts
+++ b/src/ducks/test-reducers.ts
@@ -1,6 +1,6 @@
 import { combineReducers, type UnknownAction } from '@reduxjs/toolkit';
 import type { AttributeDescriptorModel } from 'types/attributes';
-import type { ConnectInfoDto } from 'types/openapi';
+import type { ConnectInfoDto, ListViewDto } from 'types/openapi';
 import type { EventTriggerAssociationModel, TriggerModel } from 'types/rules';
 
 // IMPORTANT: This file is used ONLY in component tests (Playwright CT).
@@ -1129,6 +1129,65 @@ function commentsTestReducer(state: CommentsTestState | undefined, action: Unkno
     const payload = (action.payload ?? {}) as CommentsPostPayload;
     if (action.type === 'comments/createComment') return withPostState(recorded, payload, { isPosting: true, postSucceeded: false });
     if (action.type === 'comments/createCommentSuccess') return withPostState(recorded, payload, { isPosting: false, postSucceeded: true });
+
+    return recorded;
+}
+
+// Reducer key must match the real slice.name ('listViews') so the real list-view selectors — the ones
+// components/ViewTabs reads — find this state. Component tests run no epics, so nothing carries a
+// mutation past its request action: the views are preloaded, and every listViews action the strip
+// dispatches is recorded instead, which is what lets a test assert what was asked for.
+export type ListViewsTestState = {
+    byResource: Record<string, { views: ListViewDto[]; isFetching: boolean; isMutating: boolean; createdUuid?: string }>;
+    error?: string;
+    dispatched: Array<{ type: string; payload?: unknown }>;
+};
+
+const listViewsTestInitialState: ListViewsTestState = {
+    byResource: {},
+    dispatched: [],
+};
+
+// The uuid an optimistic create carries, mirroring PENDING_VIEW_UUID in src/ducks/listViews.ts. Spelt
+// out rather than imported, because this file must not pull in the real ducks.
+const PENDING_LIST_VIEW_UUID = 'pending-view';
+
+function listViewsTestReducer(state: ListViewsTestState = listViewsTestInitialState, action: UnknownAction): ListViewsTestState {
+    const a = action as { type: string; payload?: { resource?: string; view?: Partial<ListViewDto> } };
+    if (!a.type.startsWith('listViews/')) return state;
+
+    const recorded: ListViewsTestState = { ...state, dispatched: [...state.dispatched, { type: a.type, payload: a.payload }] };
+
+    const resource = a.payload?.resource;
+    const view = a.payload?.view;
+    if (!resource || !view) return recorded;
+
+    const entry = recorded.byResource[resource] ?? { views: [], isFetching: false, isMutating: false };
+    const withEntry = (next: Partial<ListViewsTestState['byResource'][string]>): ListViewsTestState => ({
+        ...recorded,
+        byResource: { ...recorded.byResource, [resource]: { ...entry, ...next } },
+    });
+
+    // Only the create round trip is mirrored, and only as far as the strip can observe it: a tab has
+    // to appear the moment it is asked for and then follow the uuid the API gives it. Everything else
+    // a mutation does to this slice is asserted against the real reducer in its own unit tests.
+    if (a.type === 'listViews/createView') {
+        return withEntry({ isMutating: true, views: [...entry.views, { ...view, uuid: PENDING_LIST_VIEW_UUID, resource } as ListViewDto] });
+    }
+
+    if (a.type === 'listViews/createViewSuccess') {
+        const created = view as ListViewDto;
+        const hasPending = entry.views.some((each) => each.uuid === PENDING_LIST_VIEW_UUID);
+
+        return withEntry({
+            isMutating: false,
+            createdUuid: created.uuid,
+            views: hasPending
+                ? entry.views.map((each) => (each.uuid === PENDING_LIST_VIEW_UUID ? created : each))
+                : [...entry.views, created],
+        });
+    }
+
     return recorded;
 }
 
@@ -1166,6 +1225,7 @@ export const testReducers = combineReducers({
     oids: oidsTestReducer,
     rules: rulesTestReducer,
     comments: commentsTestReducer,
+    listViews: listViewsTestReducer,
 });
 
 export const testInitialState = {
@@ -1202,4 +1262,5 @@ export const testInitialState = {
     oids: oidsTestInitialState,
     rules: rulesTestInitialState,
     comments: commentsTestInitialState,
+    listViews: listViewsTestInitialState,
 };

--- a/src/ducks/test-reducers.ts
+++ b/src/ducks/test-reducers.ts
@@ -1140,7 +1140,14 @@ function commentsTestReducer(state: CommentsTestState | undefined, action: Unkno
 export type ListViewsTestState = {
     byResource: Record<
         string,
-        { views: ListViewDto[]; isFetching: boolean; hasLoaded: boolean; isMutating: boolean; createdUuid?: string }
+        {
+            views: ListViewDto[];
+            isFetching: boolean;
+            hasLoaded: boolean;
+            isMutating: boolean;
+            createdUuid?: string;
+            rollback?: ListViewDto[];
+        }
     >;
     error?: string;
     dispatched: Array<{ type: string; payload?: unknown }>;
@@ -1171,10 +1178,11 @@ function listViewsTestReducer(state: ListViewsTestState = listViewsTestInitialSt
         byResource: { ...recorded.byResource, [resource]: { ...entry, ...next } },
     });
 
-    // Only the create round trip is mirrored, and only as far as the strip can observe it: a tab has
-    // to appear the moment it is asked for, then follow the uuid the API gives it, and disappear again
-    // if the create fails. Everything else a mutation does to this slice is asserted against the real
-    // reducer in its own unit tests.
+    // Only the create and delete round trips are mirrored, and only as far as the strip can observe
+    // them: a tab has to appear the moment a create is asked for, follow the uuid the API gives it and
+    // disappear again if the create fails, and a deleted tab has to come back if the delete fails.
+    // Everything else a mutation does to this slice is asserted against the real reducer in its own
+    // unit tests.
     if (a.type === 'listViews/createView' && view) {
         return withEntry({ isMutating: true, views: [...entry.views, { ...view, uuid: PENDING_LIST_VIEW_UUID, resource } as ListViewDto] });
     }
@@ -1194,6 +1202,16 @@ function listViewsTestReducer(state: ListViewsTestState = listViewsTestInitialSt
 
     if (a.type === 'listViews/createViewFailure') {
         return withEntry({ isMutating: false, views: entry.views.filter((each) => each.uuid !== PENDING_LIST_VIEW_UUID) });
+    }
+
+    const uuid = (a.payload as { uuid?: string } | undefined)?.uuid;
+
+    if (a.type === 'listViews/deleteView' && uuid) {
+        return withEntry({ isMutating: true, rollback: entry.views, views: entry.views.filter((each) => each.uuid !== uuid) });
+    }
+
+    if (a.type === 'listViews/deleteViewFailure') {
+        return withEntry({ isMutating: false, views: entry.rollback ?? entry.views, rollback: undefined });
     }
 
     return recorded;

--- a/src/ducks/test-reducers.ts
+++ b/src/ducks/test-reducers.ts
@@ -1138,7 +1138,10 @@ function commentsTestReducer(state: CommentsTestState | undefined, action: Unkno
 // mutation past its request action: the views are preloaded, and every listViews action the strip
 // dispatches is recorded instead, which is what lets a test assert what was asked for.
 export type ListViewsTestState = {
-    byResource: Record<string, { views: ListViewDto[]; isFetching: boolean; isMutating: boolean; createdUuid?: string }>;
+    byResource: Record<
+        string,
+        { views: ListViewDto[]; isFetching: boolean; hasLoaded: boolean; isMutating: boolean; createdUuid?: string }
+    >;
     error?: string;
     dispatched: Array<{ type: string; payload?: unknown }>;
 };
@@ -1159,23 +1162,24 @@ function listViewsTestReducer(state: ListViewsTestState = listViewsTestInitialSt
     const recorded: ListViewsTestState = { ...state, dispatched: [...state.dispatched, { type: a.type, payload: a.payload }] };
 
     const resource = a.payload?.resource;
-    const view = a.payload?.view;
-    if (!resource || !view) return recorded;
+    if (!resource) return recorded;
 
-    const entry = recorded.byResource[resource] ?? { views: [], isFetching: false, isMutating: false };
+    const view = a.payload?.view;
+    const entry = recorded.byResource[resource] ?? { views: [], isFetching: false, hasLoaded: false, isMutating: false };
     const withEntry = (next: Partial<ListViewsTestState['byResource'][string]>): ListViewsTestState => ({
         ...recorded,
         byResource: { ...recorded.byResource, [resource]: { ...entry, ...next } },
     });
 
     // Only the create round trip is mirrored, and only as far as the strip can observe it: a tab has
-    // to appear the moment it is asked for and then follow the uuid the API gives it. Everything else
-    // a mutation does to this slice is asserted against the real reducer in its own unit tests.
-    if (a.type === 'listViews/createView') {
+    // to appear the moment it is asked for, then follow the uuid the API gives it, and disappear again
+    // if the create fails. Everything else a mutation does to this slice is asserted against the real
+    // reducer in its own unit tests.
+    if (a.type === 'listViews/createView' && view) {
         return withEntry({ isMutating: true, views: [...entry.views, { ...view, uuid: PENDING_LIST_VIEW_UUID, resource } as ListViewDto] });
     }
 
-    if (a.type === 'listViews/createViewSuccess') {
+    if (a.type === 'listViews/createViewSuccess' && view) {
         const created = view as ListViewDto;
         const hasPending = entry.views.some((each) => each.uuid === PENDING_LIST_VIEW_UUID);
 
@@ -1186,6 +1190,10 @@ function listViewsTestReducer(state: ListViewsTestState = listViewsTestInitialSt
                 ? entry.views.map((each) => (each.uuid === PENDING_LIST_VIEW_UUID ? created : each))
                 : [...entry.views, created],
         });
+    }
+
+    if (a.type === 'listViews/createViewFailure') {
+        return withEntry({ isMutating: false, views: entry.views.filter((each) => each.uuid !== PENDING_LIST_VIEW_UUID) });
     }
 
     return recorded;

--- a/src/types/listViews.ts
+++ b/src/types/listViews.ts
@@ -1,0 +1,47 @@
+import type { ColumnSort } from 'utils/tableColumns';
+import type { SearchFilterModel } from './certificate';
+import type { ColumnDefinition, PickerColumn } from './tableColumns';
+
+export type {
+    ListViewColumnDto,
+    ListViewColumnDto as ListViewColumnModel,
+    ListViewDto,
+    ListViewDto as ListViewModel,
+    ListViewRequestDto,
+    ListViewRequestDto as ListViewRequestModel,
+    ListViewUpdateRequestDto,
+    ListViewUpdateRequestDto as ListViewUpdateRequestModel,
+    SearchSortRequestDto,
+    SearchSortRequestDto as SearchSortModel,
+} from './openapi';
+
+export { SortDirection } from './openapi';
+
+/**
+ * The slice of a listing a view describes. A tab is read as a promise about which rows are shown and
+ * not only which headings, so the three travel together: applying a view applies all three at once.
+ */
+export interface ViewSlice {
+    columns: ColumnDefinition[];
+    filters: SearchFilterModel[];
+    sort?: ColumnSort;
+}
+
+/**
+ * A stored view resolved against the live column catalogue.
+ *
+ * A view names `(fieldSource, fieldIdentifier)` pairs, so a deleted custom attribute — or a connector
+ * that renames a metadata identifier — leaves a column that resolves to nothing. The view still opens
+ * with the columns that did resolve, and the ones that did not are kept here so the table can say
+ * what happened instead of a heading silently vanishing.
+ */
+export interface ResolvedView {
+    /** Every stored column in its stored order, available or not. What the picker edits. */
+    columns: PickerColumn[];
+    /** The columns the table renders: the available ones, or the platform set when none resolved. */
+    renderable: ColumnDefinition[];
+    /** The stored columns the catalogue no longer publishes. */
+    unavailable: PickerColumn[];
+    /** Whether nothing resolved at all, so the render fell back to the platform column set. */
+    fellBackToStandard: boolean;
+}

--- a/src/types/listViews.ts
+++ b/src/types/listViews.ts
@@ -31,17 +31,16 @@ export interface ViewSlice {
  * A stored view resolved against the live column catalogue.
  *
  * A view names `(fieldSource, fieldIdentifier)` pairs, so a deleted custom attribute — or a connector
- * that renames a metadata identifier — leaves a column that resolves to nothing. The view still opens
- * with the columns that did resolve, and the ones that did not are kept here so the table can say
- * what happened instead of a heading silently vanishing.
+ * that renames a metadata identifier — leaves a column that resolves to nothing. The API resolves the
+ * same pairs on read and omits the ones it cannot offer, so what arrives is a view already shortened;
+ * a view built entirely on since-deleted fields arrives with no columns at all, which is the case
+ * `fellBackToStandard` exists for.
  */
 export interface ResolvedView {
     /** Every stored column in its stored order, available or not. What the picker edits. */
     columns: PickerColumn[];
     /** The columns the table renders: the available ones, or the platform set when none resolved. */
     renderable: ColumnDefinition[];
-    /** The stored columns the catalogue no longer publishes. */
-    unavailable: PickerColumn[];
     /** Whether nothing resolved at all, so the render fell back to the platform column set. */
     fellBackToStandard: boolean;
 }

--- a/src/types/listViews.ts
+++ b/src/types/listViews.ts
@@ -27,15 +27,7 @@ export interface ViewSlice {
     sort?: ColumnSort;
 }
 
-/**
- * A stored view resolved against the live column catalogue.
- *
- * A view names `(fieldSource, fieldIdentifier)` pairs, so a deleted custom attribute — or a connector
- * that renames a metadata identifier — leaves a column that resolves to nothing. The API resolves the
- * same pairs on read and omits the ones it cannot offer, so what arrives is a view already shortened;
- * a view built entirely on since-deleted fields arrives with no columns at all, which is the case
- * `fellBackToStandard` exists for.
- */
+/** A stored view resolved against the live column catalogue. See `resolveView` for the rules. */
 export interface ResolvedView {
     /** Every stored column in its stored order, available or not. What the picker edits. */
     columns: PickerColumn[];

--- a/src/utils/listViews.spec.ts
+++ b/src/utils/listViews.spec.ts
@@ -180,7 +180,6 @@ describe('resolveView', () => {
             available: true,
             sortable: false,
         });
-        expect(resolved.unavailable).toEqual([]);
         expect(resolved.fellBackToStandard).toBe(false);
     });
 
@@ -195,7 +194,7 @@ describe('resolveView', () => {
         );
 
         expect(resolved.columns).toHaveLength(2);
-        expect(resolved.unavailable.map((column) => column.fieldIdentifier)).toEqual(['cost_centre']);
+        expect(resolved.columns.filter((column) => !column.available).map((column) => column.fieldIdentifier)).toEqual(['cost_centre']);
         expect(resolved.renderable.map((column) => column.fieldIdentifier)).toEqual(['COMMON_NAME']);
         expect(resolved.fellBackToStandard).toBe(false);
     });
@@ -211,17 +210,22 @@ describe('resolveView', () => {
 
         expect(resolved.fellBackToStandard).toBe(true);
         expect(resolved.renderable).toEqual(standardColumns);
-        expect(resolved.unavailable).toHaveLength(1);
     });
 
-    it('does not report a fallback for a view that stores no columns', () => {
-        expect(resolveView([], [], standardColumns).fellBackToStandard).toBe(false);
+    it('falls back for a view that arrives with no columns at all', () => {
+        // What the API returns once every field the view was built on has left the catalogue: it
+        // resolves the stored identifiers on read and omits the ones it cannot offer. Rendering the
+        // empty list literally would leave a table with no columns.
+        const resolved = resolveView([], [commonName], standardColumns);
+
+        expect(resolved.fellBackToStandard).toBe(true);
+        expect(resolved.renderable).toEqual(standardColumns);
     });
 
     it('resolves a platform column the filter-field catalogue does not publish', () => {
         const resolved = resolveView([{ fieldSource: FilterFieldSource.Property, fieldIdentifier: 'STATUS' }], [], standardColumns);
 
-        expect(resolved.unavailable).toEqual([]);
+        expect(resolved.columns.every((column) => column.available)).toBe(true);
         expect(resolved.renderable[0].catalogueLabel).toBe('Status');
     });
 

--- a/src/utils/listViews.spec.ts
+++ b/src/utils/listViews.spec.ts
@@ -60,6 +60,40 @@ const standardColumns: ColumnDefinition[] = [
     { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'STATUS', catalogueLabel: 'Status' },
 ];
 
+/** A filter-field catalogue in which one custom attribute holds secret content. */
+const secretCatalogue = [
+    {
+        filterFieldSource: FilterFieldSource.Property,
+        searchFieldData: [{ fieldIdentifier: 'COMMON_NAME', fieldLabel: 'Common Name', type: FilterFieldType.String, conditions: [] }],
+    },
+    {
+        filterFieldSource: FilterFieldSource.Custom,
+        searchFieldData: [
+            {
+                fieldIdentifier: 'vaultToken',
+                fieldLabel: 'Vault Token',
+                type: FilterFieldType.String,
+                conditions: [],
+                attributeContentType: AttributeContentType.Secret,
+            },
+            {
+                fieldIdentifier: 'cost_centre',
+                fieldLabel: 'Cost centre',
+                type: FilterFieldType.String,
+                conditions: [],
+                attributeContentType: AttributeContentType.String,
+            },
+        ],
+    },
+] as unknown as SearchFieldDataByGroupDto[];
+
+const filter = (source: FilterFieldSource, identifier: string, value?: unknown) => ({
+    fieldSource: source,
+    fieldIdentifier: identifier,
+    condition: FilterConditionOperator.Equals,
+    ...(value === undefined ? {} : { value }),
+});
+
 describe('toTabs', () => {
     it('puts Standard first and keeps the API order of the stored views', () => {
         const tabs = toTabs([view('a', 'Expiry watch'), view('b', 'Compliance audit')]);
@@ -351,10 +385,10 @@ describe('toUpdateRequest', () => {
             sort: { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME', direction: SortDirection.Asc },
         });
 
-        expect(toUpdateRequest(stored)).toEqual({
+        expect(toUpdateRequest(stored, secretCatalogue)).toEqual({
             name: 'Expiry watch',
             columns: stored.columns,
-            filters: undefined,
+            filters: [],
             sort: stored.sort,
             defaultView: true,
         });
@@ -362,46 +396,42 @@ describe('toUpdateRequest', () => {
 
     it('applies the patch over the stored row, so a rename keeps the columns', () => {
         const stored = view('a', 'Expiry watch');
-        const renamed = toUpdateRequest(stored, { name: 'Expiry' });
+        const renamed = toUpdateRequest(stored, secretCatalogue, { name: 'Expiry' });
 
         expect(renamed.name).toBe('Expiry');
         expect(renamed.columns).toEqual(stored.columns);
     });
+
+    it.each([
+        ['a rename', { name: 'Expiry' }],
+        ['a pin', { defaultView: true }],
+        ['a column edit', { columns: [] }],
+    ])('drops a stored secret-valued filter on %s, which never names the filters', (_, patch) => {
+        const stored = view('a', 'Expiry watch', {
+            filters: [filter(FilterFieldSource.Property, 'COMMON_NAME', 'acme'), filter(FilterFieldSource.Custom, 'vaultToken', 'hunter2')],
+        });
+
+        expect(toUpdateRequest(stored, secretCatalogue, patch).filters).toEqual([
+            filter(FilterFieldSource.Property, 'COMMON_NAME', 'acme'),
+        ]);
+    });
+
+    it('drops a secret-valued filter the patch itself supplies', () => {
+        const stored = view('a', 'Expiry watch');
+        const patched = toUpdateRequest(stored, secretCatalogue, { filters: [filter(FilterFieldSource.Custom, 'vaultToken', 'hunter2')] });
+
+        expect(patched.filters).toEqual([]);
+    });
+
+    it('keeps a presence-only condition on the secret field, which carries nothing to leak', () => {
+        const stored = view('a', 'Expiry watch', { filters: [filter(FilterFieldSource.Custom, 'vaultToken')] });
+
+        expect(toUpdateRequest(stored, secretCatalogue).filters).toEqual([filter(FilterFieldSource.Custom, 'vaultToken')]);
+    });
 });
 
 describe('toStorableFilters', () => {
-    const catalogue = [
-        {
-            filterFieldSource: FilterFieldSource.Property,
-            searchFieldData: [{ fieldIdentifier: 'COMMON_NAME', fieldLabel: 'Common Name', type: FilterFieldType.String, conditions: [] }],
-        },
-        {
-            filterFieldSource: FilterFieldSource.Custom,
-            searchFieldData: [
-                {
-                    fieldIdentifier: 'vaultToken',
-                    fieldLabel: 'Vault Token',
-                    type: FilterFieldType.String,
-                    conditions: [],
-                    attributeContentType: AttributeContentType.Secret,
-                },
-                {
-                    fieldIdentifier: 'cost_centre',
-                    fieldLabel: 'Cost centre',
-                    type: FilterFieldType.String,
-                    conditions: [],
-                    attributeContentType: AttributeContentType.String,
-                },
-            ],
-        },
-    ] as unknown as SearchFieldDataByGroupDto[];
-
-    const filter = (source: FilterFieldSource, identifier: string, value?: unknown) => ({
-        fieldSource: source,
-        fieldIdentifier: identifier,
-        condition: FilterConditionOperator.Equals,
-        ...(value === undefined ? {} : { value }),
-    });
+    const catalogue = secretCatalogue;
 
     it('drops a filter carrying a value typed against secret content', () => {
         const kept = toStorableFilters(

--- a/src/utils/listViews.spec.ts
+++ b/src/utils/listViews.spec.ts
@@ -1,0 +1,357 @@
+import { describe, expect, it } from 'vitest';
+import type { ListViewModel } from 'types/listViews';
+import { SortDirection } from 'types/listViews';
+import { FilterConditionOperator, FilterFieldSource, FilterFieldType, Resource } from 'types/openapi';
+import type { ColumnDefinition, SourcedCatalogueField } from 'types/tableColumns';
+import {
+    MAX_VISIBLE_TABS,
+    STANDARD_VIEW_ID,
+    STANDARD_VIEW_NAME,
+    duplicateName,
+    isSliceDirty,
+    resolveInitialViewId,
+    resolveView,
+    splitTabs,
+    toColumnSort,
+    toCreateRequest,
+    toStandardSlice,
+    toStoredColumns,
+    toStoredSort,
+    toTabs,
+    toUpdateRequest,
+    toViewSlice,
+} from './listViews';
+
+const view = (uuid: string, name: string, overrides: Partial<ListViewModel> = {}): ListViewModel => ({
+    uuid,
+    name,
+    resource: Resource.Certificates,
+    columns: [{ fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME' }],
+    defaultView: false,
+    ...overrides,
+});
+
+const field = (source: FilterFieldSource, identifier: string, label: string, overrides = {}): SourcedCatalogueField =>
+    ({
+        fieldSource: source,
+        fieldIdentifier: identifier,
+        fieldLabel: label,
+        type: FilterFieldType.String,
+        conditions: [],
+        displayable: true,
+        sortable: true,
+        ...overrides,
+    }) as SourcedCatalogueField;
+
+const commonName = field(FilterFieldSource.Property, 'COMMON_NAME', 'Common Name');
+const costCentre = field(FilterFieldSource.Custom, 'cost_centre', 'Cost centre', { sortable: false });
+
+const standardColumns: ColumnDefinition[] = [
+    { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME', catalogueLabel: 'Common Name' },
+    { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'STATUS', catalogueLabel: 'Status' },
+];
+
+describe('toTabs', () => {
+    it('puts Standard first and keeps the API order of the stored views', () => {
+        const tabs = toTabs([view('a', 'Expiry watch'), view('b', 'Compliance audit')]);
+
+        expect(tabs.map((tab) => tab.name)).toEqual([STANDARD_VIEW_NAME, 'Expiry watch', 'Compliance audit']);
+        expect(tabs[0]).toMatchObject({ id: STANDARD_VIEW_ID, isStandard: true });
+        expect(tabs[1]).toMatchObject({ id: 'a', isStandard: false });
+    });
+
+    it('pins Standard only while no stored view is pinned', () => {
+        expect(toTabs([view('a', 'Expiry watch')])[0].isPinned).toBe(true);
+
+        const withPinned = toTabs([view('a', 'Expiry watch'), view('b', 'Pinned', { defaultView: true })]);
+        expect(withPinned[0].isPinned).toBe(false);
+        expect(withPinned[2].isPinned).toBe(true);
+    });
+
+    it('offers Standard alone when the user has stored nothing', () => {
+        expect(toTabs([])).toEqual([{ id: STANDARD_VIEW_ID, name: STANDARD_VIEW_NAME, isStandard: true, isPinned: true }]);
+    });
+});
+
+describe('resolveInitialViewId', () => {
+    it('opens the pinned view', () => {
+        expect(resolveInitialViewId([view('a', 'One'), view('b', 'Two', { defaultView: true })])).toBe('b');
+    });
+
+    it('opens Standard when nothing is pinned', () => {
+        expect(resolveInitialViewId([view('a', 'One')])).toBe(STANDARD_VIEW_ID);
+        expect(resolveInitialViewId([])).toBe(STANDARD_VIEW_ID);
+    });
+});
+
+describe('splitTabs', () => {
+    const tabs = toTabs([1, 2, 3, 4, 5, 6, 7].map((n) => view(`v${n}`, `View ${n}`)));
+
+    it('shows everything while the strip fits', () => {
+        const split = splitTabs(tabs.slice(0, 3), STANDARD_VIEW_ID);
+        expect(split.visible).toHaveLength(3);
+        expect(split.overflow).toEqual([]);
+    });
+
+    it('rolls the remainder into the overflow at the cap', () => {
+        const split = splitTabs(tabs, STANDARD_VIEW_ID);
+
+        expect(split.visible).toHaveLength(MAX_VISIBLE_TABS);
+        expect(split.overflow.map((tab) => tab.name)).toEqual(['View 5', 'View 6', 'View 7']);
+    });
+
+    it('pulls an overflowed active tab onto the strip, displacing the last visible one', () => {
+        const split = splitTabs(tabs, 'v6');
+
+        expect(split.visible.map((tab) => tab.name)).toEqual([STANDARD_VIEW_NAME, 'View 1', 'View 2', 'View 3', 'View 6']);
+        expect(split.overflow.map((tab) => tab.name)).toEqual(['View 4', 'View 5', 'View 7']);
+    });
+
+    it('leaves the strip alone when the active tab is already visible', () => {
+        expect(splitTabs(tabs, 'v2')).toEqual(splitTabs(tabs, STANDARD_VIEW_ID));
+    });
+
+    it('never collapses the strip to nothing', () => {
+        expect(splitTabs(tabs, STANDARD_VIEW_ID, 0).visible).toHaveLength(1);
+    });
+});
+
+describe('duplicateName', () => {
+    it('appends (copy)', () => {
+        expect(duplicateName('Expiry watch', [])).toBe('Expiry watch (copy)');
+    });
+
+    it('numbers the copy rather than stacking suffixes, because names are unique per resource', () => {
+        expect(duplicateName('Expiry watch', ['Expiry watch (copy)'])).toBe('Expiry watch (copy) 2');
+        expect(duplicateName('Expiry watch', ['Expiry watch (copy)', 'Expiry watch (copy) 2'])).toBe('Expiry watch (copy) 3');
+    });
+});
+
+describe('sort conversion', () => {
+    it('round-trips a stored sort through the table shape', () => {
+        const stored = { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'NOT_AFTER', direction: SortDirection.Desc };
+
+        expect(toColumnSort(stored)).toEqual({ fieldSource: FilterFieldSource.Property, fieldIdentifier: 'NOT_AFTER', direction: 'desc' });
+        expect(toStoredSort(toColumnSort(stored))).toEqual(stored);
+    });
+
+    it('keeps an absent sort absent in both directions', () => {
+        expect(toColumnSort(undefined)).toBeUndefined();
+        expect(toStoredSort(undefined)).toBeUndefined();
+    });
+
+    it('reads anything that is not descending as ascending', () => {
+        const stored = { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'NOT_AFTER', direction: SortDirection.Asc };
+        expect(toColumnSort(stored)?.direction).toBe('asc');
+        expect(toStoredSort({ ...stored, direction: 'asc' })?.direction).toBe(SortDirection.Asc);
+    });
+});
+
+describe('toStoredColumns', () => {
+    it('stores only source, identifier and the heading override', () => {
+        const columns: ColumnDefinition[] = [
+            { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME', catalogueLabel: 'Common Name', sortable: true },
+            {
+                fieldSource: FilterFieldSource.Custom,
+                fieldIdentifier: 'cost_centre',
+                catalogueLabel: 'Cost centre',
+                label: 'Owning team',
+            },
+        ];
+
+        expect(toStoredColumns(columns)).toEqual([
+            { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME' },
+            { fieldSource: FilterFieldSource.Custom, fieldIdentifier: 'cost_centre', label: 'Owning team' },
+        ]);
+    });
+});
+
+describe('resolveView', () => {
+    it('refreshes a resolved column from the catalogue and keeps the view label', () => {
+        const resolved = resolveView(
+            [{ fieldSource: FilterFieldSource.Custom, fieldIdentifier: 'cost_centre', label: 'Owning team' }],
+            [costCentre],
+            standardColumns,
+        );
+
+        expect(resolved.columns[0]).toMatchObject({
+            catalogueLabel: 'Cost centre',
+            label: 'Owning team',
+            available: true,
+            sortable: false,
+        });
+        expect(resolved.unavailable).toEqual([]);
+        expect(resolved.fellBackToStandard).toBe(false);
+    });
+
+    it('keeps a column whose field is gone in place, marked unavailable', () => {
+        const resolved = resolveView(
+            [
+                { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME' },
+                { fieldSource: FilterFieldSource.Custom, fieldIdentifier: 'cost_centre' },
+            ],
+            [commonName],
+            standardColumns,
+        );
+
+        expect(resolved.columns).toHaveLength(2);
+        expect(resolved.unavailable.map((column) => column.fieldIdentifier)).toEqual(['cost_centre']);
+        expect(resolved.renderable.map((column) => column.fieldIdentifier)).toEqual(['COMMON_NAME']);
+        expect(resolved.fellBackToStandard).toBe(false);
+    });
+
+    it('names an unresolved column by its identifier, so an administrator can tell what it was', () => {
+        const resolved = resolveView([{ fieldSource: FilterFieldSource.Custom, fieldIdentifier: 'cost_centre' }], [commonName], []);
+
+        expect(resolved.columns[0].catalogueLabel).toBe('cost_centre');
+    });
+
+    it('falls back to the platform set when nothing resolved at all', () => {
+        const resolved = resolveView([{ fieldSource: FilterFieldSource.Custom, fieldIdentifier: 'gone' }], [], standardColumns);
+
+        expect(resolved.fellBackToStandard).toBe(true);
+        expect(resolved.renderable).toEqual(standardColumns);
+        expect(resolved.unavailable).toHaveLength(1);
+    });
+
+    it('does not report a fallback for a view that stores no columns', () => {
+        expect(resolveView([], [], standardColumns).fellBackToStandard).toBe(false);
+    });
+
+    it('resolves a platform column the filter-field catalogue does not publish', () => {
+        const resolved = resolveView([{ fieldSource: FilterFieldSource.Property, fieldIdentifier: 'STATUS' }], [], standardColumns);
+
+        expect(resolved.unavailable).toEqual([]);
+        expect(resolved.renderable[0].catalogueLabel).toBe('Status');
+    });
+
+    it('drops the availability marker the picker adds from the renderable columns', () => {
+        const resolved = resolveView([{ fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME' }], [commonName], []);
+
+        expect(resolved.renderable[0]).not.toHaveProperty('available');
+    });
+});
+
+describe('toViewSlice', () => {
+    it('carries the columns, the filters and the ordering together', () => {
+        const filters = [
+            {
+                fieldSource: FilterFieldSource.Property,
+                fieldIdentifier: 'COMMON_NAME',
+                condition: FilterConditionOperator.Contains,
+                value: 'acme',
+            },
+        ];
+        const slice = toViewSlice(
+            view('a', 'Expiry watch', {
+                filters,
+                sort: { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME', direction: SortDirection.Asc },
+            }),
+            [commonName],
+            standardColumns,
+        );
+
+        expect(slice.columns.map((column) => column.fieldIdentifier)).toEqual(['COMMON_NAME']);
+        expect(slice.filters).toEqual(filters);
+        expect(slice.sort).toEqual({ fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME', direction: 'asc' });
+    });
+
+    it('reads a view that stores no filters as filtering nothing', () => {
+        expect(toViewSlice(view('a', 'Expiry watch'), [commonName], standardColumns).filters).toEqual([]);
+    });
+});
+
+describe('toStandardSlice', () => {
+    it('is the platform columns with no filters and no ordering of its own', () => {
+        expect(toStandardSlice(standardColumns)).toEqual({ columns: standardColumns, filters: [], sort: undefined });
+    });
+});
+
+describe('isSliceDirty', () => {
+    const stored = toStandardSlice(standardColumns);
+
+    it('reads an untouched slice as clean', () => {
+        expect(isSliceDirty(stored, toStandardSlice(standardColumns))).toBe(false);
+    });
+
+    it('ignores catalogue detail the view does not store', () => {
+        const refreshed = { ...stored, columns: standardColumns.map((column) => ({ ...column, sortable: true, multiValue: false })) };
+        expect(isSliceDirty(stored, refreshed)).toBe(false);
+    });
+
+    it('sees a column added, removed, reordered or renamed', () => {
+        expect(isSliceDirty(stored, { ...stored, columns: [standardColumns[0]] })).toBe(true);
+        expect(isSliceDirty(stored, { ...stored, columns: [standardColumns[1], standardColumns[0]] })).toBe(true);
+        expect(isSliceDirty(stored, { ...stored, columns: [{ ...standardColumns[0], label: 'Name' }, standardColumns[1]] })).toBe(true);
+    });
+
+    it('sees a filter change, because a view carries its filters', () => {
+        const filtered = {
+            ...stored,
+            filters: [
+                {
+                    fieldSource: FilterFieldSource.Property,
+                    fieldIdentifier: 'COMMON_NAME',
+                    condition: FilterConditionOperator.Contains,
+                    value: 'acme',
+                },
+            ],
+        };
+
+        expect(isSliceDirty(stored, filtered)).toBe(true);
+        expect(isSliceDirty(filtered, filtered)).toBe(false);
+    });
+
+    it('sees the sort move and the sort direction flip', () => {
+        const asc = { ...stored, sort: { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME', direction: 'asc' } };
+        const desc = { ...asc, sort: { ...asc.sort, direction: 'desc' } };
+
+        expect(isSliceDirty(stored, asc)).toBe(true);
+        expect(isSliceDirty(asc, desc)).toBe(true);
+        expect(isSliceDirty(asc, asc)).toBe(false);
+    });
+});
+
+describe('toCreateRequest', () => {
+    it('creates an unpinned view holding the slice', () => {
+        const request = toCreateRequest('Expiry watch', Resource.Certificates, toStandardSlice(standardColumns));
+
+        expect(request).toEqual({
+            name: 'Expiry watch',
+            resource: Resource.Certificates,
+            columns: toStoredColumns(standardColumns),
+            filters: [],
+            sort: undefined,
+            defaultView: false,
+        });
+    });
+
+    it('can pin the view it creates', () => {
+        expect(toCreateRequest('Expiry watch', Resource.Certificates, toStandardSlice(standardColumns), true).defaultView).toBe(true);
+    });
+});
+
+describe('toUpdateRequest', () => {
+    it('sends every field back, because the API replaces the whole row', () => {
+        const stored = view('a', 'Expiry watch', {
+            defaultView: true,
+            sort: { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME', direction: SortDirection.Asc },
+        });
+
+        expect(toUpdateRequest(stored)).toEqual({
+            name: 'Expiry watch',
+            columns: stored.columns,
+            filters: undefined,
+            sort: stored.sort,
+            defaultView: true,
+        });
+    });
+
+    it('applies the patch over the stored row, so a rename keeps the columns', () => {
+        const stored = view('a', 'Expiry watch');
+        const renamed = toUpdateRequest(stored, { name: 'Expiry' });
+
+        expect(renamed.name).toBe('Expiry');
+        expect(renamed.columns).toEqual(stored.columns);
+    });
+});

--- a/src/utils/listViews.spec.ts
+++ b/src/utils/listViews.spec.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import type { ListViewModel } from 'types/listViews';
 import { SortDirection } from 'types/listViews';
-import { FilterConditionOperator, FilterFieldSource, FilterFieldType, Resource } from 'types/openapi';
+import {
+    AttributeContentType,
+    FilterConditionOperator,
+    FilterFieldSource,
+    FilterFieldType,
+    Resource,
+    type SearchFieldDataByGroupDto,
+} from 'types/openapi';
 import type { ColumnDefinition, SourcedCatalogueField } from 'types/tableColumns';
 import {
     MAX_VISIBLE_TABS,
@@ -15,7 +22,9 @@ import {
     toColumnSort,
     toCreateRequest,
     toStandardSlice,
+    toStorableFilters,
     toStoredColumns,
+    toStoredColumnsKeepingUnavailable,
     toStoredSort,
     toTabs,
     toUpdateRequest,
@@ -357,5 +366,116 @@ describe('toUpdateRequest', () => {
 
         expect(renamed.name).toBe('Expiry');
         expect(renamed.columns).toEqual(stored.columns);
+    });
+});
+
+describe('toStorableFilters', () => {
+    const catalogue = [
+        {
+            filterFieldSource: FilterFieldSource.Property,
+            searchFieldData: [{ fieldIdentifier: 'COMMON_NAME', fieldLabel: 'Common Name', type: FilterFieldType.String, conditions: [] }],
+        },
+        {
+            filterFieldSource: FilterFieldSource.Custom,
+            searchFieldData: [
+                {
+                    fieldIdentifier: 'vaultToken',
+                    fieldLabel: 'Vault Token',
+                    type: FilterFieldType.String,
+                    conditions: [],
+                    attributeContentType: AttributeContentType.Secret,
+                },
+                {
+                    fieldIdentifier: 'cost_centre',
+                    fieldLabel: 'Cost centre',
+                    type: FilterFieldType.String,
+                    conditions: [],
+                    attributeContentType: AttributeContentType.String,
+                },
+            ],
+        },
+    ] as unknown as SearchFieldDataByGroupDto[];
+
+    const filter = (source: FilterFieldSource, identifier: string, value?: unknown) => ({
+        fieldSource: source,
+        fieldIdentifier: identifier,
+        condition: FilterConditionOperator.Equals,
+        ...(value === undefined ? {} : { value }),
+    });
+
+    it('drops a filter carrying a value typed against secret content', () => {
+        const kept = toStorableFilters(
+            [filter(FilterFieldSource.Property, 'COMMON_NAME', 'acme'), filter(FilterFieldSource.Custom, 'vaultToken', 'hunter2')],
+            catalogue,
+        );
+
+        expect(kept).toEqual([filter(FilterFieldSource.Property, 'COMMON_NAME', 'acme')]);
+    });
+
+    it('keeps a presence-only condition on the same field, which carries nothing to leak', () => {
+        const kept = toStorableFilters([filter(FilterFieldSource.Custom, 'vaultToken')], catalogue);
+
+        expect(kept).toEqual([filter(FilterFieldSource.Custom, 'vaultToken')]);
+    });
+
+    it('treats an empty value as no value', () => {
+        expect(toStorableFilters([filter(FilterFieldSource.Custom, 'vaultToken', '')], catalogue)).toHaveLength(1);
+        expect(toStorableFilters([filter(FilterFieldSource.Custom, 'vaultToken', [])], catalogue)).toHaveLength(1);
+        expect(toStorableFilters([filter(FilterFieldSource.Custom, 'vaultToken', ['hunter2'])], catalogue)).toHaveLength(0);
+    });
+
+    it('keys on the source as well as the identifier, so a property of the same name is untouched', () => {
+        const kept = toStorableFilters([filter(FilterFieldSource.Property, 'vaultToken', 'not a secret here')], catalogue);
+
+        expect(kept).toHaveLength(1);
+    });
+
+    it('leaves a catalogue with no secret field alone', () => {
+        const filters = [filter(FilterFieldSource.Custom, 'cost_centre', '42')];
+
+        expect(toStorableFilters(filters, [catalogue[0]])).toEqual(filters);
+    });
+});
+
+describe('toStoredColumnsKeepingUnavailable', () => {
+    const rendered: ColumnDefinition[] = [
+        { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME', catalogueLabel: 'Common Name' },
+        { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'STATUS', catalogueLabel: 'Status' },
+    ];
+
+    it('puts an unavailable stored column back at the position it was stored at', () => {
+        const resolved = [
+            { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME', catalogueLabel: 'Common Name', available: true },
+            { fieldSource: FilterFieldSource.Custom, fieldIdentifier: 'retired', catalogueLabel: 'retired', available: false },
+            { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'STATUS', catalogueLabel: 'Status', available: true },
+        ];
+
+        expect(toStoredColumnsKeepingUnavailable(rendered, resolved)).toEqual([
+            { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME' },
+            { fieldSource: FilterFieldSource.Custom, fieldIdentifier: 'retired' },
+            { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'STATUS' },
+        ]);
+    });
+
+    it("carries an unavailable column's heading override with it", () => {
+        const resolved = [
+            {
+                fieldSource: FilterFieldSource.Custom,
+                fieldIdentifier: 'retired',
+                catalogueLabel: 'retired',
+                label: 'Retired at',
+                available: false,
+            },
+        ];
+
+        expect(toStoredColumnsKeepingUnavailable([], resolved)).toEqual([
+            { fieldSource: FilterFieldSource.Custom, fieldIdentifier: 'retired', label: 'Retired at' },
+        ]);
+    });
+
+    it('is the plain stored shape when everything resolved', () => {
+        const resolved = rendered.map((column) => ({ ...column, available: true }));
+
+        expect(toStoredColumnsKeepingUnavailable(rendered, resolved)).toEqual(toStoredColumns(rendered));
     });
 });

--- a/src/utils/listViews.ts
+++ b/src/utils/listViews.ts
@@ -173,13 +173,16 @@ export function resolveView(
 
     const columns = resolveColumns(asDefinitions, [...fields], standardColumns);
     const available = columns.filter((column) => column.available);
-    const unavailable = columns.filter((column) => !column.available);
-    const fellBackToStandard = stored.length > 0 && available.length === 0;
+
+    // Nothing renderable falls back to the platform set rather than to a table with no columns at
+    // all. The reachable case is not a stored column failing to resolve here: the API omits a column
+    // whose field has left the catalogue, so a view built entirely on since-deleted attributes
+    // arrives with `columns: []` — which resolves to nothing without anything looking wrong.
+    const fellBackToStandard = available.length === 0;
 
     return {
         columns,
         renderable: fellBackToStandard ? [...standardColumns] : available.map(toDefinition),
-        unavailable,
         fellBackToStandard,
     };
 }

--- a/src/utils/listViews.ts
+++ b/src/utils/listViews.ts
@@ -9,7 +9,7 @@ import {
     SortDirection,
     type ViewSlice,
 } from 'types/listViews';
-import type { Resource } from 'types/openapi';
+import { AttributeContentType, type Resource, type SearchFieldDataByGroupDto } from 'types/openapi';
 import type { ColumnDefinition, PickerColumn, SourcedCatalogueField } from 'types/tableColumns';
 import { resolveColumns } from './columnPicker';
 import { type ColumnSort, getColumnHeading, getColumnKey, getSortKey } from './tableColumns';
@@ -151,8 +151,66 @@ export function toStoredColumns(columns: readonly ColumnDefinition[]): ListViewC
     }));
 }
 
+/** Whether a filter carries a value at all, as opposed to testing only for presence or emptiness. */
+function carriesValue(filter: SearchFilterModel): boolean {
+    if (filter.value === undefined || filter.value === null || filter.value === '') return false;
+    return !(Array.isArray(filter.value) && filter.value.length === 0);
+}
+
 /**
- * A stored view's columns resolved against the live catalogue.
+ * The `(source, identifier)` keys of the catalogue fields whose content the platform holds as a
+ * secret.
+ *
+ * Read from the raw groups rather than from {@link toCatalogueFields}, which keeps only the
+ * displayable ones: `displayable` is the flag that keeps secret content out of a column, so a secret
+ * field is exactly what that subset no longer contains — while the filter widget still offers it.
+ */
+function secretFieldKeys(catalogue: readonly SearchFieldDataByGroupDto[]): Set<string> {
+    const keys = new Set<string>();
+
+    for (const group of catalogue) {
+        for (const field of group.searchFieldData ?? []) {
+            if (field.attributeContentType === AttributeContentType.Secret) {
+                keys.add(getColumnKey({ fieldSource: group.filterFieldSource, fieldIdentifier: field.fieldIdentifier }));
+            }
+        }
+    }
+
+    return keys;
+}
+
+/**
+ * The filters a view is allowed to store: every live filter except one carrying a value typed against
+ * a field whose content is a secret.
+ *
+ * A saved view is held verbatim by Core and read back by every client that opens it, so such a value
+ * would become a durable plaintext copy of secret material outside the storage that protects it. The
+ * filter still applies to the table in front of the user; it is only kept out of what is written
+ * back. A presence-only condition on the same field survives, because it carries nothing to leak.
+ */
+export function toStorableFilters(
+    filters: readonly SearchFilterModel[],
+    catalogue: readonly SearchFieldDataByGroupDto[],
+): SearchFilterModel[] {
+    const secret = secretFieldKeys(catalogue);
+    if (secret.size === 0) return [...filters];
+
+    return filters.filter((filter) => !(secret.has(getColumnKey(filter)) && carriesValue(filter)));
+}
+
+/**
+ * A stored view's columns resolved against the live catalogue. The authoritative statement of how a
+ * stored view is read; everything downstream — {@link ResolvedView}, the notice, the picker — states
+ * only what it does with the result.
+ *
+ * A view names `(fieldSource, fieldIdentifier)` pairs, and two different things can go wrong with
+ * one. A field that has been deleted never arrives: `GET /v1/listViews` resolves the stored pairs
+ * against the resource's own catalogue and omits what it cannot offer, so a view built entirely on
+ * deleted fields arrives with no columns at all — which is the case `fellBackToStandard` exists for,
+ * and the only reachable one, since nothing is left to name. A column the *listing* cannot display —
+ * a secret's content, an encrypted value — does arrive intact, because the catalogue the API
+ * validates a view against carries no notion of `displayable`; it is kept in place and marked
+ * unavailable rather than dropped, so it can be named and reviewed instead of vanishing.
  *
  * @param standardColumns the platform default set, which both supplies columns the filter-field
  * catalogue does not publish and is what an entirely unresolved view falls back to.
@@ -174,10 +232,7 @@ export function resolveView(
     const columns = resolveColumns(asDefinitions, [...fields], standardColumns);
     const available = columns.filter((column) => column.available);
 
-    // Nothing renderable falls back to the platform set rather than to a table with no columns at
-    // all. The reachable case is not a stored column failing to resolve here: the API omits a column
-    // whose field has left the catalogue, so a view built entirely on since-deleted attributes
-    // arrives with `columns: []` — which resolves to nothing without anything looking wrong.
+    // Nothing renderable falls back to the platform set rather than to a table with no columns at all.
     const fellBackToStandard = available.length === 0;
 
     return {
@@ -227,9 +282,9 @@ function sortSignature(sort: ColumnSort | undefined): string {
 /**
  * Whether the table has drifted from the view behind the active tab.
  *
- * Sorting and filtering are edits to the view under D7, so both mark the tab and offer Revert / Save
- * to view. Never autosaved: a view is the thing a user comes back to, and a stray click on a header
- * should not quietly redefine "Expiry watch".
+ * Sorting and filtering are edits to the view, so both mark the tab and offer Revert / Save to view.
+ * Never autosaved: a view is the thing a user comes back to, and a stray click on a header should not
+ * quietly redefine "Expiry watch".
  */
 export function isSliceDirty(stored: ViewSlice, current: ViewSlice): boolean {
     return (
@@ -237,6 +292,28 @@ export function isSliceDirty(stored: ViewSlice, current: ViewSlice): boolean {
         filterSignature(stored.filters) !== filterSignature(current.filters) ||
         sortSignature(stored.sort) !== sortSignature(current.sort)
     );
+}
+
+/**
+ * The stored column list a full-row save carries: what the table renders, with the stored columns it
+ * cannot render put back at the positions they were stored at.
+ *
+ * Saving an ordering or a filter must not drop a column the listing cannot display. The table never
+ * showed it, so the user was never offered the choice — the column picker is the one place such a
+ * column is removed, because it is the one place it is shown.
+ */
+export function toStoredColumnsKeepingUnavailable(
+    rendered: readonly ColumnDefinition[],
+    resolved: readonly PickerColumn[],
+): ListViewColumnModel[] {
+    const stored = toStoredColumns(rendered);
+
+    resolved.forEach((column, index) => {
+        if (column.available) return;
+        stored.splice(Math.min(index, stored.length), 0, ...toStoredColumns([column]));
+    });
+
+    return stored;
 }
 
 /** A create request for a new view holding the given slice. */

--- a/src/utils/listViews.ts
+++ b/src/utils/listViews.ts
@@ -1,0 +1,266 @@
+import type { SearchFilterModel } from 'types/certificate';
+import {
+    type ListViewColumnModel,
+    type ListViewModel,
+    type ListViewRequestModel,
+    type ListViewUpdateRequestModel,
+    type ResolvedView,
+    type SearchSortModel,
+    SortDirection,
+    type ViewSlice,
+} from 'types/listViews';
+import type { Resource } from 'types/openapi';
+import type { ColumnDefinition, PickerColumn, SourcedCatalogueField } from 'types/tableColumns';
+import { resolveColumns } from './columnPicker';
+import { type ColumnSort, getColumnHeading, getColumnKey, getSortKey } from './tableColumns';
+
+/**
+ * The identity of the Standard tab. Standard is the platform default column set, and deliberately not
+ * a stored row — which is what makes "always present and never removable" fall out of the model
+ * rather than needing a protected-row rule. There is nothing to delete.
+ *
+ * A stored view is addressed by its UUID, so this cannot collide with one.
+ */
+export const STANDARD_VIEW_ID = 'standard';
+
+/**
+ * How many tabs the strip shows before the rest roll into an overflow menu. Tabs are excellent at
+ * four views and unusable at twelve, and on these pages the strip competes with the filter widget for
+ * vertical space.
+ */
+export const MAX_VISIBLE_TABS = 5;
+
+/** One entry of the tab strip, Standard included. */
+export interface ViewTab {
+    /** {@link STANDARD_VIEW_ID} for Standard, otherwise the stored view's UUID. */
+    id: string;
+    name: string;
+    isStandard: boolean;
+    /** Whether this is the tab that opens on load. Standard is pinned only when no stored view is. */
+    isPinned: boolean;
+}
+
+/** The tab strip split into what it shows and what its overflow menu holds. */
+export interface TabSplit {
+    visible: ViewTab[];
+    overflow: ViewTab[];
+}
+
+/** The name Standard is offered under. Not "Default", which is kept free to mean "opens on load". */
+export const STANDARD_VIEW_NAME = 'Standard';
+
+/** The stored view that opens on load, if any. */
+function findPinned(views: readonly ListViewModel[]): ListViewModel | undefined {
+    return views.find((view) => view.defaultView);
+}
+
+/**
+ * The tab strip: Standard first, then the stored views in the order the API returned them.
+ *
+ * Standard carries the pin only when no stored view does, because that is exactly when it is the view
+ * that opens — `defaultView` on a stored row and "Standard opens" are one state, not two.
+ */
+export function toTabs(views: readonly ListViewModel[]): ViewTab[] {
+    const pinned = findPinned(views);
+
+    return [
+        { id: STANDARD_VIEW_ID, name: STANDARD_VIEW_NAME, isStandard: true, isPinned: pinned === undefined },
+        ...views.map((view) => ({ id: view.uuid, name: view.name, isStandard: false, isPinned: view === pinned })),
+    ];
+}
+
+/**
+ * The tab that opens on load: the pinned stored view, or Standard when none is pinned.
+ */
+export function resolveInitialViewId(views: readonly ListViewModel[]): string {
+    return findPinned(views)?.uuid ?? STANDARD_VIEW_ID;
+}
+
+/**
+ * The strip split at the visible cap, with the active tab always on the visible side.
+ *
+ * Pulling the active tab forward matters more than preserving order: selecting a view from the
+ * overflow menu would otherwise leave the strip with no tab marked active, and the user looking at a
+ * table that no tab claims. The tab it displaces goes to the front of the overflow rather than the
+ * back, so it is the first thing found again.
+ */
+export function splitTabs(tabs: readonly ViewTab[], activeId: string, cap: number = MAX_VISIBLE_TABS): TabSplit {
+    const limit = Math.max(1, cap);
+    if (tabs.length <= limit) return { visible: [...tabs], overflow: [] };
+
+    const visible = tabs.slice(0, limit);
+    const overflow = tabs.slice(limit);
+
+    const activeIndex = overflow.findIndex((tab) => tab.id === activeId);
+    if (activeIndex === -1) return { visible, overflow };
+
+    const displaced = visible[limit - 1];
+    return {
+        visible: [...visible.slice(0, limit - 1), overflow[activeIndex]],
+        overflow: [displaced, ...overflow.slice(0, activeIndex), ...overflow.slice(activeIndex + 1)],
+    };
+}
+
+/**
+ * The name a duplicate is auto-named with, so duplicating never interrupts with a dialog.
+ *
+ * Names are unique per user and resource, so `<name> (copy)` alone would fail the second time. A
+ * numeric suffix is appended rather than stacking `(copy) (copy)`, which reads as an accident.
+ */
+export function duplicateName(name: string, existing: readonly string[]): string {
+    const taken = new Set(existing);
+    const base = `${name} (copy)`;
+    if (!taken.has(base)) return base;
+
+    for (let suffix = 2; ; suffix++) {
+        const candidate = `${base} ${suffix}`;
+        if (!taken.has(candidate)) return candidate;
+    }
+}
+
+/** A stored sort as the table expresses one. */
+export function toColumnSort(sort: SearchSortModel | undefined): ColumnSort | undefined {
+    if (!sort) return undefined;
+    return {
+        fieldSource: sort.fieldSource,
+        fieldIdentifier: sort.fieldIdentifier,
+        direction: sort.direction === SortDirection.Desc ? 'desc' : 'asc',
+    };
+}
+
+/** The table's sort in the shape a view stores. */
+export function toStoredSort(sort: ColumnSort | undefined): SearchSortModel | undefined {
+    if (!sort) return undefined;
+    return {
+        fieldSource: sort.fieldSource,
+        fieldIdentifier: sort.fieldIdentifier,
+        direction: sort.direction === 'desc' ? SortDirection.Desc : SortDirection.Asc,
+    };
+}
+
+/**
+ * A column list in the shape a view stores: source, identifier and the heading override, and nothing
+ * else. Everything the catalogue supplies is resolved on read, so storing it would only let a stored
+ * view drift from a field that was relabelled since.
+ */
+export function toStoredColumns(columns: readonly ColumnDefinition[]): ListViewColumnModel[] {
+    return columns.map((column) => ({
+        fieldSource: column.fieldSource,
+        fieldIdentifier: column.fieldIdentifier,
+        ...(column.label ? { label: column.label } : {}),
+    }));
+}
+
+/**
+ * A stored view's columns resolved against the live catalogue.
+ *
+ * @param standardColumns the platform default set, which both supplies columns the filter-field
+ * catalogue does not publish and is what an entirely unresolved view falls back to.
+ */
+export function resolveView(
+    stored: readonly ListViewColumnModel[],
+    fields: readonly SourcedCatalogueField[],
+    standardColumns: readonly ColumnDefinition[],
+): ResolvedView {
+    const asDefinitions = stored.map((column) => ({
+        fieldSource: column.fieldSource,
+        fieldIdentifier: column.fieldIdentifier,
+        // A stand-in until the catalogue answers. An unresolved column shows its identifier instead,
+        // which is what tells an administrator what the column used to be.
+        catalogueLabel: column.label ?? column.fieldIdentifier,
+        ...(column.label ? { label: column.label } : {}),
+    }));
+
+    const columns = resolveColumns(asDefinitions, [...fields], standardColumns);
+    const available = columns.filter((column) => column.available);
+    const unavailable = columns.filter((column) => !column.available);
+    const fellBackToStandard = stored.length > 0 && available.length === 0;
+
+    return {
+        columns,
+        renderable: fellBackToStandard ? [...standardColumns] : available.map(toDefinition),
+        unavailable,
+        fellBackToStandard,
+    };
+}
+
+/** A resolved column without the picker's availability marker, which the table has no use for. */
+function toDefinition({ available, ...definition }: PickerColumn): ColumnDefinition {
+    return definition;
+}
+
+/** The slice a stored view describes, resolved against the live catalogue. */
+export function toViewSlice(
+    view: ListViewModel,
+    fields: readonly SourcedCatalogueField[],
+    standardColumns: readonly ColumnDefinition[],
+): ViewSlice {
+    return {
+        columns: resolveView(view.columns, fields, standardColumns).renderable,
+        filters: view.filters ?? [],
+        sort: toColumnSort(view.sort),
+    };
+}
+
+/** The Standard tab's own slice: the platform columns, no filters and no ordering of its own. */
+export function toStandardSlice(standardColumns: readonly ColumnDefinition[]): ViewSlice {
+    return { columns: [...standardColumns], filters: [], sort: undefined };
+}
+
+/** A column list reduced to what a view actually stores, so two can be compared for equality. */
+function columnSignature(columns: readonly ColumnDefinition[]): string {
+    return JSON.stringify(columns.map((column) => [getColumnKey(column), getColumnHeading(column)]));
+}
+
+/** A filter list reduced to its four stored fields, so key order in the object cannot matter. */
+function filterSignature(filters: readonly SearchFilterModel[]): string {
+    return JSON.stringify(filters.map((filter) => [filter.fieldSource, filter.fieldIdentifier, filter.condition, filter.value ?? null]));
+}
+
+function sortSignature(sort: ColumnSort | undefined): string {
+    return sort ? `${getSortKey(sort)}:${sort.direction}` : '';
+}
+
+/**
+ * Whether the table has drifted from the view behind the active tab.
+ *
+ * Sorting and filtering are edits to the view under D7, so both mark the tab and offer Revert / Save
+ * to view. Never autosaved: a view is the thing a user comes back to, and a stray click on a header
+ * should not quietly redefine "Expiry watch".
+ */
+export function isSliceDirty(stored: ViewSlice, current: ViewSlice): boolean {
+    return (
+        columnSignature(stored.columns) !== columnSignature(current.columns) ||
+        filterSignature(stored.filters) !== filterSignature(current.filters) ||
+        sortSignature(stored.sort) !== sortSignature(current.sort)
+    );
+}
+
+/** A create request for a new view holding the given slice. */
+export function toCreateRequest(name: string, resource: Resource, slice: ViewSlice, defaultView = false): ListViewRequestModel {
+    return {
+        name,
+        resource,
+        columns: toStoredColumns(slice.columns),
+        filters: slice.filters,
+        sort: toStoredSort(slice.sort),
+        defaultView,
+    };
+}
+
+/**
+ * An update request for a stored view.
+ *
+ * The API replaces the whole row, so every field it does not mean to change has to be sent back as it
+ * stands. A rename that omitted the columns would empty the view.
+ */
+export function toUpdateRequest(view: ListViewModel, patch: Partial<ListViewUpdateRequestModel> = {}): ListViewUpdateRequestModel {
+    return {
+        name: view.name,
+        columns: view.columns,
+        filters: view.filters,
+        sort: view.sort,
+        defaultView: view.defaultView,
+        ...patch,
+    };
+}

--- a/src/utils/listViews.ts
+++ b/src/utils/listViews.ts
@@ -333,9 +333,19 @@ export function toCreateRequest(name: string, resource: Resource, slice: ViewSli
  *
  * The API replaces the whole row, so every field it does not mean to change has to be sent back as it
  * stands. A rename that omitted the columns would empty the view.
+ *
+ * Which is why the catalogue is required rather than optional: a rename, a pin or a column edit sends
+ * the stored filters back untouched, and a view that arrived carrying a secret-valued filter — written
+ * by a client that predates this rule, or by one that does not apply it — would have that plaintext
+ * rewritten on every one of them. The whole row is filtered on the way out, the patch included, so
+ * there is no update path left that can carry such a value. See {@link toStorableFilters}.
  */
-export function toUpdateRequest(view: ListViewModel, patch: Partial<ListViewUpdateRequestModel> = {}): ListViewUpdateRequestModel {
-    return {
+export function toUpdateRequest(
+    view: ListViewModel,
+    catalogue: readonly SearchFieldDataByGroupDto[],
+    patch: Partial<ListViewUpdateRequestModel> = {},
+): ListViewUpdateRequestModel {
+    const row: ListViewUpdateRequestModel = {
         name: view.name,
         columns: view.columns,
         filters: view.filters,
@@ -343,4 +353,6 @@ export function toUpdateRequest(view: ListViewModel, patch: Partial<ListViewUpda
         defaultView: view.defaultView,
         ...patch,
     };
+
+    return { ...row, filters: toStorableFilters(row.filters ?? [], catalogue) };
 }


### PR DESCRIPTION
Views are presented as a tab strip above the filter widget. Clicking a tab re-renders the table as that view: its columns, its filters and its ordering, applied together.

The first tab is **Standard**, the platform default column set the page ships with. It is deliberately not a stored row, which is what makes "always present and never removable" fall out of the model rather than needing a protected-row rule — there is nothing to delete, and nothing to hold a rename. `defaultView` on a stored view then means only "this tab opens on load"; when no view holds it, Standard opens.

No page is wired to the strip yet. That is the pilot, #2020.

## What lands

- **`ducks/listViews`** and its epics hold the views per resource. Every mutation is optimistic over a snapshot, so a failed create, rename or delete rolls the strip back. A failure goes to an alert rather than to `fetchError`: the strip is one widget on a page that lists rows of its own, and the tab the user just created has already disappeared again, so the failure has to be readable beside the strip that undid it. Every mutation of a resource shares one `concatMap` pipeline, because the rollback snapshot and the `isMutating` flag are single per resource — two writes in flight together, of any kinds, would let the second snapshot the first one's optimistic state. A list response is dated against those mutation boundaries, so a read that overlapped a write is never committed over it.
- **`utils/listViews`** carries the pure parts: the tab list, the visible-tab split that always keeps the active tab on the strip, duplicate naming, the stored shape of a slice, resolution of stored columns against the live catalogue, and whether the table has drifted from the view behind it. It is also where a filter that must not be stored is dropped — see below.
- **`components/ViewTabs`** renders the strip, the overflow menu, the "+" tab, the per-tab action menu and its reduced form on Standard, the unsaved-changes bar shared by sort and filter, the name and delete dialogs, and the notice for a stored column the catalogue no longer publishes.
- `ListViewApi` is instantiated in `api.ts`.

## Decisions worth stating

- **A tab switch applies filters and ordering as well as columns.** A tab named "Expiry watch" reads as a claim about which rows are shown and not only which headings, so restoring columns while leaving the caller's filter untouched would make the same tab mean different things depending on what was typed before it was clicked. The strip's `onApply` is where a page returns to page 1 and clears row selection.
- **A filter on secret content is never saved into a view.** A view is stored verbatim by Core and read back by every client that opens it, so a value typed against a field whose content is a secret would become a durable plaintext copy outside the storage that protects it. Such a filter is dropped from what a create or a full-row update carries, and, since the view cannot hold it, it does not read as drift either; the filter still applies to the table in front of the user. A presence-only condition on the same field survives, because it carries nothing to leak.
- **Drift is never autosaved.** Sorting or filtering marks the tab and offers Revert or Save to view. A view is the thing a user comes back to, and a stray click on a header should not quietly redefine it. Standard has nothing to save into, so there the offer is to keep the change as a new view.
- **On Standard the menu offers only Duplicate.** The other actions are absent rather than disabled, because they will never become available.
- **The strip renders nothing until the view list has settled and the catalogue read has settled.** An empty read is otherwise indistinguishable from one still in flight — the first optimistic create would then be read as the initial result — and with no catalogue every stored column resolves to nothing, so a tab applied then would show the platform columns under that view's name and stay there. It waits for the catalogue read to have settled rather than for it to have produced displayable fields, since a resource that publishes none is a resource Standard still opens on; a page that tracks its own fetch state says so through `isCatalogueLoaded`.
- **A column the table cannot show is never dropped behind the user's back.** Saving a drifted ordering or filter sends it back with the rest, because the table never showed it and the user was therefore never offered the choice. The column picker is the one place such a column is removed, because it is the one place it is shown.
- **A column the table cannot show is reported, not silently skipped.** `GET /v1/listViews` resolves the stored identifiers itself and omits what the resource catalogue no longer offers, so a deleted field never reaches the client: a view built entirely on deleted fields arrives with no columns at all, and falls back to the platform set rather than rendering an empty table. A column the *listing* cannot display does arrive intact, because the catalogue the API validates a view against carries no notion of `displayable` — those are named, and the notice opens the column dialog over them so they can be removed.
- **The action menu is a sibling of the tab button, not a child.** A menu trigger nested inside a tab is one interactive element inside another, which leaves both unreachable from the keyboard in the order they appear. Arrow keys wrap around the strip, and Home and End jump to its ends.

## Tests

`utils/listViews`, the duck and its epics are unit-tested. The strip itself has 32 Playwright component tests over a store built on the browser side, since only serializable props cross into it and a store created in the test body arrives with none of its preloaded state. `test-reducers` gains a `listViews` slice that records what the strip dispatched — as much of a mutation as a run with no epics can observe — and mirrors the create and delete round trips, so the optimistic tab, the uuid it is later given, and the tab a failed delete brings back are all asserted.

Writing them turned up one defect: the column dialog was seeded from the columns the table *renders*, so a stored column the listing cannot display was unreachable in the very dialog the notice about it sends the user to, and would have been dropped by the next save without ever being shown. It is now seeded from the resolved stored list, unavailable columns included — except when nothing resolved at all, where it opens on the platform set the table fell back to, so Save produces a usable view rather than an empty one.

Review then found the load-order, rollback and persistence defects listed above, each now covered by a test that fails without its fix: the initial-apply latch could not tell an empty read from one in flight; a failed create left the strip pointing at the optimistic row the rollback had removed; a list read that overlapped a write was committed over it; arrow-key navigation moved the selection without moving focus; a failed delete left the user on another view's rows; readiness was gated on displayable catalogue fields rather than on the read having settled; saving a drifted ordering dropped a stored column the listing cannot display; the three mutation epics were serialised only against writes of their own kind; a failed list read was silent; and a filter value on secret content was copied into the saved view.

Closes #2019

