### PR TITLE
Patch expat CVEs in the runtime base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,13 @@ RUN npm run build
 FROM nginxinc/nginx-unprivileged:1.31.4-alpine
 
 # Patch base-image OS packages for known CVEs (c-ares CVE-2026-33630;
-# curl/libcurl CVE-2026-5773, CVE-2026-6276; openssl CVE-2026-14456).
+# curl/libcurl CVE-2026-5773, CVE-2026-6276; openssl CVE-2026-14456;
+# expat CVE-2026-66046, CVE-2026-76641).
 # Pin the minimum fixed version so the build fails fast if the patched package
 # is ever unavailable, keeping the Trivy scan gate reliably green.
 USER root
 RUN apk add --no-cache --upgrade "c-ares>=1.34.8-r0" "curl>=8.20.0-r0" "libcrypto3>=3.5.8-r0" \
-    "libcurl>=8.20.0-r0" "libssl3>=3.5.8-r0"
+    "libcurl>=8.20.0-r0" "libexpat>=2.8.4-r0" "libssl3>=3.5.8-r0"
 USER 101
 
 WORKDIR /usr/share/nginx/html


### PR DESCRIPTION
The `nginxinc/nginx-unprivileged:1.31.4-alpine` runtime base image ships `libexpat` 2.8.3-r0, which Trivy reports as two HIGH vulnerabilities:

- `CVE-2026-66046` — denial of service in Expat through 2.8.3
- `CVE-2026-76641` — affects expat below 2.8.3-2

Both are fixed in `libexpat` 2.8.4-r0, which is available in the Alpine 3.24 main repository. This adds `libexpat>=2.8.4-r0` to the existing `apk add --upgrade` pin list in the runtime stage, following the same pattern already used for c-ares, curl/libcurl and openssl.

Verified locally by building the runtime stage and scanning it with Trivy 0.69.3 (`--severity HIGH,CRITICAL`): 2 HIGH findings without the pin, 0 findings with it.