### PR TITLE
Warn on brand colours that fail WCAG AA

### DIFF
--- a/src/components/_pages/platform-settings/appearance/AppearanceSettings.spec.tsx
+++ b/src/components/_pages/platform-settings/appearance/AppearanceSettings.spec.tsx
@@ -32,12 +32,16 @@ const unbranded = storedBranding({});
 /**
  * A brand with every field filled. Most of these tests need one now: branding saves whole, so a form missing any
  * colour or either logo offers no Save to click.
+ *
+ * The colours are the platform's own, which matters beyond realism: they clear WCAG AA everywhere, so a Save here goes
+ * straight through rather than stopping at the contrast warning. The tests that want that warning choose colours that
+ * fail it - see the contrast group at the bottom.
  */
 const COMPLETE_BRANDING = {
     primaryColor: '#0073CF',
-    secondaryColor: '#00A3E0',
-    backgroundColor: '#FFFFFF',
-    textColor: '#171717',
+    secondaryColor: '#0369A1',
+    backgroundColor: '#F8FAFC',
+    textColor: '#1F2937',
     lightLogo: PNG_DATA_URI,
     darkLogo: PNG_DATA_URI,
 };
@@ -305,21 +309,21 @@ test.describe('AppearanceSettings', () => {
 
     test('should send the edited colours on save', async ({ mount, page }) => {
         await mount(<AppearanceSettingsTestWrapper preloadedState={branded} />);
-        await setHex(page, 'primaryColor', '#123456');
-        await setHex(page, 'textColor', '#654321');
+        await setHex(page, 'primaryColor', '#1D4ED8');
+        await setHex(page, 'textColor', '#292524');
         await page.getByTestId('appearance-save').click();
 
         const sent = page.getByTestId('sent-branding');
 
-        await expect(sent).toContainText('"primaryColor":"#123456"');
-        await expect(sent).toContainText('"textColor":"#654321"');
+        await expect(sent).toContainText('"primaryColor":"#1D4ED8"');
+        await expect(sent).toContainText('"textColor":"#292524"');
         // The untouched fields go with them: Core clears anything left out of an update.
-        await expect(sent).toContainText('"secondaryColor":"#00A3E0"');
+        await expect(sent).toContainText('"secondaryColor":"#0369A1"');
     });
 
     test('should carry the operator default theme through a save it does not edit', async ({ mount, page }) => {
         await mount(<AppearanceSettingsTestWrapper preloadedState={storedBranding({ ...COMPLETE_BRANDING, defaultTheme: 'dark' })} />);
-        await setHex(page, 'primaryColor', '#00A3E0');
+        await setHex(page, 'primaryColor', '#1D4ED8');
         await page.getByTestId('appearance-save').click();
 
         await expect(page.getByTestId('sent-branding')).toContainText('"defaultTheme":"dark"');
@@ -473,5 +477,86 @@ test.describe('AppearanceSettings', () => {
 
         await expect(page.getByTestId('appearance-unavailable')).toHaveCount(0);
         await expect(page.getByTestId('color-hex-primaryColor')).toBeEnabled();
+    });
+
+    /**
+     * The brand belongs to the operator, so contrast warns and never blocks. What is asserted here is the shape of
+     * that bargain: the failing pairs are named with their ratios, Cancel sends nothing, and Save anyway sends the
+     * colours exactly as chosen. Which pairs fail for which colours is `brand-contrast.spec.ts`.
+     */
+    test.describe('contrast warning', () => {
+        test('should save straight through when the colours clear AA everywhere', async ({ mount, page }) => {
+            await mount(<AppearanceSettingsTestWrapper preloadedState={branded} />);
+            await setHex(page, 'primaryColor', '#1D4ED8');
+
+            await page.getByTestId('appearance-save').click();
+
+            await expect(page.getByTestId('appearance-contrast-dialog')).toHaveCount(0);
+            await expect(page.getByTestId('sent-branding')).toContainText('"primaryColor":"#1D4ED8"');
+        });
+
+        test('should name each failing pair with its ratio and threshold', async ({ mount, page }) => {
+            await mount(<AppearanceSettingsTestWrapper preloadedState={branded} />);
+            await setHex(page, 'primaryColor', '#7FC4FF');
+
+            await page.getByTestId('appearance-save').click();
+
+            const findings = page.getByTestId('appearance-contrast-findings');
+
+            await expect(findings).toBeVisible();
+            await expect(findings.getByRole('listitem')).toHaveCount(3);
+            await expect(findings).toContainText('Light theme: Links and active states on cards and dialogs reaches 1.81:1');
+            await expect(findings).toContainText('below the required 4.5:1');
+            // The header takes Primary in both compositions, so the same choice is reported against each.
+            await expect(findings).toContainText('Light theme: White text on the page header and primary buttons');
+            await expect(findings).toContainText('Dark theme: White text on the page header and primary buttons');
+        });
+
+        test('should report a non-text pairing against the 3:1 threshold', async ({ mount, page }) => {
+            await mount(<AppearanceSettingsTestWrapper preloadedState={branded} />);
+            await setHex(page, 'secondaryColor', '#E8F4FF');
+
+            await page.getByTestId('appearance-save').click();
+
+            await expect(page.getByTestId('appearance-contrast-findings')).toContainText('Informational indicators on cards and dialogs');
+            await expect(page.getByTestId('appearance-contrast-findings')).toContainText('below the required 3:1');
+        });
+
+        test('should send nothing when the warning is cancelled', async ({ mount, page }) => {
+            await mount(<AppearanceSettingsTestWrapper preloadedState={branded} />);
+            await setHex(page, 'primaryColor', '#7FC4FF');
+
+            await page.getByTestId('appearance-save').click();
+            await page.getByRole('button', { name: 'Cancel' }).click();
+
+            await expect(page.getByTestId('sent-branding')).toHaveText('none');
+        });
+
+        test('should save the colours as chosen once the warning is confirmed', async ({ mount, page }) => {
+            await mount(<AppearanceSettingsTestWrapper preloadedState={branded} />);
+            await setHex(page, 'primaryColor', '#7FC4FF');
+
+            await page.getByTestId('appearance-save').click();
+            await page.getByRole('button', { name: 'Save anyway' }).click();
+
+            await expect(page.getByTestId('appearance-contrast-dialog')).toHaveCount(0);
+            await expect(page.getByTestId('sent-branding')).toContainText('"primaryColor":"#7FC4FF"');
+        });
+
+        test('should measure the derived weights, not only the colour that was typed', async ({ mount, page }) => {
+            await mount(<AppearanceSettingsTestWrapper preloadedState={branded} />);
+            // #767676 clears AA as body text on a white page; the two quieter weights derived below it do not, which
+            // is exactly what a check over the four typed colours alone would miss.
+            await setHex(page, 'backgroundColor', '#FFFFFF');
+            await setHex(page, 'textColor', '#767676');
+
+            await page.getByTestId('appearance-save').click();
+
+            const findings = page.getByTestId('appearance-contrast-findings');
+
+            await expect(findings).toContainText('Secondary text on the page background');
+            await expect(findings).toContainText('Hint text on cards and dialogs');
+            await expect(findings).not.toContainText('Body text on the page background reaches');
+        });
     });
 });

--- a/src/components/_pages/platform-settings/appearance/AppearanceSettings.spec.tsx
+++ b/src/components/_pages/platform-settings/appearance/AppearanceSettings.spec.tsx
@@ -480,9 +480,10 @@ test.describe('AppearanceSettings', () => {
     });
 
     /**
-     * The brand belongs to the operator, so contrast warns and never blocks. What is asserted here is the shape of
-     * that bargain: the failing pairs are named with their ratios, Cancel sends nothing, and Save anyway sends the
-     * colours exactly as chosen. Which pairs fail for which colours is `brand-contrast.spec.ts`.
+     * The brand belongs to the operator, so contrast warns and never blocks.
+     *
+     * Which pairs fail for which colours is `brand-contrast.spec.ts`; these cases take a colour it establishes as
+     * failing and assert what the warning then does with it.
      */
     test.describe('contrast warning', () => {
         test('should save straight through when the colours clear AA everywhere', async ({ mount, page }) => {

--- a/src/components/_pages/platform-settings/appearance/AppearanceSettings.tsx
+++ b/src/components/_pages/platform-settings/appearance/AppearanceSettings.tsx
@@ -5,6 +5,8 @@ import Dialog from 'components/Dialog';
 import ProgressButton from 'components/ProgressButton';
 import { actions, selectors } from 'ducks/branding';
 import type { BrandingSettingsModel, BrandingSettingsUpdateModel } from 'types/branding';
+import { brandContrastFindings, describeFinding } from 'utils/brand-contrast';
+import { brandColors } from 'utils/brand-tokens';
 import { isBrandColor, readLogoFile } from 'utils/branding';
 import ColorField from './ColorField';
 import LogoSlot from './LogoSlot';
@@ -50,6 +52,13 @@ const LOGO_SLOTS: ReadonlyArray<{ key: LogoKey; label: string }> = [
 const LOGO_COMPOSITION = 'Each theme uses its own logo, so both are required. Neither slot falls back to the other.';
 
 /**
+ * Contrast warns, it never blocks: the brand belongs to the operator, and the platform's job is to say what a choice
+ * costs rather than to overrule it. The named pairings and their ratios come from `utils/brand-contrast.ts`.
+ */
+const CONTRAST_WARNING =
+    'These combinations fall below the WCAG 2.1 AA contrast the platform holds itself to, so the text and controls named below will be hard to read. You can save them anyway.';
+
+/**
  * Reset is an empty update, and Core clears every field left out of one, so the operator's default theme goes with the
  * colours and logos. Named here because nothing in this application can set it again.
  */
@@ -90,6 +99,7 @@ function AppearanceSettings() {
     const [logos, setLogos] = useState<Logos>(() => toLogos(branding));
     const [readingLogos, setReadingLogos] = useState<Record<LogoKey, boolean>>({ lightLogo: false, darkLogo: false });
     const [isResetDialogOpen, setIsResetDialogOpen] = useState(false);
+    const [isContrastDialogOpen, setIsContrastDialogOpen] = useState(false);
 
     // Reads settle asynchronously, so the slot is claimed by a token. Anything that supersedes a read - a second file,
     // or a delete - bumps the token, and the earlier read's result is then dropped instead of overwriting the newer
@@ -129,6 +139,11 @@ function AppearanceSettings() {
     const isReadOnly = isBusy || !hasKnownBranding;
 
     const hasInvalidColor = useMemo(() => Object.values(colors).some((value) => value !== '' && !isBrandColor(value)), [colors]);
+
+    // Measured over the token families the colours derive, in both compositions, so the warning is about what the
+    // page will paint rather than about the four inputs on their own. An unset or half-typed colour drives nothing and
+    // is simply left out of the evaluation.
+    const contrastFindings = useMemo(() => brandContrastFindings(brandColors(colors)), [colors]);
 
     // Saving mid-read would send the branding without the file the user just chose.
     const isReadingLogo = LOGO_SLOTS.some(({ key }) => readingLogos[key]);
@@ -188,7 +203,7 @@ function AppearanceSettings() {
         setLogos((current) => ({ ...current, [key]: { dataUri: undefined, fileName: undefined, error: undefined } }));
     }, []);
 
-    const onSave = useCallback(() => {
+    const sendSave = useCallback(() => {
         const update: BrandingSettingsUpdateModel = {
             // Carried through untouched. The tab does not edit it, and Core clears any field left out of the request,
             // so omitting it would wipe the operator's default theme on every save.
@@ -203,6 +218,20 @@ function AppearanceSettings() {
 
         dispatch(actions.updateBranding({ branding: update }));
     }, [branding?.defaultTheme, colors, dispatch, logos]);
+
+    const onSave = useCallback(() => {
+        if (contrastFindings.length > 0) {
+            setIsContrastDialogOpen(true);
+            return;
+        }
+
+        sendSave();
+    }, [contrastFindings, sendSave]);
+
+    const onContrastConfirmed = useCallback(() => {
+        setIsContrastDialogOpen(false);
+        sendSave();
+    }, [sendSave]);
 
     const onResetConfirmed = useCallback(() => {
         setIsResetDialogOpen(false);
@@ -302,6 +331,29 @@ function AppearanceSettings() {
                     Reset to Default
                 </Button>
             </div>
+
+            <Dialog
+                isOpen={isContrastDialogOpen}
+                toggle={() => setIsContrastDialogOpen(false)}
+                caption="These colors may be hard to read"
+                icon="warning"
+                size="lg"
+                dataTestId="appearance-contrast-dialog"
+                body={
+                    <div className="space-y-3">
+                        <p>{CONTRAST_WARNING}</p>
+                        <ul className="list-disc space-y-1 pl-5" data-testid="appearance-contrast-findings">
+                            {contrastFindings.map((finding) => (
+                                <li key={`${finding.theme}-${finding.label}`}>{describeFinding(finding)}</li>
+                            ))}
+                        </ul>
+                    </div>
+                }
+                buttons={[
+                    { color: 'warning', body: 'Save anyway', onClick: onContrastConfirmed },
+                    { color: 'secondary', variant: 'outline', body: 'Cancel', onClick: () => setIsContrastDialogOpen(false) },
+                ]}
+            />
 
             <Dialog
                 isOpen={isResetDialogOpen}

--- a/src/utils/brand-contrast.spec.ts
+++ b/src/utils/brand-contrast.spec.ts
@@ -1,0 +1,127 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, test } from 'vitest';
+import { AA_NON_TEXT, AA_TEXT, brandContrastFindings, describeFinding, PLATFORM_TOKENS } from './brand-contrast';
+import { brandColors, brandTokenValues } from './brand-tokens';
+import { contrastRatio } from './contrast';
+import { readSemanticTokens } from './theme-tokens';
+
+/** A brand chosen to pass everywhere: the platform's own palette, restated as operator input. */
+const PASSING = brandColors({
+    primaryColor: '#0073cf',
+    secondaryColor: '#0369a1',
+    backgroundColor: '#f8fafc',
+    textColor: '#1f2937',
+});
+
+describe('brand-contrast', () => {
+    describe('PLATFORM_TOKENS', () => {
+        const tokens = readSemanticTokens(readFileSync(path.resolve(__dirname, '../tailwindcss.css'), 'utf8'));
+
+        test.each(['light', 'dark'] as const)('should match the %s values the stylesheet declares', (theme) => {
+            for (const [token, value] of Object.entries(PLATFORM_TOKENS[theme])) {
+                expect(tokens[theme][token], `--${token} in the ${theme} theme`).toBe(value);
+            }
+        });
+
+        test('should carry the same tokens for both compositions', () => {
+            expect(Object.keys(PLATFORM_TOKENS.dark).sort()).toStrictEqual(Object.keys(PLATFORM_TOKENS.light).sort());
+        });
+    });
+
+    // The white-on-header pairing speaks for primary buttons too, which is only honest while the mapping derives both
+    // from Primary. If that ever diverges, the label has to be split and a second pairing added.
+    describe.each(['light', 'dark'] as const)('%s composition invariants', (theme) => {
+        test('should derive the header surface and the brand fill from the same colour', () => {
+            const values = brandTokenValues(PASSING, theme);
+
+            expect(values['surface-header']).toBe(values['brand-solid']);
+        });
+    });
+
+    describe('brandContrastFindings', () => {
+        test('should report nothing for a brand that passes everywhere', () => {
+            expect(brandContrastFindings(PASSING)).toStrictEqual([]);
+        });
+
+        test('should report nothing for an unbranded instance', () => {
+            expect(brandContrastFindings({})).toStrictEqual([]);
+        });
+
+        test('should report a text failure when the text colour is too light for the background', () => {
+            const findings = brandContrastFindings(brandColors({ backgroundColor: '#ffffff', textColor: '#b9b9b9' }));
+
+            expect(findings.map(({ label }) => label)).toContain('Body text on the page background');
+            expect(findings.every(({ threshold }) => threshold === AA_TEXT)).toBe(true);
+        });
+
+        test('should report a non-text failure when the informational indicator is too pale for the surface', () => {
+            const findings = brandContrastFindings(brandColors({ secondaryColor: '#e8f4ff' }));
+
+            expect(findings.some(({ label, threshold }) => label.includes('Informational indicators') && threshold === AA_NON_TEXT)).toBe(
+                true,
+            );
+        });
+
+        test('should evaluate both compositions', () => {
+            // A pale Primary cannot carry white text, and the header takes Primary in both themes, so the same input
+            // fails on both sides of the theme switch. The branded link fails only in light, where the card is white:
+            // the dark composition lightens Primary further against a near-black card, where it still passes.
+            const findings = brandContrastFindings(brandColors({ primaryColor: '#7fc4ff' }));
+            const themes = new Set(findings.map(({ theme }) => theme));
+
+            expect(themes).toStrictEqual(new Set(['light', 'dark']));
+            expect(findings.filter(({ theme }) => theme === 'light').map(({ label }) => label)).toContain(
+                'Links and active states on cards and dialogs',
+            );
+            expect(findings.filter(({ theme }) => theme === 'dark').map(({ label }) => label)).not.toContain(
+                'Links and active states on cards and dialogs',
+            );
+        });
+
+        test('should report a failure in one composition only when the colours that cause it apply there only', () => {
+            // Background and Text reach the light composition alone, so nothing they can be set to may produce a
+            // finding against the dark theme's own surfaces and content.
+            const findings = brandContrastFindings(brandColors({ backgroundColor: '#111111', textColor: '#0d0d0d' }));
+
+            expect(findings.length).toBeGreaterThan(0);
+            expect(findings.every(({ theme }) => theme === 'light')).toBe(true);
+        });
+
+        test('should name the colours it compared and the ratio they achieve', () => {
+            const [finding] = brandContrastFindings(brandColors({ backgroundColor: '#ffffff', textColor: '#c9c9c9' }));
+
+            expect(finding.foreground).toBe('#c9c9c9');
+            expect(finding.background).toBe('#ffffff');
+            expect(finding.ratio).toBeCloseTo(contrastRatio('#c9c9c9', '#ffffff'), 1);
+            expect(finding.ratio).toBeLessThan(AA_TEXT);
+        });
+
+        test('should measure the derived steps, not only the raw inputs', () => {
+            // Text itself clears AA on white; the two quieter weights derived from it do not, which is exactly what a
+            // check over the four inputs alone would miss.
+            const colors = brandColors({ backgroundColor: '#ffffff', textColor: '#767676' });
+            const labels = brandContrastFindings(colors).map(({ label }) => label);
+
+            expect(contrastRatio('#767676', '#ffffff')).toBeGreaterThanOrEqual(AA_TEXT);
+            expect(labels).not.toContain('Body text on the page background');
+            expect(labels).toContain('Secondary text on the page background');
+        });
+
+        test('should round the ratio down, so a stated figure never rounds up past its threshold', () => {
+            for (const finding of brandContrastFindings(brandColors({ primaryColor: '#7fc4ff' }))) {
+                expect(finding.ratio).toBeLessThan(finding.threshold);
+            }
+        });
+    });
+
+    describe('describeFinding', () => {
+        test('should name the theme, the pairing, the ratio and the threshold', () => {
+            const [finding] = brandContrastFindings(brandColors({ backgroundColor: '#ffffff', textColor: '#c9c9c9' }));
+
+            expect(describeFinding(finding)).toMatch(
+                /^Light theme: Body text on the page background reaches \d+\.\d{2}:1, below the required 4\.5:1\.$/,
+            );
+        });
+    });
+});

--- a/src/utils/brand-contrast.ts
+++ b/src/utils/brand-contrast.ts
@@ -1,0 +1,163 @@
+/**
+ * WCAG 2.1 AA contrast for the operator's brand colours.
+ *
+ * `theme-tokens.spec.ts` already enforces AA over the platform palette at build time, by parsing the token values out
+ * of the stylesheet. Operator colours arrive at runtime and are invisible to that check, so the same guard has to run
+ * on save - over the *derived* token families rather than the four raw inputs, because that is what the page paints.
+ *
+ * The derivation is not repeated here. `brand-tokens.ts` owns the mapping and resolves it to hex through the same
+ * Oklab mix the stylesheet performs, so what is measured below is what the browser will render.
+ *
+ * The result warns, it never blocks. The operator stays in control of the brand and is told what it costs.
+ */
+
+import { brandTokenValues, type BrandColors } from './brand-tokens';
+import { contrastRatio } from './contrast';
+import type { ResolvedTheme } from './theme';
+
+/** WCAG 2.1 1.4.3: body text and images of text. */
+export const AA_TEXT = 4.5;
+
+/** WCAG 2.1 1.4.11: user-interface components and meaningful graphics - borders, status dots, chart series. */
+export const AA_NON_TEXT = 3;
+
+const THEME_LABEL: Record<ResolvedTheme, string> = { light: 'Light theme', dark: 'Dark theme' };
+
+/**
+ * The platform token values a pairing may need for the side branding does not override - white on a branded header,
+ * a branded link on the platform's dark card, an unbranded input border on a branded card.
+ *
+ * These duplicate the stylesheet, which is why `brand-contrast.spec.ts` asserts every entry against the value
+ * `readSemanticTokens` parses out of `tailwindcss.css`. A token retuned there and not here would otherwise make the
+ * warning describe a pairing the application no longer has.
+ */
+export const PLATFORM_TOKENS: Record<ResolvedTheme, Record<string, string>> = {
+    light: {
+        surface: '#f8fafc',
+        'surface-raised': '#ffffff',
+        'surface-sunken': '#f5f5f5',
+        'surface-header': '#0073cf',
+        content: '#1f2937',
+        'content-muted': '#525252',
+        'content-subtle': '#6e6e6e',
+        'content-on-brand': '#ffffff',
+        outline: '#8f8f8f',
+        brand: '#0073cf',
+        info: '#0369a1',
+        'info-surface': '#e6f2ff',
+        'info-solid': '#2798e7',
+    },
+    dark: {
+        surface: '#0a0a0a',
+        'surface-raised': '#171717',
+        'surface-sunken': '#262626',
+        'surface-header': '#171717',
+        content: '#f5f5f5',
+        'content-muted': '#d4d4d4',
+        'content-subtle': '#a3a3a3',
+        'content-on-brand': '#ffffff',
+        outline: '#666666',
+        brand: '#3399ff',
+        info: '#38bdf8',
+        'info-surface': '#002d59',
+        'info-solid': '#2798e7',
+    },
+};
+
+type Pairing = {
+    /** What the operator is being told about, in the terms the Appearance tab uses rather than token names. */
+    label: string;
+    foreground: string;
+    background: string;
+    threshold: number;
+};
+
+/**
+ * The pairings `theme-tokens.spec.ts` covers, restricted to the ones branding can reach.
+ *
+ * White text is measured against `surface-header` only, and the label says it covers primary buttons too: the mapping
+ * derives `brand-solid` and `surface-header` from Primary alike, so the two are the same colour and a second pairing
+ * would only repeat the finding. `brand-contrast.spec.ts` asserts that invariant, so the label cannot quietly go stale.
+ *
+ * `compositeOver` from `contrast.ts` has no call site here on purpose: no branded token is painted through an opacity
+ * modifier, so there is no translucent fill to flatten. The flow chart, which is where that happens, is not branded.
+ */
+const PAIRINGS: readonly Pairing[] = [
+    { label: 'Body text on the page background', foreground: 'content', background: 'surface', threshold: AA_TEXT },
+    { label: 'Body text on cards and dialogs', foreground: 'content', background: 'surface-raised', threshold: AA_TEXT },
+    { label: 'Body text on inset panels', foreground: 'content', background: 'surface-sunken', threshold: AA_TEXT },
+    { label: 'Secondary text on the page background', foreground: 'content-muted', background: 'surface', threshold: AA_TEXT },
+    { label: 'Secondary text on cards and dialogs', foreground: 'content-muted', background: 'surface-raised', threshold: AA_TEXT },
+    { label: 'Hint text on cards and dialogs', foreground: 'content-subtle', background: 'surface-raised', threshold: AA_TEXT },
+    { label: 'Links and active states on cards and dialogs', foreground: 'brand', background: 'surface-raised', threshold: AA_TEXT },
+    {
+        label: 'White text on the page header and primary buttons',
+        foreground: 'content-on-brand',
+        background: 'surface-header',
+        threshold: AA_TEXT,
+    },
+    { label: 'Informational text on its badge', foreground: 'info', background: 'info-surface', threshold: AA_TEXT },
+    {
+        label: 'Informational indicators on cards and dialogs',
+        foreground: 'info-solid',
+        background: 'surface-raised',
+        threshold: AA_NON_TEXT,
+    },
+    { label: 'Input borders on cards and dialogs', foreground: 'outline', background: 'surface-raised', threshold: AA_NON_TEXT },
+];
+
+export type ContrastFinding = {
+    label: string;
+    theme: ResolvedTheme;
+    themeLabel: string;
+    foreground: string;
+    background: string;
+    ratio: number;
+    threshold: number;
+};
+
+const findingsForTheme = (colors: BrandColors, theme: ResolvedTheme): ContrastFinding[] => {
+    const branded = brandTokenValues(colors, theme);
+    const tokens = { ...PLATFORM_TOKENS[theme], ...branded };
+    const findings: ContrastFinding[] = [];
+
+    for (const { label, foreground, background, threshold } of PAIRINGS) {
+        // A pairing neither side of which branding reaches is the platform's own, and is already asserted at build
+        // time. Reporting it would blame the operator's colours for something they did not change - and in the dark
+        // composition, where Background and Text do not apply, that is most of the list.
+        if (!(foreground in branded) && !(background in branded)) {
+            continue;
+        }
+
+        const ratio = contrastRatio(tokens[foreground], tokens[background]);
+
+        if (ratio < threshold) {
+            findings.push({
+                label,
+                theme,
+                themeLabel: THEME_LABEL[theme],
+                foreground: tokens[foreground],
+                background: tokens[background],
+                // Rounded to the precision the warning states, so the number the operator reads is the number that
+                // was compared against the threshold rather than one that rounds to look like it passes.
+                ratio: Math.floor(ratio * 100) / 100,
+                threshold,
+            });
+        }
+    }
+
+    return findings;
+};
+
+/**
+ * Every AA failure the chosen colours would produce, in both compositions. Empty when the brand passes everywhere,
+ * which is what lets the Appearance tab save without asking.
+ */
+export const brandContrastFindings = (colors: BrandColors): ContrastFinding[] => [
+    ...findingsForTheme(colors, 'light'),
+    ...findingsForTheme(colors, 'dark'),
+];
+
+/** One finding as a sentence: what fails, in which theme, by how much. */
+export const describeFinding = ({ label, themeLabel, ratio, threshold }: ContrastFinding): string =>
+    `${themeLabel}: ${label} reaches ${ratio.toFixed(2)}:1, below the required ${threshold}:1.`;


### PR DESCRIPTION
Closes #2043

Stacked on #2101 — that PR adds the colour-to-token mapping this one measures. Review it first; the base will move to `main` once it merges.

Contrast is checked when the operator saves, over the token families the four colours derive rather than over the four inputs on their own. A Text colour that clears AA as body copy can still produce a hint weight that does not, and a check over the raw input would miss exactly that.

## What is measured

`utils/brand-contrast.ts` reuses `contrastRatio` from `utils/contrast.ts` — no second contrast implementation — and resolves the derived values through the single mapping table in `utils/brand-tokens.ts`, so the ratios reported are the ones the browser will paint. `compositeOver` has no call site: no branded token is painted through an opacity modifier, so there is no translucent fill to flatten.

The pairings are the ones `theme-tokens.spec.ts` already covers, restricted to those branding can reach:

| Pairing | Threshold |
|---|---|
| Body / secondary / hint text on the page, cards and inset panels | 4.5:1 |
| Links and active states on cards and dialogs | 4.5:1 |
| White text on the page header and primary buttons | 4.5:1 |
| Informational text on its badge | 4.5:1 |
| Informational indicators on cards and dialogs | 3:1 |
| Input borders on cards and dialogs | 3:1 |

Both compositions are evaluated. A pairing branding does not reach in a given composition is skipped rather than blamed on the operator's colours — in the dark theme that is most of the list, since Background and Text apply to light only.

White text is measured against the header surface once, with a label saying it covers primary buttons too: the mapping derives `surface-header` and `brand-solid` from Primary alike, so a second pairing would only repeat the finding. A test asserts that invariant, so the label cannot quietly go stale.

## Keeping the platform side honest

`PLATFORM_TOKENS` restates the platform values a pairing needs for whichever side branding does not override — white on a branded header, a branded link on the platform's dark card, an unbranded input border on a branded card. A spec asserts every entry against what `readSemanticTokens` parses out of `tailwindcss.css`, so a token retuned there cannot leave the warning describing a pairing the application no longer has.

## Behaviour

Warn, never block. A brand that passes everywhere saves with no dialog. A brand that does not gets each failing pair named individually — theme, pairing, achieved ratio, required threshold — and **Save anyway** sends the colours exactly as chosen. Ratios are rounded down, so a stated figure never rounds up past the threshold it missed.

## Note on the fixture change

`AppearanceSettings.spec.tsx`'s complete-brand fixture moves to the platform's own palette. Its previous Secondary (`#00A3E0`) genuinely fails AA as informational text on its own badge and as an indicator on a white card, so every existing save test would have been diverted through the new dialog. The platform palette clears AA everywhere, which keeps those tests about what they were about.

## Tests

- `utils/brand-contrast.spec.ts` — the stylesheet drift guard, a passing set, a text failure, a non-text failure, a set failing in one composition only, a set failing in both, the derived-weights case, and the rounding direction.
- `AppearanceSettings.spec.tsx` — a passing set saving straight through, the failing pairs named with ratio and threshold, the 3:1 pairing, Cancel sending nothing, Save anyway sending the colours as chosen, and the derived-weights case through the UI.

---

**Two things this PR's base costs, both fixed by retargeting to `main` once #2101 merges.**

1. **Checks.** `build_pr.yml`, `playwright.yml` and `codeql.yml` all trigger on `pull_request` with `branches: [main]`, so while this PR is based on a feature branch only the Docker build runs. The unit and component suites were run locally and are green; the full set will run here once the base moves.
2. **The `Closes` link.** GitHub registers a closing reference only for a PR targeting the default branch, so this one currently has none — merging it as-is would leave the issue open and its board status untouched. Retarget before merging.

