### PR TITLE
Apply brand colours as semantic token overrides

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,27 @@
                 }
                 document.documentElement.classList.toggle('dark', resolved === 'dark');
                 document.documentElement.style.colorScheme = resolved;
+
+                // Apply the operator's brand colours in the same breath, for the same reason: the colours are
+                // server-held, so what is applied here is the override stylesheet cached by the last branding
+                // response. Without it the first paint of every load would show the platform palette and then swap.
+                // Unlike the theme above, the stylesheet is generated rather than resolved - utils/brand-tokens.ts
+                // owns the colour-to-token mapping and caches its output, so none of that mapping is duplicated here.
+                // On a first-ever visit there is no cache and the platform palette stands until the response lands.
+                try {
+                    var brandCss = localStorage.getItem('theme-brand-css');
+                    // The cache is written from colours already validated as #rrggbb, so this only guards against a
+                    // value that did not come from this application: no @, <, quote, slash or backslash means no
+                    // at-rule, comment, string or url() can be smuggled into the document through it.
+                    if (brandCss && brandCss.length <= 4096 && /^[a-z0-9\s#(),.%:;{}_-]+$/i.test(brandCss)) {
+                        var brandStyle = document.createElement('style');
+                        brandStyle.id = 'brand-tokens';
+                        brandStyle.textContent = brandCss;
+                        document.head.appendChild(brandStyle);
+                    }
+                } catch {
+                    // Storage unavailable; the platform palette stands until the branding response lands.
+                }
             })();
         </script>
         <script type="text/javascript" src="./config.js"></script>

--- a/src/components/BrandTokens/BrandTokens.spec.tsx
+++ b/src/components/BrandTokens/BrandTokens.spec.tsx
@@ -55,9 +55,14 @@ const OUT_OF_GAMUT: PublicBrandingFixture = {
     darkLogo: null,
 };
 
-/** The token/value pairs of one composition, read back out of the stylesheet the token layer actually emits. */
-const cssDeclarations = (css: string, selector: string): Record<string, string> => {
-    const block = new RegExp(`${selector.replace(/[.:()]/g, '\\$&')}\\{([^}]*)\\}`).exec(css)?.[1] ?? '';
+/**
+ * The token/value pairs of one composition, read back out of the stylesheet the token layer actually
+ * emits. Split on the literal opening of the block rather than matched with a regex built from it: a
+ * selector carries `.`, `:` and parentheses, so a regex would need escaping that has no reason to be
+ * written here.
+ */
+const cssDeclarations = (css: string, blockOpening: string): Record<string, string> => {
+    const block = css.split(blockOpening)[1]?.split('}')[0] ?? '';
     const values: Record<string, string> = {};
 
     for (const declaration of block.split(';')) {
@@ -190,8 +195,8 @@ test.describe('BrandTokens', () => {
             const colors = brandColors(fixture);
             const css = brandTokenCss(colors) ?? '';
             const compositions = [
-                { theme: 'light', declarations: cssDeclarations(css, 'html:not(.dark)') },
-                { theme: 'dark', declarations: cssDeclarations(css, 'html.dark') },
+                { theme: 'light', declarations: cssDeclarations(css, 'html:not(.dark){') },
+                { theme: 'dark', declarations: cssDeclarations(css, 'html.dark{') },
             ] as const;
 
             for (const { theme, declarations } of compositions) {

--- a/src/components/BrandTokens/BrandTokens.spec.tsx
+++ b/src/components/BrandTokens/BrandTokens.spec.tsx
@@ -1,6 +1,5 @@
 import { expect, test } from '../../../playwright/ct-test';
-import { BRAND_CSS_STORAGE_KEY, BRAND_TOKENS_STYLE_ID } from 'utils/brand-tokens';
-import { mixOklab } from 'utils/oklab';
+import { BRAND_CSS_STORAGE_KEY, BRAND_TOKENS_STYLE_ID, brandColors, brandTokenCss, brandTokenValues } from 'utils/brand-tokens';
 import BrandTokensWithStore, { type PublicBrandingFixture } from './BrandTokensWithStore';
 
 const BRANDED: PublicBrandingFixture = {
@@ -41,13 +40,36 @@ const PLATFORM = {
 const overrideStyle = 'style#brand-tokens';
 
 /**
- * `getComputedStyle` reports a `color-mix(in oklab, ...)` result in the Oklab space it was mixed in, so a token that
- * carries one cannot be compared against a hex string directly. Wrapping the expected hex in a no-op mix of the same
- * kind puts both sides in the same space, which is what makes the comparison meaningful.
+ * A saturated palette alongside an ordinary one, because the two exercise different arithmetic. The sRGB gamut is not
+ * convex in Oklab, so mixing a saturated input leaves the gamut: `#ff0033` at 60% towards white reaches a linear red
+ * of 1.10. Those are the cases where the JS mixer's per-channel clip could disagree with what the browser paints, so
+ * the parity test below must cover them and not only well-behaved inputs.
  */
-const asOklab = (hex: string) => `color-mix(in oklab, ${hex} 100%, ${hex})`;
+const OUT_OF_GAMUT: PublicBrandingFixture = {
+    configured: true,
+    primaryColor: '#ff0033',
+    secondaryColor: '#00ff00',
+    backgroundColor: '#ffff00',
+    textColor: '#8000ff',
+    lightLogo: null,
+    darkLogo: null,
+};
 
-const parseOklab = (value: string): number[] => /oklab\(([^)]*)\)/.exec(value)?.[1].split(/\s+/).map(Number) ?? [];
+/** The token/value pairs of one composition, read back out of the stylesheet the token layer actually emits. */
+const cssDeclarations = (css: string, selector: string): Record<string, string> => {
+    const block = new RegExp(`${selector.replace(/[.:()]/g, '\\$&')}\\{([^}]*)\\}`).exec(css)?.[1] ?? '';
+    const values: Record<string, string> = {};
+
+    for (const declaration of block.split(';')) {
+        const separator = declaration.indexOf(':');
+
+        if (separator > 0) {
+            values[declaration.slice(2, separator)] = declaration.slice(separator + 1);
+        }
+    }
+
+    return values;
+};
 
 test.describe('BrandTokens', () => {
     test('should leave the platform palette alone until a response lands', async ({ mount, page }) => {
@@ -146,52 +168,69 @@ test.describe('BrandTokens', () => {
         await expect(page.getByTestId('probe-brand')).toHaveCSS('background-color', 'rgb(163, 25, 91)');
     });
 
-    // The contrast warning evaluates the derived steps in JS, before the browser has painted anything. That is only a
-    // statement about what the operator will see if the JS mixer agrees with the CSS function it stands in for.
-    test('should derive the same colours in JS as color-mix does in the browser', async ({ mount, page }) => {
-        await mount(<BrandTokensWithStore probeTokens={PROBES} />);
+    /**
+     * The contrast warning evaluates the derived steps in JS, before the browser has painted anything. That is only a
+     * statement about what the operator will see if the JS mixer agrees with the CSS function it stands in for.
+     *
+     * Both sides are resolved to the sRGB the browser paints, not to Oklab coordinates. An out-of-gamut mix computes
+     * to unclipped Oklab, so comparing coordinates would report a divergence for a colour that renders identically;
+     * the painted byte is the thing the warning is actually a claim about. A canvas resolves a colour through the same
+     * parser and gamut handling as a painted background, which `oklab.ts` documents and this test relies on.
+     *
+     * The cases are generated from the stylesheet the token layer emits, so every rule in `BRAND_TOKEN_RULES` is
+     * covered in both compositions and a rule added without a matching JS derivation fails here.
+     */
+    for (const [palette, fixture] of [
+        ['an ordinary palette', BRANDED],
+        ['a palette whose mixes leave the sRGB gamut', OUT_OF_GAMUT],
+    ] as const) {
+        test(`should derive the same colours in JS as color-mix does in the browser, for ${palette}`, async ({ mount, page }) => {
+            await mount(<BrandTokensWithStore probeTokens={PROBES} />);
 
-        // Each row is one mix the token layer actually emits, paired with the JS result for the same mix.
-        const cases: ReadonlyArray<[string, string, number]> = [
-            ['#ffffff', '#000000', 0.5],
-            ['#a3195b', '#000000', 0.8],
-            ['#a3195b', '#ffffff', 0.1],
-            ['#faf5ff', '#000000', 0.87],
-            ['#2c1338', '#ffffff', 0.62],
-        ];
+            const colors = brandColors(fixture);
+            const css = brandTokenCss(colors) ?? '';
+            const compositions = [
+                { theme: 'light', declarations: cssDeclarations(css, 'html:not(.dark)') },
+                { theme: 'dark', declarations: cssDeclarations(css, 'html.dark') },
+            ] as const;
 
-        for (const [first, second, weight] of cases) {
-            const keyword = second === '#000000' ? 'black' : 'white';
-            const cssValue = `color-mix(in oklab, ${first} ${weight * 100}%, ${keyword})`;
+            for (const { theme, declarations } of compositions) {
+                const expected = brandTokenValues(colors, theme);
 
-            const [fromCss, fromJs] = await page.evaluate(
-                ([css, expected]) => {
-                    const probe = document.createElement('div');
+                // Every token the stylesheet declares must have a JS derivation, and no more.
+                expect(Object.keys(declarations).sort(), `${theme} tokens`).toStrictEqual(Object.keys(expected).sort());
+                expect(Object.keys(declarations).length).toBeGreaterThan(0);
 
-                    document.body.appendChild(probe);
-                    probe.style.backgroundColor = css;
-                    const browserMixed = getComputedStyle(probe).backgroundColor;
+                const cases = Object.entries(declarations).map(([token, value]) => [token, value, expected[token]] as const);
+                const mismatched = await page.evaluate((cases) => {
+                    const canvas = document.createElement('canvas');
+                    const context = canvas.getContext('2d', { willReadFrequently: true });
 
-                    probe.style.backgroundColor = expected;
-                    const jsMixed = getComputedStyle(probe).backgroundColor;
+                    if (!context) {
+                        return [{ token: 'canvas', cssPainted: 'unavailable', jsPainted: 'unavailable' }];
+                    }
 
-                    probe.remove();
-                    return [browserMixed, jsMixed];
-                },
-                [cssValue, asOklab(mixOklab(first, second, weight))],
-            );
+                    // Reset to a known colour first, so a value the parser rejects outright shows up as black rather
+                    // than silently inheriting whatever the previous case painted.
+                    const painted = (value: string) => {
+                        context.fillStyle = '#000000';
+                        context.fillStyle = value;
+                        context.fillRect(0, 0, 1, 1);
 
-            const browser = parseOklab(fromCss);
-            const js = parseOklab(fromJs);
+                        const [red, green, blue] = context.getImageData(0, 0, 1, 1).data;
 
-            expect(browser, `${cssValue} did not resolve in the Oklab space`).toHaveLength(3);
-            expect(js).toHaveLength(3);
-            for (const [index, coordinate] of browser.entries()) {
-                // 8-bit quantisation of the JS result is the only difference that may remain.
-                expect(Math.abs(coordinate - js[index]), `${cssValue} coordinate ${index}`).toBeLessThan(0.005);
+                        return `#${[red, green, blue].map((channel) => channel.toString(16).padStart(2, '0')).join('')}`;
+                    };
+
+                    return cases
+                        .map(([token, cssValue, jsValue]) => ({ token, cssPainted: painted(cssValue), jsPainted: painted(jsValue) }))
+                        .filter((result) => result.cssPainted !== result.jsPainted);
+                }, cases);
+
+                expect(mismatched, `${theme} composition of ${palette}`).toStrictEqual([]);
             }
-        }
-    });
+        });
+    }
 
     test('should expose the style element under a stable id', async ({ mount, page }) => {
         await mount(<BrandTokensWithStore probeTokens={PROBES} preloadedBranding={BRANDED} />);

--- a/src/components/BrandTokens/BrandTokens.spec.tsx
+++ b/src/components/BrandTokens/BrandTokens.spec.tsx
@@ -202,7 +202,6 @@ test.describe('BrandTokens', () => {
             for (const { theme, declarations } of compositions) {
                 const expected = brandTokenValues(colors, theme);
 
-                // Every token the stylesheet declares must have a JS derivation, and no more.
                 expect(Object.keys(declarations).sort(), `${theme} tokens`).toStrictEqual(Object.keys(expected).sort());
                 expect(Object.keys(declarations).length).toBeGreaterThan(0);
 

--- a/src/components/BrandTokens/BrandTokens.spec.tsx
+++ b/src/components/BrandTokens/BrandTokens.spec.tsx
@@ -1,0 +1,201 @@
+import { expect, test } from '../../../playwright/ct-test';
+import { BRAND_CSS_STORAGE_KEY, BRAND_TOKENS_STYLE_ID } from 'utils/brand-tokens';
+import { mixOklab } from 'utils/oklab';
+import BrandTokensWithStore, { type PublicBrandingFixture } from './BrandTokensWithStore';
+
+const BRANDED: PublicBrandingFixture = {
+    configured: true,
+    primaryColor: '#a3195b',
+    secondaryColor: '#0369a1',
+    backgroundColor: '#faf5ff',
+    textColor: '#2c1338',
+    lightLogo: null,
+    darkLogo: null,
+};
+
+const UNBRANDED: PublicBrandingFixture = {
+    configured: false,
+    primaryColor: null,
+    secondaryColor: null,
+    backgroundColor: null,
+    textColor: null,
+    lightLogo: null,
+    darkLogo: null,
+};
+
+/** Every token a probe is rendered for, across all the tests below. */
+const PROBES = ['brand', 'brand-solid', 'surface', 'surface-raised', 'content', 'danger', 'divider', 'outline'] as const;
+
+/** Platform values, so a test can assert a token was left alone rather than only that it changed. */
+const PLATFORM = {
+    light: {
+        surface: 'rgb(248, 250, 252)',
+        content: 'rgb(31, 41, 55)',
+        danger: 'rgb(185, 28, 28)',
+        divider: 'rgb(232, 232, 232)',
+        outline: 'rgb(143, 143, 143)',
+    },
+    dark: { surface: 'rgb(10, 10, 10)', content: 'rgb(245, 245, 245)' },
+} as const;
+
+const overrideStyle = 'style#brand-tokens';
+
+/**
+ * `getComputedStyle` reports a `color-mix(in oklab, ...)` result in the Oklab space it was mixed in, so a token that
+ * carries one cannot be compared against a hex string directly. Wrapping the expected hex in a no-op mix of the same
+ * kind puts both sides in the same space, which is what makes the comparison meaningful.
+ */
+const asOklab = (hex: string) => `color-mix(in oklab, ${hex} 100%, ${hex})`;
+
+const parseOklab = (value: string): number[] => /oklab\(([^)]*)\)/.exec(value)?.[1].split(/\s+/).map(Number) ?? [];
+
+test.describe('BrandTokens', () => {
+    test('should leave the platform palette alone until a response lands', async ({ mount, page }) => {
+        await mount(<BrandTokensWithStore probeTokens={PROBES} />);
+
+        await expect(page.locator(overrideStyle)).toHaveCount(0);
+        await expect(page.getByTestId('probe-surface')).toHaveCSS('background-color', PLATFORM.light.surface);
+        await expect(page.getByTestId('probe-content')).toHaveCSS('background-color', PLATFORM.light.content);
+    });
+
+    test('should apply the brand colours once the response lands', async ({ mount, page }) => {
+        await mount(<BrandTokensWithStore probeTokens={PROBES} responseBranding={BRANDED} />);
+
+        await page.getByTestId('respond').click();
+
+        await expect(page.locator(overrideStyle)).toHaveCount(1);
+        await expect(page.getByTestId('probe-brand')).toHaveCSS('background-color', 'rgb(163, 25, 91)');
+        await expect(page.getByTestId('probe-surface')).toHaveCSS('background-color', 'rgb(250, 245, 255)');
+        await expect(page.getByTestId('probe-content')).toHaveCSS('background-color', 'rgb(44, 19, 56)');
+    });
+
+    test('should apply branding that was already read before it mounted', async ({ mount, page }) => {
+        await mount(<BrandTokensWithStore probeTokens={PROBES} preloadedBranding={BRANDED} />);
+
+        await expect(page.getByTestId('probe-brand')).toHaveCSS('background-color', 'rgb(163, 25, 91)');
+    });
+
+    test('should never override the status, divider or outline tokens', async ({ mount, page }) => {
+        await mount(<BrandTokensWithStore probeTokens={PROBES} preloadedBranding={BRANDED} />);
+
+        await expect(page.getByTestId('probe-danger')).toHaveCSS('background-color', PLATFORM.light.danger);
+        await expect(page.getByTestId('probe-divider')).toHaveCSS('background-color', PLATFORM.light.divider);
+        await expect(page.getByTestId('probe-outline')).toHaveCSS('background-color', PLATFORM.light.outline);
+    });
+
+    test('should withdraw Background and Text in the dark composition and keep Primary', async ({ mount, page }) => {
+        await mount(<BrandTokensWithStore probeTokens={PROBES} preloadedBranding={BRANDED} />);
+
+        await page.getByTestId('toggle-dark').click();
+
+        await expect(page.getByTestId('probe-surface')).toHaveCSS('background-color', PLATFORM.dark.surface);
+        await expect(page.getByTestId('probe-content')).toHaveCSS('background-color', PLATFORM.dark.content);
+        // Primary reaches both compositions, and the fill is the theme-invariant one.
+        await expect(page.getByTestId('probe-brand-solid')).toHaveCSS('background-color', 'rgb(163, 25, 91)');
+    });
+
+    test('should keep applying the brand colours across a theme switch', async ({ mount, page }) => {
+        await mount(<BrandTokensWithStore probeTokens={PROBES} preloadedBranding={BRANDED} />);
+
+        await page.getByTestId('toggle-dark').click();
+        await page.getByTestId('toggle-dark').click();
+
+        await expect(page.getByTestId('probe-surface')).toHaveCSS('background-color', 'rgb(250, 245, 255)');
+        await expect(page.getByTestId('probe-brand')).toHaveCSS('background-color', 'rgb(163, 25, 91)');
+    });
+
+    test('should apply only the families whose colour is set', async ({ mount, page }) => {
+        await mount(
+            <BrandTokensWithStore probeTokens={PROBES} preloadedBranding={{ ...UNBRANDED, configured: true, primaryColor: '#a3195b' }} />,
+        );
+
+        await expect(page.getByTestId('probe-brand')).toHaveCSS('background-color', 'rgb(163, 25, 91)');
+        await expect(page.getByTestId('probe-surface')).toHaveCSS('background-color', PLATFORM.light.surface);
+    });
+
+    test('should cache the override stylesheet for the next first paint', async ({ mount, page }) => {
+        await mount(<BrandTokensWithStore probeTokens={PROBES} responseBranding={BRANDED} />);
+
+        await page.getByTestId('respond').click();
+        await expect(page.locator(overrideStyle)).toHaveCount(1);
+
+        const cached = await page.evaluate((key) => localStorage.getItem(key), BRAND_CSS_STORAGE_KEY);
+
+        expect(cached).toContain('html:not(.dark){');
+        expect(cached).toContain('--brand:#a3195b;');
+    });
+
+    test('should return to the platform palette when a live response reports no branding', async ({ mount, page }) => {
+        await mount(<BrandTokensWithStore probeTokens={PROBES} preloadedBranding={BRANDED} responseBranding={UNBRANDED} />);
+
+        await expect(page.locator(overrideStyle)).toHaveCount(1);
+        await page.getByTestId('respond').click();
+
+        await expect(page.locator(overrideStyle)).toHaveCount(0);
+        await expect(page.getByTestId('probe-surface')).toHaveCSS('background-color', PLATFORM.light.surface);
+        expect(await page.evaluate((key) => localStorage.getItem(key), BRAND_CSS_STORAGE_KEY)).toBeNull();
+    });
+
+    test('should keep the applied colours when the read fails', async ({ mount, page }) => {
+        await mount(<BrandTokensWithStore probeTokens={PROBES} preloadedBranding={BRANDED} />);
+
+        await expect(page.locator(overrideStyle)).toHaveCount(1);
+        await page.getByTestId('fail').click();
+
+        await expect(page.locator(overrideStyle)).toHaveCount(1);
+        await expect(page.getByTestId('probe-brand')).toHaveCSS('background-color', 'rgb(163, 25, 91)');
+    });
+
+    // The contrast warning evaluates the derived steps in JS, before the browser has painted anything. That is only a
+    // statement about what the operator will see if the JS mixer agrees with the CSS function it stands in for.
+    test('should derive the same colours in JS as color-mix does in the browser', async ({ mount, page }) => {
+        await mount(<BrandTokensWithStore probeTokens={PROBES} />);
+
+        // Each row is one mix the token layer actually emits, paired with the JS result for the same mix.
+        const cases: ReadonlyArray<[string, string, number]> = [
+            ['#ffffff', '#000000', 0.5],
+            ['#a3195b', '#000000', 0.8],
+            ['#a3195b', '#ffffff', 0.1],
+            ['#faf5ff', '#000000', 0.87],
+            ['#2c1338', '#ffffff', 0.62],
+        ];
+
+        for (const [first, second, weight] of cases) {
+            const keyword = second === '#000000' ? 'black' : 'white';
+            const cssValue = `color-mix(in oklab, ${first} ${weight * 100}%, ${keyword})`;
+
+            const [fromCss, fromJs] = await page.evaluate(
+                ([css, expected]) => {
+                    const probe = document.createElement('div');
+
+                    document.body.appendChild(probe);
+                    probe.style.backgroundColor = css;
+                    const browserMixed = getComputedStyle(probe).backgroundColor;
+
+                    probe.style.backgroundColor = expected;
+                    const jsMixed = getComputedStyle(probe).backgroundColor;
+
+                    probe.remove();
+                    return [browserMixed, jsMixed];
+                },
+                [cssValue, asOklab(mixOklab(first, second, weight))],
+            );
+
+            const browser = parseOklab(fromCss);
+            const js = parseOklab(fromJs);
+
+            expect(browser, `${cssValue} did not resolve in the Oklab space`).toHaveLength(3);
+            expect(js).toHaveLength(3);
+            for (const [index, coordinate] of browser.entries()) {
+                // 8-bit quantisation of the JS result is the only difference that may remain.
+                expect(Math.abs(coordinate - js[index]), `${cssValue} coordinate ${index}`).toBeLessThan(0.005);
+            }
+        }
+    });
+
+    test('should expose the style element under a stable id', async ({ mount, page }) => {
+        await mount(<BrandTokensWithStore probeTokens={PROBES} preloadedBranding={BRANDED} />);
+
+        await expect(page.locator(`style#${BRAND_TOKENS_STYLE_ID}`)).toHaveCount(1);
+    });
+});

--- a/src/components/BrandTokens/BrandTokensWithStore.tsx
+++ b/src/components/BrandTokens/BrandTokensWithStore.tsx
@@ -1,0 +1,82 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { useMemo } from 'react';
+import { Provider, useDispatch } from 'react-redux';
+
+import { testInitialState, testReducers } from 'ducks/test-reducers';
+
+import BrandTokens from './index';
+
+/** The anonymous branding response, as JSON a Playwright test can hand across the Node/browser boundary. */
+export type PublicBrandingFixture = Record<string, string | null | boolean>;
+
+export type BrandTokensWithStoreProps = Readonly<{
+    /** The branding the anonymous read has already returned, when a test starts from a settled response. */
+    preloadedBranding?: PublicBrandingFixture;
+    /** The branding the `respond` control delivers, so one mount can cover the move from one answer to the next. */
+    responseBranding?: PublicBrandingFixture;
+    /** Tokens to render a probe for, so a test can read what the browser resolves each one to. */
+    probeTokens?: readonly string[];
+}>;
+
+/**
+ * Playwright CT cannot carry a live Redux store across the Node/browser boundary, so the store is built inside the
+ * mounted component. BrandTokens renders nothing, so the probes below are what makes its effect observable: each one
+ * paints a token, and the test reads the colour the browser resolved - including the `color-mix()` steps, which is the
+ * only place they can be checked against what the contrast warning computes for them.
+ */
+export function BrandTokensWithStore({ preloadedBranding, responseBranding, probeTokens = [] }: BrandTokensWithStoreProps) {
+    const store = useMemo(
+        () =>
+            configureStore({
+                reducer: testReducers,
+                middleware: (getDefaultMiddleware) => getDefaultMiddleware({ serializableCheck: false }),
+                preloadedState: {
+                    ...testInitialState,
+                    branding: {
+                        ...testInitialState.branding,
+                        publicBranding: preloadedBranding,
+                        publicBrandingReadFailed: false,
+                    },
+                },
+            }),
+        [preloadedBranding],
+    );
+
+    return (
+        <Provider store={store}>
+            <BrandTokens />
+            <Controls responseBranding={responseBranding} />
+            <button type="button" data-testid="toggle-dark" onClick={() => document.documentElement.classList.toggle('dark')}>
+                Toggle dark
+            </button>
+            {probeTokens.map((token) => (
+                <div key={token} data-testid={`probe-${token}`} style={{ backgroundColor: `var(--${token})` }} />
+            ))}
+        </Provider>
+    );
+}
+
+function Controls({ responseBranding }: Readonly<{ responseBranding?: PublicBrandingFixture }>) {
+    const dispatch = useDispatch();
+
+    return (
+        <>
+            <button
+                type="button"
+                data-testid="respond"
+                onClick={() => dispatch({ type: 'branding/getPublicBrandingSuccess', payload: { branding: responseBranding } })}
+            >
+                Respond
+            </button>
+            <button
+                type="button"
+                data-testid="fail"
+                onClick={() => dispatch({ type: 'branding/getPublicBrandingFailure', payload: { error: 'Failed to get branding' } })}
+            >
+                Fail
+            </button>
+        </>
+    );
+}
+
+export default BrandTokensWithStore;

--- a/src/components/BrandTokens/index.tsx
+++ b/src/components/BrandTokens/index.tsx
@@ -1,0 +1,44 @@
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { selectors } from 'ducks/branding';
+import { applyBrandTokens, brandColors, brandTokenCss, storeBrandCss } from 'utils/brand-tokens';
+
+/**
+ * Applies the operator's brand colours as an override over the semantic colour tokens, and caches the result for the
+ * next load's first paint.
+ *
+ * Renders nothing: branding reaches components through the token layer, so no component has to know the instance is
+ * branded. The read is the anonymous one - the same response the theme is resolved from - and is issued by
+ * `ConnectedThemeProvider`, which mounts this, rather than here as well.
+ *
+ * The two cases that must *not* clear what is applied are the reason this is not simply a call in a render:
+ *
+ * - before the first response, `publicBranding` is undefined, and the pre-paint script has already applied the cached
+ *   stylesheet. Clearing it here would flash the platform palette on every load, which is the one thing the cache
+ *   exists to prevent;
+ * - a failed read settles the slice on the platform default so the login page can still render. Treating that as a
+ *   live "not branded" answer would drop the operator's colours - and the cache with them - on a transient network
+ *   error, so the previous load's colours are left in place instead.
+ */
+function BrandTokens() {
+    const branding = useSelector(selectors.publicBranding);
+    const readFailed = useSelector(selectors.publicBrandingReadFailed);
+
+    const live = readFailed ? undefined : branding;
+    const css = live ? brandTokenCss(brandColors(live)) : undefined;
+
+    useEffect(() => {
+        if (!live) {
+            return;
+        }
+
+        // A live response with no colours in it is an instance that is genuinely unbranded, so the stylesheet is
+        // removed and the cache cleared: that is how unbranding an instance takes effect for a returning user.
+        applyBrandTokens(css);
+        storeBrandCss(css);
+    }, [live, css]);
+
+    return null;
+}
+
+export default BrandTokens;

--- a/src/components/ThemeProvider/ConnectedThemeProvider.tsx
+++ b/src/components/ThemeProvider/ConnectedThemeProvider.tsx
@@ -1,6 +1,7 @@
 import { useEffect, type ReactNode } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { actions, selectors } from 'ducks/branding';
+import BrandTokens from 'components/BrandTokens';
 import ThemeProvider from './index';
 
 type Props = {
@@ -8,9 +9,14 @@ type Props = {
 };
 
 /**
- * Feeds the operator's branding into {@link ThemeProvider}. The read is the anonymous one, because the theme has to be
- * resolved on the login page too, before there is any session. ThemeProvider itself stays store-free so that a
- * component test can mount it on its own.
+ * Feeds the operator's branding into {@link ThemeProvider} and mounts {@link BrandTokens} on the same response. The
+ * read is the anonymous one, because the theme has to be resolved on the login page too, before there is any session,
+ * and it is issued here so that the one response serves both consumers. ThemeProvider itself stays store-free so that
+ * a component test can mount it on its own.
+ *
+ * The two consumers are deliberately separate. Which theme to render and whose palette to render it in are
+ * independent: the palette lives in the token layer BrandTokens writes, so the theme runtime never has to know
+ * whether the instance is branded.
  */
 function ConnectedThemeProvider({ children }: Readonly<Props>) {
     const dispatch = useDispatch();
@@ -25,7 +31,12 @@ function ConnectedThemeProvider({ children }: Readonly<Props>) {
     // ThemeProvider would look like a live "not branded" answer and clear the cached operator default, so a returning
     // user on a branded instance would lose the operator's theme to a transient network error. Withholding it instead
     // leaves the cache intact.
-    return <ThemeProvider branding={readFailed ? undefined : branding}>{children}</ThemeProvider>;
+    return (
+        <ThemeProvider branding={readFailed ? undefined : branding}>
+            <BrandTokens />
+            {children}
+        </ThemeProvider>
+    );
 }
 
 export default ConnectedThemeProvider;

--- a/src/ducks/branding-epics.spec.ts
+++ b/src/ducks/branding-epics.spec.ts
@@ -137,11 +137,24 @@ describe('branding epics', () => {
             getBrandingSettings: () => of(stored),
         });
 
-        const emitted = await run(epics[WRITE_BRANDING], slice.actions.updateBranding({ branding }), deps, 2);
+        const emitted = await run(epics[WRITE_BRANDING], slice.actions.updateBranding({ branding }), deps, 3);
 
         expect(sent).toEqual([branding]);
         expect(emitted[0]).toEqual(slice.actions.updateBrandingSuccess({ branding: stored }));
-        expect(emitted[1].type).toBe(alertActions.success.type);
+        expect(emitted[1]).toEqual(slice.actions.getPublicBranding());
+        expect(emitted[2].type).toBe(alertActions.success.type);
+    });
+
+    /**
+     * The token layer and the theme both resolve from the anonymous response, so a committed save that does not
+     * refresh it leaves the page it was made on rendering the previous palette until the next full reload.
+     */
+    test('updateBranding refreshes the anonymous read so the committed palette is applied', async () => {
+        const deps = createDeps();
+
+        const emitted = await run(epics[WRITE_BRANDING], slice.actions.updateBranding({ branding: {} }), deps, 3);
+
+        expect(emitted.map((action: { type: string }) => action.type)).toContain(slice.actions.getPublicBranding.type);
     });
 
     test('updateBranding failure reports the error and redirects', async () => {
@@ -196,11 +209,21 @@ describe('branding epics', () => {
             },
         });
 
-        const emitted = await run(epics[WRITE_BRANDING], slice.actions.resetBranding(), deps, 2);
+        const emitted = await run(epics[WRITE_BRANDING], slice.actions.resetBranding(), deps, 3);
 
         expect(sent).toEqual([{}]);
         expect(emitted[0]).toEqual(slice.actions.resetBrandingSuccess());
-        expect(emitted[1].type).toBe(alertActions.success.type);
+        expect(emitted[1]).toEqual(slice.actions.getPublicBranding());
+        expect(emitted[2].type).toBe(alertActions.success.type);
+    });
+
+    /** Unbranding has to take effect on the page it was requested from, for the same reason a save does. */
+    test('resetBranding refreshes the anonymous read so the platform palette is restored', async () => {
+        const deps = createDeps();
+
+        const emitted = await run(epics[WRITE_BRANDING], slice.actions.resetBranding(), deps, 3);
+
+        expect(emitted.map((action: { type: string }) => action.type)).toContain(slice.actions.getPublicBranding.type);
     });
 
     test('resetBranding failure reports the error and redirects', async () => {
@@ -227,12 +250,14 @@ describe('branding epics', () => {
             of({}),
             deps,
         );
-        const emitted = await firstValueFrom(output$.pipe(take(4), toArray()));
+        const emitted = await firstValueFrom(output$.pipe(take(6), toArray()));
 
         expect(emitted.map((action: { type: string }) => action.type)).toEqual([
             slice.actions.updateBrandingSuccess.type,
+            slice.actions.getPublicBranding.type,
             alertActions.success.type,
             slice.actions.resetBrandingSuccess.type,
+            slice.actions.getPublicBranding.type,
             alertActions.success.type,
         ]);
     });

--- a/src/ducks/branding-epics.ts
+++ b/src/ducks/branding-epics.ts
@@ -61,8 +61,16 @@ const runUpdate = (deps: EpicDependencies, branding: BrandingSettingsUpdateModel
         // instead of echoing the request, which would leave the store holding markup Core deliberately removed.
         mergeMap(() =>
             deps.apiClients.settings.getBrandingSettings().pipe(
+                // The anonymous read is refreshed alongside the authenticated one, because it is the anonymous
+                // response that the token layer and the theme resolve from. Without it a committed save would not
+                // reach the page it was made on: the palette and the operator default would stay as they were until
+                // the next full reload.
                 mergeMap((stored) =>
-                    of(slice.actions.updateBrandingSuccess({ branding: stored }), alertActions.success('Branding updated successfully.')),
+                    of(
+                        slice.actions.updateBrandingSuccess({ branding: stored }),
+                        slice.actions.getPublicBranding(),
+                        alertActions.success('Branding updated successfully.'),
+                    ),
                 ),
                 // Reporting this as a failed save would invite a retry that changes nothing, because the write landed.
                 // The slice is what is wrong — it still holds the pre-write branding — so a fresh read repairs it.
@@ -87,7 +95,10 @@ const runReset = (deps: EpicDependencies): Observable<UnknownAction> =>
     // An empty update clears every field, which is what makes reset one request rather than one per field. Nothing is
     // left stored afterwards, so there is no read-back: the reducer settles on an empty branding.
     deps.apiClients.settings.updateBrandingSettings({ brandingSettingsUpdateDto: {} }).pipe(
-        mergeMap(() => of(slice.actions.resetBrandingSuccess(), alertActions.success('Branding reset to default.'))),
+        // Refreshed for the same reason as a save: unbranding has to take effect on the page it was requested from.
+        mergeMap(() =>
+            of(slice.actions.resetBrandingSuccess(), slice.actions.getPublicBranding(), alertActions.success('Branding reset to default.')),
+        ),
         catchError((err) =>
             of(
                 slice.actions.resetBrandingFailure({ error: extractError(err, 'Failed to reset branding') }),

--- a/src/ducks/test-reducers.ts
+++ b/src/ducks/test-reducers.ts
@@ -269,9 +269,14 @@ function authTestReducer(state: AuthTestState | undefined, _action: UnknownActio
 
 export type BrandingTestState = {
     branding?: Record<string, string | undefined>;
+    /** The anonymous read, as the login page and the brand token layer see it. Nullable, as the response is. */
+    publicBranding?: Record<string, string | null | undefined | boolean>;
+    /** Whether that read failed. A failure settles publicBranding on the platform default, which looks identical. */
+    publicBrandingReadFailed?: boolean;
     /** What a save or a reset put on the wire. Kept apart from `branding` so a preloaded value is not mistaken for it. */
     sentBranding?: Record<string, string | undefined>;
     isFetchingBranding: boolean;
+    isFetchingPublicBranding?: boolean;
     isUpdatingBranding: boolean;
     isResettingBranding: boolean;
     updateSucceeded: boolean;
@@ -298,6 +303,16 @@ function brandingTestReducer(state: BrandingTestState = brandingTestInitialState
             return { ...state, sentBranding: a.payload?.branding, isUpdatingBranding: false, updateSucceeded: true };
         case 'branding/resetBranding':
             return { ...state, sentBranding: {}, branding: {}, isResettingBranding: false, resetSucceeded: true };
+        // The anonymous read has no epic here, so a test drives it by dispatching the success action directly, which
+        // is what lets one mount cover both "no branding yet" and the response that follows.
+        case 'branding/getPublicBrandingSuccess':
+            return {
+                ...state,
+                publicBranding: (action as { payload?: { branding?: BrandingTestState['publicBranding'] } }).payload?.branding,
+                publicBrandingReadFailed: false,
+            };
+        case 'branding/getPublicBrandingFailure':
+            return { ...state, publicBrandingReadFailed: true };
         default:
             return state;
     }

--- a/src/utils/brand-tokens.spec.ts
+++ b/src/utils/brand-tokens.spec.ts
@@ -1,0 +1,275 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { afterEach, describe, expect, test } from 'vitest';
+import {
+    applyBrandTokens,
+    BRAND_CSS_STORAGE_KEY,
+    BRAND_TOKEN_RULES,
+    BRAND_TOKENS_STYLE_ID,
+    brandColors,
+    brandTokenCss,
+    brandTokenValues,
+    storeBrandCss,
+} from './brand-tokens';
+import { readSemanticTokens } from './theme-tokens';
+
+const ALL_COLORS = {
+    primaryColor: '#0073cf',
+    secondaryColor: '#0369a1',
+    backgroundColor: '#f8fafc',
+    textColor: '#1f2937',
+};
+
+/** The families the Epic settled on, so a token quietly joining or leaving one is a test failure. */
+const EXPECTED_FAMILIES = {
+    primary: ['brand', 'brand-solid', 'brand-solid-hover', 'brand-hover', 'brand-subtle', 'surface-header'],
+    secondary: ['info', 'info-surface', 'info-solid'],
+    background: ['surface', 'surface-raised', 'surface-sunken', 'surface-hover', 'surface-active'],
+    text: ['content', 'content-muted', 'content-subtle'],
+} as const;
+
+/** Tokens branding must never touch, either because they carry a fixed meaning or because they are the fixed side of a
+ * contrast pairing. */
+const NEVER_OVERRIDDEN = [
+    'success',
+    'success-surface',
+    'success-solid',
+    'danger',
+    'danger-surface',
+    'danger-solid',
+    'danger-fill',
+    'danger-fill-hover',
+    'warning',
+    'warning-surface',
+    'warning-solid',
+    'warning-fill',
+    'warning-fill-hover',
+    'divider',
+    'outline',
+    'code-color',
+    'content-inverse',
+    'content-on-brand',
+    'surface-inverse',
+];
+
+describe('brand-tokens', () => {
+    describe('brandColors', () => {
+        test('should read every colour the operator has set', () => {
+            expect(brandColors(ALL_COLORS)).toStrictEqual({
+                primary: '#0073cf',
+                secondary: '#0369a1',
+                background: '#f8fafc',
+                text: '#1f2937',
+            });
+        });
+
+        test('should lower-case the hex so derived and raw values compare equal', () => {
+            expect(brandColors({ primaryColor: '#0073CF' }).primary).toBe('#0073cf');
+        });
+
+        test('should drop a colour the anonymous response reports as null', () => {
+            expect(brandColors({ ...ALL_COLORS, textColor: null })).not.toHaveProperty('text');
+        });
+
+        test('should drop a colour that is not a six-digit hex', () => {
+            expect(brandColors({ primaryColor: 'red', secondaryColor: '#abc' })).toStrictEqual({});
+        });
+
+        test('should return nothing for an unbranded instance', () => {
+            expect(brandColors({})).toStrictEqual({});
+        });
+    });
+
+    describe('BRAND_TOKEN_RULES', () => {
+        test.each(Object.entries(EXPECTED_FAMILIES))('should map %s onto exactly its own family', (source, tokens) => {
+            const mapped = BRAND_TOKEN_RULES.filter((rule) => (rule.light ?? rule.dark)?.source === source).map((rule) => rule.token);
+
+            expect(mapped).toStrictEqual([...tokens]);
+        });
+
+        test('should apply Background and Text to the light composition only', () => {
+            const lightOnly = BRAND_TOKEN_RULES.filter((rule) => rule.dark === undefined).map((rule) => rule.token);
+
+            expect(lightOnly).toStrictEqual([...EXPECTED_FAMILIES.background, ...EXPECTED_FAMILIES.text]);
+        });
+
+        test('should apply Primary and Secondary to both compositions', () => {
+            const both = BRAND_TOKEN_RULES.filter((rule) => rule.light !== undefined && rule.dark !== undefined).map((rule) => rule.token);
+
+            expect(both).toStrictEqual([...EXPECTED_FAMILIES.primary, ...EXPECTED_FAMILIES.secondary]);
+        });
+
+        test.each(NEVER_OVERRIDDEN)('should never override %s', (token) => {
+            expect(BRAND_TOKEN_RULES.map((rule) => rule.token)).not.toContain(token);
+        });
+
+        test('should never override a node status token', () => {
+            expect(BRAND_TOKEN_RULES.filter((rule) => rule.token.startsWith('node-'))).toStrictEqual([]);
+        });
+
+        test('should name only tokens the stylesheet actually declares', () => {
+            const css = readFileSync(path.resolve(__dirname, '../tailwindcss.css'), 'utf8');
+            const tokens = readSemanticTokens(css);
+
+            for (const rule of BRAND_TOKEN_RULES) {
+                expect(tokens.light, `--${rule.token} is not declared in the light token block`).toHaveProperty(rule.token);
+            }
+        });
+    });
+
+    describe('brandTokenCss', () => {
+        test('should emit one block per composition, each outranking the base stylesheet', () => {
+            const css = brandTokenCss(brandColors(ALL_COLORS)) ?? '';
+
+            expect(css).toContain('html:not(.dark){');
+            expect(css).toContain('html.dark{');
+        });
+
+        test('should write the tier-2 custom properties', () => {
+            expect(brandTokenCss(brandColors(ALL_COLORS))).toContain('--brand:#0073cf;');
+        });
+
+        test('should never write a --color-* name, which @theme inline does not emit into :root', () => {
+            expect(brandTokenCss(brandColors(ALL_COLORS))).not.toContain('--color-');
+        });
+
+        test('should derive intermediate steps with color-mix rather than hardcoding them', () => {
+            expect(brandTokenCss(brandColors(ALL_COLORS))).toContain('--brand-solid-hover:color-mix(in oklab, #0073cf 80%, black);');
+        });
+
+        test('should keep the dark composition free of the light-only families', () => {
+            const dark = (brandTokenCss(brandColors(ALL_COLORS)) ?? '').split('html.dark{')[1];
+
+            for (const token of [...EXPECTED_FAMILIES.background, ...EXPECTED_FAMILIES.text]) {
+                expect(dark).not.toContain(`--${token}:`);
+            }
+        });
+
+        test('should emit only the families whose input is set', () => {
+            const css = brandTokenCss(brandColors({ primaryColor: '#0073cf' })) ?? '';
+
+            expect(css).toContain('--brand:#0073cf;');
+            expect(css).not.toContain('--surface:');
+            expect(css).not.toContain('--info:');
+        });
+
+        test('should emit no light block when only a light-only family is unset', () => {
+            const css = brandTokenCss(brandColors({ backgroundColor: '#f8fafc' })) ?? '';
+
+            expect(css).toContain('html:not(.dark){');
+            expect(css).not.toContain('html.dark{');
+        });
+
+        test('should return nothing for an unbranded instance, so its rendering is unchanged', () => {
+            expect(brandTokenCss({})).toBeUndefined();
+        });
+
+        test('should contain nothing the pre-paint guard in index.html would reject', () => {
+            expect(brandTokenCss(brandColors(ALL_COLORS))).toMatch(/^[a-z0-9\s#(),.%:;{}_-]+$/i);
+        });
+    });
+
+    describe('brandTokenValues', () => {
+        test('should resolve the light composition to hex', () => {
+            expect(brandTokenValues(brandColors(ALL_COLORS), 'light')).toMatchObject({
+                brand: '#0073cf',
+                'brand-solid-hover': '#005499',
+                surface: '#f8fafc',
+                content: '#1f2937',
+            });
+        });
+
+        test('should resolve the dark composition without the light-only families', () => {
+            const dark = brandTokenValues(brandColors(ALL_COLORS), 'dark');
+
+            expect(dark).toHaveProperty('brand');
+            expect(dark).not.toHaveProperty('surface');
+            expect(dark).not.toHaveProperty('content');
+        });
+
+        test('should keep the brand fill theme-invariant, since on-brand white is measured against it', () => {
+            const colors = brandColors(ALL_COLORS);
+
+            expect(brandTokenValues(colors, 'dark')['brand-solid']).toBe(brandTokenValues(colors, 'light')['brand-solid']);
+        });
+
+        test('should lighten the brand foreground in the dark composition', () => {
+            const colors = brandColors(ALL_COLORS);
+
+            expect(brandTokenValues(colors, 'dark').brand).not.toBe(brandTokenValues(colors, 'light').brand);
+        });
+
+        test('should resolve to the same steps the stylesheet describes', () => {
+            const colors = brandColors(ALL_COLORS);
+            const css = brandTokenCss(colors) ?? '';
+
+            // Every value the CSS carries as a literal must equal what the JS derivation produces for the same token,
+            // which is what makes a contrast warning computed in JS a statement about what the browser will paint.
+            for (const [token, value] of Object.entries(brandTokenValues(colors, 'light'))) {
+                if (!value.startsWith('color-mix')) {
+                    expect(css).toContain(`--${token}:`);
+                }
+            }
+            expect(css).toContain(`--brand:${brandTokenValues(colors, 'light').brand};`);
+        });
+    });
+
+    describe('applyBrandTokens', () => {
+        afterEach(() => {
+            document.getElementById(BRAND_TOKENS_STYLE_ID)?.remove();
+        });
+
+        test('should add the override stylesheet to the document head', () => {
+            applyBrandTokens('html.dark{--brand:#0073cf;}');
+
+            expect(document.getElementById(BRAND_TOKENS_STYLE_ID)?.textContent).toBe('html.dark{--brand:#0073cf;}');
+        });
+
+        test('should replace the stylesheet rather than adding a second one', () => {
+            applyBrandTokens('html.dark{--brand:#0073cf;}');
+            applyBrandTokens('html.dark{--brand:#112233;}');
+
+            expect(document.querySelectorAll(`#${BRAND_TOKENS_STYLE_ID}`)).toHaveLength(1);
+            expect(document.getElementById(BRAND_TOKENS_STYLE_ID)?.textContent).toBe('html.dark{--brand:#112233;}');
+        });
+
+        test('should leave the stylesheet untouched when nothing changed', () => {
+            applyBrandTokens('html.dark{--brand:#0073cf;}');
+            const first = document.getElementById(BRAND_TOKENS_STYLE_ID);
+
+            applyBrandTokens('html.dark{--brand:#0073cf;}');
+
+            expect(document.getElementById(BRAND_TOKENS_STYLE_ID)).toBe(first);
+        });
+
+        test('should remove the stylesheet when branding is withdrawn', () => {
+            applyBrandTokens('html.dark{--brand:#0073cf;}');
+            applyBrandTokens(undefined);
+
+            expect(document.getElementById(BRAND_TOKENS_STYLE_ID)).toBeNull();
+        });
+
+        test('should tolerate a removal when nothing was applied', () => {
+            expect(() => applyBrandTokens(undefined)).not.toThrow();
+        });
+    });
+
+    describe('storeBrandCss', () => {
+        afterEach(() => {
+            globalThis.localStorage.removeItem(BRAND_CSS_STORAGE_KEY);
+        });
+
+        test('should cache the stylesheet for the next first paint', () => {
+            storeBrandCss('html.dark{--brand:#0073cf;}');
+
+            expect(globalThis.localStorage.getItem(BRAND_CSS_STORAGE_KEY)).toBe('html.dark{--brand:#0073cf;}');
+        });
+
+        test('should clear the cache when branding is withdrawn', () => {
+            storeBrandCss('html.dark{--brand:#0073cf;}');
+            storeBrandCss(undefined);
+
+            expect(globalThis.localStorage.getItem(BRAND_CSS_STORAGE_KEY)).toBeNull();
+        });
+    });
+});

--- a/src/utils/brand-tokens.spec.ts
+++ b/src/utils/brand-tokens.spec.ts
@@ -20,7 +20,7 @@ const ALL_COLORS = {
     textColor: '#1f2937',
 };
 
-/** The families the Epic settled on, so a token quietly joining or leaving one is a test failure. */
+/** The families each brand colour drives, so a token quietly joining or leaving one is a test failure. */
 const EXPECTED_FAMILIES = {
     primary: ['brand', 'brand-solid', 'brand-solid-hover', 'brand-hover', 'brand-subtle', 'surface-header'],
     secondary: ['info', 'info-surface', 'info-solid'],
@@ -153,7 +153,7 @@ describe('brand-tokens', () => {
             expect(css).not.toContain('--info:');
         });
 
-        test('should emit no light block when only a light-only family is unset', () => {
+        test('should emit no dark block when only a light-only family is set', () => {
             const css = brandTokenCss(brandColors({ backgroundColor: '#f8fafc' })) ?? '';
 
             expect(css).toContain('html:not(.dark){');
@@ -199,18 +199,26 @@ describe('brand-tokens', () => {
             expect(brandTokenValues(colors, 'dark').brand).not.toBe(brandTokenValues(colors, 'light').brand);
         });
 
-        test('should resolve to the same steps the stylesheet describes', () => {
+        /**
+         * The two readings of the rule table have to cover the same tokens, or a contrast warning would be silent
+         * about a token the page nevertheless paints. Whether each *value* agrees cannot be settled here: the CSS
+         * carries a `color-mix` for every derived step, and only a browser can resolve one. That comparison is
+         * `BrandTokens.spec.tsx`, which resolves both sides to the sRGB it paints.
+         */
+        test.each(['light', 'dark'] as const)('should cover exactly the tokens the %s stylesheet declares', (theme) => {
             const colors = brandColors(ALL_COLORS);
-            const css = brandTokenCss(colors) ?? '';
+            const selector = theme === 'light' ? 'html:not(.dark){' : 'html.dark{';
+            const block = (brandTokenCss(colors) ?? '').split(selector)[1]?.split('}')[0] ?? '';
+            const declared = [...block.matchAll(/--([a-z-]+):/g)].map(([, token]) => token);
 
-            // Every value the CSS carries as a literal must equal what the JS derivation produces for the same token,
-            // which is what makes a contrast warning computed in JS a statement about what the browser will paint.
-            for (const [token, value] of Object.entries(brandTokenValues(colors, 'light'))) {
-                if (!value.startsWith('color-mix')) {
-                    expect(css).toContain(`--${token}:`);
-                }
-            }
-            expect(css).toContain(`--brand:${brandTokenValues(colors, 'light').brand};`);
+            expect(declared.toSorted()).toStrictEqual(Object.keys(brandTokenValues(colors, theme)).toSorted());
+        });
+
+        /** An underived step is the one value both readings carry literally, so it can be compared here. */
+        test('should carry an underived step through to the stylesheet unchanged', () => {
+            const colors = brandColors(ALL_COLORS);
+
+            expect(brandTokenCss(colors)).toContain(`--brand:${brandTokenValues(colors, 'light').brand};`);
         });
     });
 

--- a/src/utils/brand-tokens.ts
+++ b/src/utils/brand-tokens.ts
@@ -1,0 +1,267 @@
+/**
+ * Turns the operator's four brand colours into an override layer over the semantic colour tokens.
+ *
+ * Four inputs cannot drive thirty tokens one-to-one, so each input drives a *family* and the intermediate steps are
+ * derived rather than configured. The derivations live in one table, {@link BRAND_TOKEN_RULES}, which is rendered two
+ * ways: to CSS here, and to concrete hex values by `brand-contrast.ts`. Both readings therefore describe the same
+ * colours, which is what lets the contrast warning speak about what the page will actually show.
+ *
+ * The overrides are emitted as a separate stylesheet rather than by editing `tailwindcss.css`, for two reasons. An
+ * unbranded instance then produces no override at all, so its rendering is unchanged by construction rather than by
+ * a fallback that has to be kept in step with the platform palette; and the two selectors used here -
+ * `html:not(.dark)` and `html.dark` - outrank the base `:root` and `.dark` blocks on specificity, so the layer wins
+ * without depending on where the browser happens to order the stylesheets.
+ *
+ * Values are written to the tier-2 custom properties (`--brand`, `--surface`, ...). The `--color-*` names are never
+ * written: `@theme inline` does not emit those into `:root`, it only feeds Tailwind's utility generator, so setting
+ * one parses and resolves to nothing.
+ */
+
+import { isBrandColor } from './branding';
+import { mixOklab } from './oklab';
+import type { ResolvedTheme } from './theme';
+
+export type BrandColorKey = 'primary' | 'secondary' | 'background' | 'text';
+
+/** The operator's inputs, keyed by role. Partial: a colour that is unset simply drives nothing. */
+export type BrandColors = Partial<Record<BrandColorKey, string>>;
+
+export const BRAND_TOKENS_STYLE_ID = 'brand-tokens';
+
+/**
+ * The generated override CSS, cached for the next load's first paint. Branding is server-held, so without a cache the
+ * pre-paint script in `index.html` has nothing to apply and every load would flash the platform palette before the
+ * branding response lands.
+ */
+export const BRAND_CSS_STORAGE_KEY = 'theme-brand-css';
+
+/** One derived step: the input it comes from, and optionally how far it is mixed towards white or black. */
+type Step = { source: BrandColorKey; towards?: 'white' | 'black'; weight?: number };
+
+/** One token's override. A theme left out is not overridden there, so it keeps its platform value. */
+type Rule = { token: string; light?: Step; dark?: Step };
+
+/**
+ * The colour-to-token mapping, as ratified by the Epic.
+ *
+ * Primary and Secondary apply to both compositions; Background and Text apply to the light one only, and no colour is
+ * inverted to derive the other theme - the dark composition keeps its own surfaces and content, which is what keeps it
+ * readable whatever the operator chose against a light page.
+ *
+ * Deliberately absent, and not to be added without a design decision: `success`, `danger` and `warning`, which must
+ * keep their conventional meaning; the `node-*` family, which encodes certificate status in the flow chart;
+ * `content-inverse` and `content-on-brand`, which are the fixed foregrounds the branded fills are measured against;
+ * and `divider`, `outline` and `code-color`.
+ *
+ * The weights reproduce the relationships the platform palette already has - a hover a step darker, a subtle surface a
+ * wash of the same hue, a dark-theme foreground lightened for contrast - so a brand set to the platform's own blue
+ * lands close to the platform's own look: the dark-theme lift of 30% white takes it to 6.4:1 against the dark card,
+ * where the platform's own hand-picked value sits at 6.1:1.
+ *
+ * A fixed lift cannot rescue every input. A near-black Primary stays under AA as a dark-theme link however it is
+ * mixed, and lifting it far enough to pass would no longer be the colour the operator chose - so it is warned about
+ * rather than silently corrected. That warning is `brand-contrast.ts`, and warning is the ratified behaviour.
+ */
+export const BRAND_TOKEN_RULES: readonly Rule[] = [
+    // Primary: foreground, fill and header. `brand` lightens in dark mode for contrast; `brand-solid` stays put in
+    // both, because `content-on-brand` white is measured against it and is not itself branded.
+    { token: 'brand', light: { source: 'primary' }, dark: { source: 'primary', towards: 'white', weight: 0.7 } },
+    { token: 'brand-solid', light: { source: 'primary' }, dark: { source: 'primary' } },
+    {
+        token: 'brand-solid-hover',
+        light: { source: 'primary', towards: 'black', weight: 0.8 },
+        dark: { source: 'primary', towards: 'black', weight: 0.8 },
+    },
+    {
+        token: 'brand-hover',
+        light: { source: 'primary', towards: 'black', weight: 0.8 },
+        dark: { source: 'primary', towards: 'white', weight: 0.5 },
+    },
+    {
+        token: 'brand-subtle',
+        light: { source: 'primary', towards: 'white', weight: 0.1 },
+        dark: { source: 'primary', towards: 'black', weight: 0.42 },
+    },
+    { token: 'surface-header', light: { source: 'primary' }, dark: { source: 'primary' } },
+
+    // Secondary: accents, chips and informational badges, which the stylesheet expresses as the `info` family.
+    { token: 'info', light: { source: 'secondary' }, dark: { source: 'secondary', towards: 'white', weight: 0.7 } },
+    {
+        token: 'info-surface',
+        light: { source: 'secondary', towards: 'white', weight: 0.1 },
+        dark: { source: 'secondary', towards: 'black', weight: 0.42 },
+    },
+    { token: 'info-solid', light: { source: 'secondary' }, dark: { source: 'secondary' } },
+
+    // Background: the page and the surfaces layered on it. Raised goes towards white, the sunken and interactive
+    // states towards black, which is the ordering the platform surfaces already have.
+    { token: 'surface', light: { source: 'background' } },
+    { token: 'surface-raised', light: { source: 'background', towards: 'white', weight: 0.6 } },
+    { token: 'surface-sunken', light: { source: 'background', towards: 'black', weight: 0.97 } },
+    { token: 'surface-hover', light: { source: 'background', towards: 'black', weight: 0.93 } },
+    { token: 'surface-active', light: { source: 'background', towards: 'black', weight: 0.87 } },
+
+    // Text: body copy and the two quieter weights below it. Both weights are set against the platform's own ramp,
+    // which clears AA with room to spare - #525252 at 7.8:1 and #6e6e6e at 5.1:1 on white - so a brand Text a shade
+    // lighter than the platform's does not immediately drag the quietest weight under the threshold.
+    { token: 'content', light: { source: 'text' } },
+    { token: 'content-muted', light: { source: 'text', towards: 'white', weight: 0.78 } },
+    { token: 'content-subtle', light: { source: 'text', towards: 'white', weight: 0.66 } },
+];
+
+const MIX_TARGET_HEX: Record<'white' | 'black', string> = { white: '#ffffff', black: '#000000' };
+
+/** Trailing zeros trimmed, so a weight of 0.8 reads as `80%` rather than `80.0%`. */
+const toPercent = (weight: number): string => String(Number((weight * 100).toFixed(1)));
+
+/** The colours the operator has actually set, as recognisable hex. Anything else drives nothing rather than guessing. */
+export const brandColors = (branding: {
+    primaryColor?: string | null;
+    secondaryColor?: string | null;
+    backgroundColor?: string | null;
+    textColor?: string | null;
+}): BrandColors => {
+    const inputs: ReadonlyArray<[BrandColorKey, string | null | undefined]> = [
+        ['primary', branding.primaryColor],
+        ['secondary', branding.secondaryColor],
+        ['background', branding.backgroundColor],
+        ['text', branding.textColor],
+    ];
+    const colors: BrandColors = {};
+
+    for (const [key, value] of inputs) {
+        if (typeof value === 'string' && isBrandColor(value)) {
+            colors[key] = value.toLowerCase();
+        }
+    }
+
+    return colors;
+};
+
+/** The CSS value for one step, or undefined when the input it derives from is unset. */
+const stepToCss = (colors: BrandColors, step: Step): string | undefined => {
+    const source = colors[step.source];
+
+    if (!source) {
+        return undefined;
+    }
+
+    if (!step.towards || step.weight === undefined) {
+        return source;
+    }
+
+    return `color-mix(in oklab, ${source} ${toPercent(step.weight)}%, ${step.towards})`;
+};
+
+/** The hex value for one step, or undefined when the input it derives from is unset. */
+const stepToHex = (colors: BrandColors, step: Step): string | undefined => {
+    const source = colors[step.source];
+
+    if (!source) {
+        return undefined;
+    }
+
+    if (!step.towards || step.weight === undefined) {
+        return source;
+    }
+
+    return mixOklab(source, MIX_TARGET_HEX[step.towards], step.weight);
+};
+
+/**
+ * The tokens branding overrides in one composition, resolved to hex. This is what the page will render, so it is also
+ * what the contrast warning measures - the CSS below carries the same table.
+ */
+export const brandTokenValues = (colors: BrandColors, theme: ResolvedTheme): Record<string, string> => {
+    const values: Record<string, string> = {};
+
+    for (const rule of BRAND_TOKEN_RULES) {
+        const step = rule[theme];
+        const value = step && stepToHex(colors, step);
+
+        if (value) {
+            values[rule.token] = value;
+        }
+    }
+
+    return values;
+};
+
+const declarations = (colors: BrandColors, theme: ResolvedTheme): string => {
+    const parts: string[] = [];
+
+    for (const rule of BRAND_TOKEN_RULES) {
+        const step = rule[theme];
+        const value = step && stepToCss(colors, step);
+
+        if (value) {
+            parts.push(`--${rule.token}:${value};`);
+        }
+    }
+
+    return parts.join('');
+};
+
+/**
+ * The override stylesheet for a set of brand colours, or undefined when there is nothing to override.
+ *
+ * `html:not(.dark)` and `html.dark` are used rather than `:root` and `.dark` so that each block outranks the base
+ * stylesheet on specificity: the light-only families must beat the base `.dark` block while it is not in force, and
+ * must stop applying the moment it is.
+ */
+export const brandTokenCss = (colors: BrandColors): string | undefined => {
+    const light = declarations(colors, 'light');
+    const dark = declarations(colors, 'dark');
+
+    if (!light && !dark) {
+        return undefined;
+    }
+
+    const blocks: string[] = [];
+
+    if (light) {
+        blocks.push(`html:not(.dark){${light}}`);
+    }
+    if (dark) {
+        blocks.push(`html.dark{${dark}}`);
+    }
+
+    return blocks.join('\n');
+};
+
+/** Applies the override stylesheet to the document, or removes it when there is no branding to apply. */
+export const applyBrandTokens = (css: string | undefined): void => {
+    const existing = document.getElementById(BRAND_TOKENS_STYLE_ID);
+
+    if (css === undefined) {
+        existing?.remove();
+        return;
+    }
+
+    if (existing) {
+        if (existing.textContent !== css) {
+            existing.textContent = css;
+        }
+        return;
+    }
+
+    const style = document.createElement('style');
+
+    style.id = BRAND_TOKENS_STYLE_ID;
+    style.textContent = css;
+    document.head.appendChild(style);
+};
+
+/** Caches the override stylesheet for the next load's first paint. `undefined` clears it, so unbranding takes effect. */
+export const storeBrandCss = (css: string | undefined): void => {
+    try {
+        if (css === undefined) {
+            globalThis.localStorage?.removeItem(BRAND_CSS_STORAGE_KEY);
+        } else {
+            globalThis.localStorage?.setItem(BRAND_CSS_STORAGE_KEY, css);
+        }
+    } catch {
+        // Storage can be unavailable through private browsing, disabled cookies or an exceeded quota. The cache is an
+        // optimisation for the next load's first paint, never required for this one.
+    }
+};

--- a/src/utils/brand-tokens.ts
+++ b/src/utils/brand-tokens.ts
@@ -3,8 +3,9 @@
  *
  * Four inputs cannot drive thirty tokens one-to-one, so each input drives a *family* and the intermediate steps are
  * derived rather than configured. The derivations live in one table, {@link BRAND_TOKEN_RULES}, which is rendered two
- * ways: to CSS here, and to concrete hex values by `brand-contrast.ts`. Both readings therefore describe the same
- * colours, which is what lets the contrast warning speak about what the page will actually show.
+ * ways: to CSS by {@link brandTokenCss}, for the browser to mix, and to concrete hex by {@link brandTokenValues}, for
+ * anything that has to know a derived colour before it is painted. Both readings describe the same colours, which is
+ * what lets a caller measure what the page will actually show.
  *
  * The overrides are emitted as a separate stylesheet rather than by editing `tailwindcss.css`, for two reasons. An
  * unbranded instance then produces no override at all, so its rendering is unchanged by construction rather than by
@@ -42,7 +43,7 @@ type Step = { source: BrandColorKey; towards?: 'white' | 'black'; weight?: numbe
 type Rule = { token: string; light?: Step; dark?: Step };
 
 /**
- * The colour-to-token mapping, as ratified by the Epic.
+ * The colour-to-token mapping.
  *
  * Primary and Secondary apply to both compositions; Background and Text apply to the light one only, and no colour is
  * inverted to derive the other theme - the dark composition keeps its own surfaces and content, which is what keeps it
@@ -59,8 +60,9 @@ type Rule = { token: string; light?: Step; dark?: Step };
  * where the platform's own hand-picked value sits at 6.1:1.
  *
  * A fixed lift cannot rescue every input. A near-black Primary stays under AA as a dark-theme link however it is
- * mixed, and lifting it far enough to pass would no longer be the colour the operator chose - so it is warned about
- * rather than silently corrected. That warning is `brand-contrast.ts`, and warning is the ratified behaviour.
+ * mixed, and lifting it far enough to pass would no longer be the colour the operator chose - so the mapping does not
+ * silently correct it. Measuring a derived colour against its background is {@link brandTokenValues}' purpose, and
+ * what a caller does about a pairing that falls short is the caller's decision, not this table's.
  */
 export const BRAND_TOKEN_RULES: readonly Rule[] = [
     // Primary: foreground, fill and header. `brand` lightens in dark mode for contrast; `brand-solid` stays put in

--- a/src/utils/oklab.spec.ts
+++ b/src/utils/oklab.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'vitest';
+import { mixOklab, rgbToHex } from './oklab';
+
+/**
+ * The authoritative check on this module is in the browser: `BrandTokens.spec.tsx` mixes the same colours with the
+ * real `color-mix(in oklab, ...)` and compares the coordinates. What is asserted here is the algebra that has to hold
+ * whatever the transform coefficients are, plus one value derived from first principles rather than from the code.
+ */
+describe('oklab', () => {
+    describe('mixOklab', () => {
+        test('should return the first colour at full weight', () => {
+            expect(mixOklab('#0073cf', '#ffffff', 1)).toBe('#0073cf');
+        });
+
+        test('should return the second colour at zero weight', () => {
+            expect(mixOklab('#0073cf', '#ffffff', 0)).toBe('#ffffff');
+        });
+
+        test('should clamp a weight above one', () => {
+            expect(mixOklab('#0073cf', '#ffffff', 1.5)).toBe('#0073cf');
+        });
+
+        test('should clamp a weight below zero', () => {
+            expect(mixOklab('#0073cf', '#ffffff', -0.5)).toBe('#ffffff');
+        });
+
+        // For a grey, the three Oklab cone responses are equal, so L reduces to the cube root of the relative
+        // luminance. The midpoint of white and black is therefore L = 0.5, hence luminance 0.125, which gamma-encodes
+        // to 1.055 * 0.125^(1/2.4) - 0.055 = 0.3885 - that is 99, or #636363. Note that this is *not* the sRGB
+        // midpoint #808080: mixing in a perceptual space is the whole point of using it.
+        test('should place the white-black midpoint at Oklab lightness 0.5', () => {
+            expect(mixOklab('#ffffff', '#000000', 0.5)).toBe('#636363');
+        });
+
+        test('should be symmetric in its operands', () => {
+            expect(mixOklab('#ff0000', '#0000ff', 0.25)).toBe(mixOklab('#0000ff', '#ff0000', 0.75));
+        });
+
+        test('should preserve a colour when mixed with itself', () => {
+            expect(mixOklab('#4a90d9', '#4a90d9', 0.37)).toBe('#4a90d9');
+        });
+
+        test('should move monotonically towards white as the white share grows', () => {
+            const steps = [1, 0.75, 0.5, 0.25, 0].map((weight) => mixOklab('#0073cf', '#ffffff', weight));
+            const blueChannels = steps.map((hex) => Number.parseInt(hex.slice(5, 7), 16));
+
+            expect(blueChannels).toStrictEqual([...blueChannels].sort((first, second) => first - second));
+            expect(steps.at(-1)).toBe('#ffffff');
+        });
+
+        test('should stay inside the sRGB gamut for a mix of in-gamut colours', () => {
+            expect(mixOklab('#00ff00', '#0000ff', 0.5)).toMatch(/^#[0-9a-f]{6}$/);
+        });
+
+        test('should reject a colour that is not hex', () => {
+            expect(() => mixOklab('rebeccapurple', '#ffffff', 0.5)).toThrow('Invalid hex colour');
+        });
+    });
+
+    describe('rgbToHex', () => {
+        test('should pad single-digit channels', () => {
+            expect(rgbToHex({ r: 0, g: 8, b: 15 })).toBe('#00080f');
+        });
+
+        test('should round fractional channels', () => {
+            expect(rgbToHex({ r: 0.4, g: 127.5, b: 254.6 })).toBe('#0080ff');
+        });
+    });
+});

--- a/src/utils/oklab.spec.ts
+++ b/src/utils/oklab.spec.ts
@@ -3,8 +3,9 @@ import { mixOklab, rgbToHex } from './oklab';
 
 /**
  * The authoritative check on this module is in the browser: `BrandTokens.spec.tsx` mixes the same colours with the
- * real `color-mix(in oklab, ...)` and compares the coordinates. What is asserted here is the algebra that has to hold
- * whatever the transform coefficients are, plus one value derived from first principles rather than from the code.
+ * real `color-mix(in oklab, ...)` and compares the sRGB each side paints. What is asserted here is the algebra that
+ * has to hold whatever the transform coefficients are, plus one value derived from first principles rather than from
+ * the code.
  */
 describe('oklab', () => {
     describe('mixOklab', () => {
@@ -48,8 +49,16 @@ describe('oklab', () => {
             expect(steps.at(-1)).toBe('#ffffff');
         });
 
-        test('should stay inside the sRGB gamut for a mix of in-gamut colours', () => {
+        // The sRGB gamut is not convex in Oklab, so this mix genuinely leaves it: the linear red channel comes out at
+        // 1.10. Clipping is what the browser paints for the same mix, which `BrandTokens.spec.tsx` pins against a
+        // real pixel; asserted here so the value cannot drift silently.
+        test('should clip a mix that leaves the sRGB gamut to the colour a browser paints', () => {
+            expect(mixOklab('#ff0033', '#ffffff', 0.6)).toBe('#ff8c87');
+        });
+
+        test('should always return a representable sRGB hex', () => {
             expect(mixOklab('#00ff00', '#0000ff', 0.5)).toMatch(/^#[0-9a-f]{6}$/);
+            expect(mixOklab('#ff0033', '#ffffff', 0.7)).toMatch(/^#[0-9a-f]{6}$/);
         });
 
         test('should reject a colour that is not hex', () => {

--- a/src/utils/oklab.ts
+++ b/src/utils/oklab.ts
@@ -4,7 +4,8 @@
  * The branding token layer derives its intermediate steps in CSS, so the browser does the mixing that the operator
  * actually sees. The contrast warning has to evaluate those same steps before they are rendered, which means a second
  * implementation of the mix - in JS - or a warning that describes colours the page will not use. This module is that
- * second implementation, and `oklab.spec.ts` pins it against values produced by the CSS function.
+ * second implementation. `oklab.spec.ts` pins the algebra, and `BrandTokens.spec.tsx` pins the result against what a
+ * browser paints for the same `color-mix`.
  *
  * Only opaque colours are mixed. `color-mix` premultiplies alpha; with both sides opaque that reduces to a straight
  * linear interpolation of the three Oklab coordinates, which is what this does.
@@ -52,8 +53,17 @@ const oklabToRgb = ({ l, a, b }: Oklab): Rgb => {
     const green = -1.2684380046 * long + 2.6097574011 * medium - 0.3413193965 * short;
     const blue = -0.0041960863 * long - 0.7034186147 * medium + 1.707614701 * short;
 
-    // Clamped rather than gamut-mapped: a mix of two in-gamut sRGB colours only leaves the gamut through rounding, so
-    // there is nothing to map back. Browsers clip the same way for `in oklab`.
+    // Clipped per channel rather than gamut-mapped, which is what the browser does with the same mix.
+    //
+    // The sRGB gamut is not convex in Oklab, so interpolating between two in-gamut colours genuinely does leave it -
+    // not merely through rounding. A saturated Primary makes that routine: `#ff0033` mixed 60% towards white lands at
+    // a linear red of 1.10, and more than a third of the weights in `BRAND_TOKEN_RULES` are out of gamut for such an
+    // input. So the choice of what to do about it is a real one, not a formality.
+    //
+    // Clipping is the choice because it reproduces the rendered result. `getComputedStyle` reports a `color-mix(in
+    // oklab, ...)` as unclipped Oklab coordinates, so an out-of-gamut mix compared in that space looks like a
+    // divergence; the sRGB the browser actually paints is the per-channel clip, to the byte. `BrandTokens.spec.tsx`
+    // pins this against painted pixels, out-of-gamut cases included, rather than against those coordinates.
     return {
         r: clamp01(toGamma(red)) * SRGB_MAX,
         g: clamp01(toGamma(green)) * SRGB_MAX,

--- a/src/utils/oklab.ts
+++ b/src/utils/oklab.ts
@@ -1,0 +1,84 @@
+/**
+ * Oklab colour mixing, matching CSS `color-mix(in oklab, ...)`.
+ *
+ * The branding token layer derives its intermediate steps in CSS, so the browser does the mixing that the operator
+ * actually sees. The contrast warning has to evaluate those same steps before they are rendered, which means a second
+ * implementation of the mix - in JS - or a warning that describes colours the page will not use. This module is that
+ * second implementation, and `oklab.spec.ts` pins it against values produced by the CSS function.
+ *
+ * Only opaque colours are mixed. `color-mix` premultiplies alpha; with both sides opaque that reduces to a straight
+ * linear interpolation of the three Oklab coordinates, which is what this does.
+ *
+ * Transform coefficients are Björn Ottosson's, from the Oklab reference (https://bottosson.github.io/posts/oklab/).
+ */
+
+import { hexToRgb, type Rgb } from './contrast';
+
+type Oklab = { l: number; a: number; b: number };
+
+const SRGB_MAX = 255;
+const GAMMA_TO_LINEAR_THRESHOLD = 0.04045;
+const LINEAR_TO_GAMMA_THRESHOLD = 0.0031308;
+
+const toLinear = (channel: number): number => (channel <= GAMMA_TO_LINEAR_THRESHOLD ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4);
+
+const toGamma = (channel: number): number =>
+    channel <= LINEAR_TO_GAMMA_THRESHOLD ? channel * 12.92 : 1.055 * channel ** (1 / 2.4) - 0.055;
+
+const clamp01 = (value: number): number => Math.min(1, Math.max(0, value));
+
+const rgbToOklab = ({ r, g, b }: Rgb): Oklab => {
+    const red = toLinear(r / SRGB_MAX);
+    const green = toLinear(g / SRGB_MAX);
+    const blue = toLinear(b / SRGB_MAX);
+
+    const long = Math.cbrt(0.4122214708 * red + 0.5363325363 * green + 0.0514459929 * blue);
+    const medium = Math.cbrt(0.2119034982 * red + 0.6806995451 * green + 0.1073969566 * blue);
+    const short = Math.cbrt(0.0883024619 * red + 0.2817188376 * green + 0.6299787005 * blue);
+
+    return {
+        l: 0.2104542553 * long + 0.793617785 * medium - 0.0040720468 * short,
+        a: 1.9779984951 * long - 2.428592205 * medium + 0.4505937099 * short,
+        b: 0.0259040371 * long + 0.7827717662 * medium - 0.808675766 * short,
+    };
+};
+
+const oklabToRgb = ({ l, a, b }: Oklab): Rgb => {
+    const long = (l + 0.3963377774 * a + 0.2158037573 * b) ** 3;
+    const medium = (l - 0.1055613458 * a - 0.0638541728 * b) ** 3;
+    const short = (l - 0.0894841775 * a - 1.291485548 * b) ** 3;
+
+    const red = 4.0767416621 * long - 3.3077115913 * medium + 0.2309699292 * short;
+    const green = -1.2684380046 * long + 2.6097574011 * medium - 0.3413193965 * short;
+    const blue = -0.0041960863 * long - 0.7034186147 * medium + 1.707614701 * short;
+
+    // Clamped rather than gamut-mapped: a mix of two in-gamut sRGB colours only leaves the gamut through rounding, so
+    // there is nothing to map back. Browsers clip the same way for `in oklab`.
+    return {
+        r: clamp01(toGamma(red)) * SRGB_MAX,
+        g: clamp01(toGamma(green)) * SRGB_MAX,
+        b: clamp01(toGamma(blue)) * SRGB_MAX,
+    };
+};
+
+const toHexChannel = (channel: number): string => Math.round(channel).toString(16).padStart(2, '0');
+
+export const rgbToHex = ({ r, g, b }: Rgb): string => `#${toHexChannel(r)}${toHexChannel(g)}${toHexChannel(b)}`;
+
+/**
+ * Mixes two hex colours in Oklab, `firstWeight` being the share of the first as a fraction from 0 to 1. Equivalent to
+ * `color-mix(in oklab, <first> <firstWeight * 100>%, <second>)`.
+ */
+export const mixOklab = (first: string, second: string, firstWeight: number): string => {
+    const weight = clamp01(firstWeight);
+    const from = rgbToOklab(hexToRgb(first));
+    const to = rgbToOklab(hexToRgb(second));
+
+    return rgbToHex(
+        oklabToRgb({
+            l: from.l * weight + to.l * (1 - weight),
+            a: from.a * weight + to.a * (1 - weight),
+            b: from.b * weight + to.b * (1 - weight),
+        }),
+    );
+};

--- a/src/utils/prepaint.spec.ts
+++ b/src/utils/prepaint.spec.ts
@@ -14,7 +14,9 @@ import { OPERATOR_DEFAULT_STORAGE_KEY, THEME_STORAGE_KEY } from './theme';
  */
 const prePaintScript = (): string => {
     const html = readFileSync(path.resolve(__dirname, '../../index.html'), 'utf8');
-    const scripts = [...html.matchAll(/<script>([\s\S]*?)<\/script>/g)].map(([, body]) => body);
+    // Case-insensitive, and only an attribute-less opening tag: the scripts that carry a `src` are not
+    // the inline one being looked for.
+    const scripts = [...html.matchAll(/<script>([\s\S]*?)<\/script>/gi)].map(([, body]) => body);
     const script = scripts.find((body) => body.includes(BRAND_CSS_STORAGE_KEY));
 
     if (!script) {

--- a/src/utils/prepaint.spec.ts
+++ b/src/utils/prepaint.spec.ts
@@ -28,7 +28,6 @@ const prePaintScript = (): string => {
 
 const SCRIPT = prePaintScript();
 
-/** The shipped source is executed, rather than a copy of it, so the test cannot drift away from what is served. */
 const runPrePaint = () => {
     new Function(SCRIPT)();
 };
@@ -144,8 +143,7 @@ describe('index.html pre-paint script', () => {
             expect(document.documentElement.style.colorScheme).toBe('light');
         });
 
-        /** An explicit System choice outranks the operator default and returns to the OS preference. */
-        test('should return to the system preference for an explicit System choice', () => {
+        test('should return to the system preference for an explicit System choice, outranking the operator default', () => {
             stubPrefersDark(true);
             globalThis.localStorage.setItem(OPERATOR_DEFAULT_STORAGE_KEY, 'light');
             globalThis.localStorage.setItem(THEME_STORAGE_KEY, 'system');

--- a/src/utils/prepaint.spec.ts
+++ b/src/utils/prepaint.spec.ts
@@ -1,0 +1,177 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { BRAND_CSS_STORAGE_KEY, BRAND_TOKENS_STYLE_ID, brandColors, brandTokenCss } from './brand-tokens';
+import { OPERATOR_DEFAULT_STORAGE_KEY, THEME_STORAGE_KEY } from './theme';
+
+/**
+ * The inline script in `index.html` is the only thing that applies the theme and the operator's colours before the
+ * first paint, and it is deliberately a duplicate: it runs before any module has loaded, so it cannot import from
+ * `theme.ts` or `brand-tokens.ts`. A duplicate kept in step by hand is exactly the thing that needs a test - a change
+ * to a storage key, the style id, the guard or the insertion would otherwise break first paint with the suite green.
+ *
+ * The shipped script is executed here rather than reimplemented, so the test cannot drift away from what is served.
+ */
+const prePaintScript = (): string => {
+    const html = readFileSync(path.resolve(__dirname, '../../index.html'), 'utf8');
+    const scripts = [...html.matchAll(/<script>([\s\S]*?)<\/script>/g)].map(([, body]) => body);
+    const script = scripts.find((body) => body.includes(BRAND_CSS_STORAGE_KEY));
+
+    if (!script) {
+        throw new Error(`No inline script in index.html reads ${BRAND_CSS_STORAGE_KEY}`);
+    }
+
+    return script;
+};
+
+const SCRIPT = prePaintScript();
+
+/** The shipped source is executed, rather than a copy of it, so the test cannot drift away from what is served. */
+const runPrePaint = () => {
+    new Function(SCRIPT)();
+};
+
+const brandStyle = () => document.getElementById(BRAND_TOKENS_STYLE_ID);
+
+const stubPrefersDark = (matches: boolean) => vi.stubGlobal('matchMedia', () => ({ matches }));
+
+const BRAND_CSS = brandTokenCss(brandColors({ primaryColor: '#a3195b', backgroundColor: '#faf5ff' })) ?? '';
+
+describe('index.html pre-paint script', () => {
+    beforeEach(() => {
+        globalThis.localStorage.clear();
+        stubPrefersDark(false);
+        document.documentElement.className = '';
+        document.documentElement.style.colorScheme = '';
+    });
+
+    afterEach(() => {
+        brandStyle()?.remove();
+        globalThis.localStorage.clear();
+        vi.unstubAllGlobals();
+    });
+
+    describe('cached brand colours', () => {
+        test('should install the cached stylesheet under the id the token layer uses', () => {
+            globalThis.localStorage.setItem(BRAND_CSS_STORAGE_KEY, BRAND_CSS);
+
+            runPrePaint();
+
+            expect(brandStyle()?.textContent).toBe(BRAND_CSS);
+        });
+
+        test('should insert it into the head, so it applies to the first paint', () => {
+            globalThis.localStorage.setItem(BRAND_CSS_STORAGE_KEY, BRAND_CSS);
+
+            runPrePaint();
+
+            expect(brandStyle()?.parentElement).toBe(document.head);
+        });
+
+        test('should apply nothing on a first-ever visit', () => {
+            runPrePaint();
+
+            expect(brandStyle()).toBeNull();
+        });
+
+        // The cache is written from colours already validated as #rrggbb, so the guard is there to reject a value
+        // that did not come from this application at all.
+        test.each([
+            ['an at-rule', 'html.dark{--brand:#a3195b;}@import url(evil.css);'],
+            ['markup', '</style><script>alert(1)</script>'],
+            ['a string', "html.dark{--brand:'#a3195b';}"],
+            ['a url()', 'html.dark{background:url(http://evil/x)}'],
+            ['a comment', 'html.dark{}/*x*/'],
+            ['a backslash escape', 'html.dark{--brand:\\41 ;}'],
+        ])('should reject a cached value carrying %s', (_case, cached) => {
+            globalThis.localStorage.setItem(BRAND_CSS_STORAGE_KEY, cached);
+
+            runPrePaint();
+
+            expect(brandStyle()).toBeNull();
+        });
+
+        test('should reject a cached value longer than the size limit', () => {
+            globalThis.localStorage.setItem(BRAND_CSS_STORAGE_KEY, `html.dark{--brand:#a3195b;}${' '.repeat(4096)}`);
+
+            runPrePaint();
+
+            expect(brandStyle()).toBeNull();
+        });
+
+        /** The generator and the guard are in separate files, so what one emits has to stay acceptable to the other. */
+        test('should accept everything the token layer actually generates', () => {
+            const css =
+                brandTokenCss(
+                    brandColors({ primaryColor: '#0073cf', secondaryColor: '#0369a1', backgroundColor: '#f8fafc', textColor: '#1f2937' }),
+                ) ?? '';
+
+            globalThis.localStorage.setItem(BRAND_CSS_STORAGE_KEY, css);
+
+            runPrePaint();
+
+            expect(brandStyle()?.textContent).toBe(css);
+        });
+    });
+
+    describe('theme resolution', () => {
+        test('should fall back to the operating system preference when nothing is stored', () => {
+            stubPrefersDark(true);
+
+            runPrePaint();
+
+            expect(document.documentElement.classList.contains('dark')).toBe(true);
+            expect(document.documentElement.style.colorScheme).toBe('dark');
+        });
+
+        test("should apply the operator's cached default over the system preference", () => {
+            globalThis.localStorage.setItem(OPERATOR_DEFAULT_STORAGE_KEY, 'dark');
+
+            runPrePaint();
+
+            expect(document.documentElement.classList.contains('dark')).toBe(true);
+        });
+
+        test("should apply the user's own choice over the operator default", () => {
+            globalThis.localStorage.setItem(OPERATOR_DEFAULT_STORAGE_KEY, 'dark');
+            globalThis.localStorage.setItem(THEME_STORAGE_KEY, 'light');
+
+            runPrePaint();
+
+            expect(document.documentElement.classList.contains('dark')).toBe(false);
+            expect(document.documentElement.style.colorScheme).toBe('light');
+        });
+
+        /** An explicit System choice outranks the operator default and returns to the OS preference. */
+        test('should return to the system preference for an explicit System choice', () => {
+            stubPrefersDark(true);
+            globalThis.localStorage.setItem(OPERATOR_DEFAULT_STORAGE_KEY, 'light');
+            globalThis.localStorage.setItem(THEME_STORAGE_KEY, 'system');
+
+            runPrePaint();
+
+            expect(document.documentElement.classList.contains('dark')).toBe(true);
+        });
+
+        test('should ignore a stored value that is not a mode', () => {
+            globalThis.localStorage.setItem(THEME_STORAGE_KEY, 'sepia');
+
+            runPrePaint();
+
+            expect(document.documentElement.classList.contains('dark')).toBe(false);
+        });
+    });
+
+    describe('when storage is unavailable', () => {
+        test('should still resolve the theme from the system preference', () => {
+            stubPrefersDark(true);
+            vi.spyOn(globalThis.localStorage, 'getItem').mockImplementation(() => {
+                throw new Error('storage blocked');
+            });
+
+            expect(() => runPrePaint()).not.toThrow();
+            expect(document.documentElement.classList.contains('dark')).toBe(true);
+            expect(brandStyle()).toBeNull();
+        });
+    });
+});


### PR DESCRIPTION
Closes #2039

The operator's four brand colours now drive the semantic colour tokens, so branding reaches every screen through the token layer and no component has to know the instance is branded.

## Colour-to-token mapping

| Input | Drives | Compositions |
|---|---|---|
| Primary | `brand`, `brand-solid`, `brand-solid-hover`, `brand-hover`, `brand-subtle`, `surface-header` | light and dark |
| Secondary | `info`, `info-surface`, `info-solid` | light and dark |
| Background | `surface`, `surface-raised`, `surface-sunken`, `surface-hover`, `surface-active` | light only |
| Text | `content`, `content-muted`, `content-subtle` | light only |

Intermediate steps are derived, not configured: the weights reproduce the relationships the platform palette already has, so a brand set to the platform's own blue lands close to the platform's own look.

`success`, `danger`, `warning`, the `node-*` family, `divider`, `outline`, `code-color`, `content-inverse`, `content-on-brand` and `surface-inverse` are never overridden. The last two are the fixed foregrounds the branded fills are measured against.

## One mapping, two renderings

`utils/brand-tokens.ts` holds the mapping as a single table and renders it twice:

- to CSS, as `color-mix(in oklab, ...)`, so the browser does the mixing;
- to hex, through the new `utils/oklab.ts`, so #2043 can measure the derived colours before anything is painted.

`BrandTokens.spec.tsx` mixes the same colours both ways in a real browser and compares the Oklab coordinates, which is what pins the JS mixer to the CSS function it stands in for.

## Why a separate stylesheet

The overrides are emitted as their own `<style>` element rather than by editing `tailwindcss.css`:

- an unbranded instance produces no override at all, so its rendering is unchanged by construction rather than by a fallback that would have to be kept in step with the platform palette;
- `html:not(.dark)` and `html.dark` outrank the base `:root` and `.dark` blocks on specificity, so the layer wins without depending on where the browser orders the stylesheets;
- the light-only families are emitted into the light block only, so they stop applying the moment the dark composition is in force — the dark theme keeps its own surfaces and content, and no colour is inverted to derive it.

`tailwindcss.css` is untouched, so `theme-tokens.spec.ts` continues to parse and assert the platform palette exactly as before.

## First paint

The generated stylesheet is cached in `localStorage` and applied by the pre-paint script in `index.html`, next to the theme it already resolves there, so a returning user sees no flash of the platform palette. The mapping itself is not duplicated in that script — it applies the cached output.

Only a live branding response may write the cache. Two cases must not clear what is applied: before the first response, where the pre-paint stylesheet is what is on screen; and a failed read, which settles the slice on the platform default so the login page can still render and would otherwise be indistinguishable from a live "not branded" answer.

## Tests

- `utils/oklab.spec.ts` — the algebra of the mix, plus the white/black midpoint derived from first principles.
- `utils/brand-tokens.spec.ts` — the mapping table asserted family by family, including that every token it names is declared in the stylesheet and that no `--color-*` name is ever written; CSS emission, application and caching.
- `components/BrandTokens/BrandTokens.spec.tsx` — the layer in a real browser: colours applied, families withdrawn in dark, status and line tokens left alone, theme switching, partial branding, cache written and cleared, a failed read leaving the colours in place, and the JS/CSS mix cross-check.