### PR TITLE
Clear the SonarCloud reliability and maintainability findings on main

### DIFF
--- a/src/components/BrandLogo/index.tsx
+++ b/src/components/BrandLogo/index.tsx
@@ -43,7 +43,8 @@ function BrandLogo({ defaultLight, defaultDark, alt, className, dataTestId }: Re
     // from a live "not branded" answer. Either way the platform mark is what shows, and no error is put in front of a
     // visitor who cannot act on it. It counts as settled: there is no second answer coming.
     const settled = branding !== undefined;
-    const uploaded = readFailed ? undefined : resolvedTheme === 'dark' ? branding?.darkLogo : branding?.lightLogo;
+    const themed = resolvedTheme === 'dark' ? branding?.darkLogo : branding?.lightLogo;
+    const uploaded = readFailed ? undefined : themed;
     const platform = resolvedTheme === 'dark' ? defaultDark : defaultLight;
 
     return (

--- a/src/components/ColumnPicker/ColumnPickerTestWrapper.tsx
+++ b/src/components/ColumnPicker/ColumnPickerTestWrapper.tsx
@@ -12,8 +12,6 @@ type Props = Readonly<{
     onSave?: (columns: ColumnDefinition[]) => void;
 }>;
 
-const clone = <T,>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
-
 /**
  * Drives {@link ColumnPicker} through prop changes that a component test cannot produce with
  * `component.update()`, because the dialog renders into a portal and updating unmounts it.
@@ -37,9 +35,9 @@ export default function ColumnPickerTestWrapper({ columns, standardColumns = [],
                 isOpen
                 onClose={() => {}}
                 onSave={onSave ?? (() => {})}
-                catalogue={isReleased ? clone(catalogue) : []}
-                columns={clone(columns)}
-                standardColumns={clone(standardColumns)}
+                catalogue={isReleased ? structuredClone(catalogue) : []}
+                columns={structuredClone(columns)}
+                standardColumns={structuredClone(standardColumns)}
                 resourceLabel="Certificates"
             />
         </div>

--- a/src/components/CustomTable/CustomTable.spec.tsx
+++ b/src/components/CustomTable/CustomTable.spec.tsx
@@ -1167,6 +1167,11 @@ test.describe('CustomTable', () => {
                     ['name', 'desc'],
                     ['name', 'asc'],
                 ]);
+            expect(calls).toEqual([
+                ['name', 'asc'],
+                ['name', 'desc'],
+                ['name', 'asc'],
+            ]);
         });
 
         test('a click on another sortable column moves the sort rather than adding to it', async ({ mount }) => {
@@ -1241,6 +1246,10 @@ test.describe('CustomTable', () => {
                     ['name', 'desc'],
                     ['name', 'asc'],
                 ]);
+            expect(calls).toEqual([
+                ['name', 'desc'],
+                ['name', 'asc'],
+            ]);
         });
 
         // Reporting a sort makes the caller refetch, and a caller re-derives its headers when the fetch
@@ -1316,6 +1325,7 @@ test.describe('CustomTable', () => {
             await nameButton.press('Enter');
 
             await expect.poll(() => calls).toEqual([['name', 'asc']]);
+            expect(calls).toEqual([['name', 'asc']]);
         });
 
         test('carries aria-sort on the sorted header only', async ({ mount }) => {

--- a/src/components/CustomTable/columns/MultiValueCell.tsx
+++ b/src/components/CustomTable/columns/MultiValueCell.tsx
@@ -4,6 +4,12 @@ import Toggletip from 'components/Toggletip';
 import { listCellLinkPath, type ListCellValue } from 'utils/attributes/listCellValues';
 import ValueCell from './ValueCell';
 
+const revealed = (value: ListCellValue) => {
+    if (value.link) return <Link to={listCellLinkPath(value.link)}>{value.label}</Link>;
+    if (value.detail) return `${value.label} (${value.detail})`;
+    return value.label;
+};
+
 type Props = Readonly<{
     /** Every value the attribute holds, in `item_order`. */
     values: ListCellValue[];
@@ -39,15 +45,7 @@ export default function MultiValueCell({ values, dataTestId }: Props) {
                         {values.map((value, index) => (
                             // Values are free text and may repeat, so a value's position in
                             // item_order is the only stable identity it has here.
-                            <li key={`${value.label}-${index}`}>
-                                {value.link ? (
-                                    <Link to={listCellLinkPath(value.link)}>{value.label}</Link>
-                                ) : value.detail ? (
-                                    `${value.label} (${value.detail})`
-                                ) : (
-                                    value.label
-                                )}
-                            </li>
+                            <li key={`${value.label}-${index}`}>{revealed(value)}</li>
                         ))}
                     </ul>
                 }

--- a/src/components/ThemeProvider/ThemeProvider.spec.tsx
+++ b/src/components/ThemeProvider/ThemeProvider.spec.tsx
@@ -186,6 +186,7 @@ test.describe('ThemeProvider', () => {
         );
 
         await expect.poll(async () => page.evaluate(() => globalThis.localStorage.getItem('theme-operator-default'))).toBe('dark');
+        expect(await page.evaluate(() => globalThis.localStorage.getItem('theme-operator-default'))).toBe('dark');
     });
 
     test('should clear the cached operator default once branding is removed', async ({ mount, page }) => {
@@ -197,6 +198,7 @@ test.describe('ThemeProvider', () => {
         );
 
         await expect.poll(async () => page.evaluate(() => globalThis.localStorage.getItem('theme-operator-default'))).toBeNull();
+        expect(await page.evaluate(() => globalThis.localStorage.getItem('theme-operator-default'))).toBeNull();
     });
 
     test('should keep the cached operator default while no branding has been read', async ({ mount, page }) => {

--- a/src/components/ThemeToggle/ThemeToggle.spec.tsx
+++ b/src/components/ThemeToggle/ThemeToggle.spec.tsx
@@ -88,15 +88,15 @@ test.describe('ThemeToggle', () => {
         const toggle = page.getByTestId('theme-toggle');
         await toggle.focus();
 
-        await expect
-            .poll(async () =>
-                toggle.evaluate(
-                    (element) =>
-                        globalThis.getComputedStyle(element).outlineStyle !== 'none' ||
-                        globalThis.getComputedStyle(element).boxShadow !== 'none',
-                ),
-            )
-            .toBe(true);
+        const hasFocusIndicator = () =>
+            toggle.evaluate(
+                (element) =>
+                    globalThis.getComputedStyle(element).outlineStyle !== 'none' ||
+                    globalThis.getComputedStyle(element).boxShadow !== 'none',
+            );
+
+        await expect.poll(hasFocusIndicator).toBe(true);
+        expect(await hasFocusIndicator()).toBe(true);
     });
 
     /**

--- a/src/components/ViewTabs/NameViewDialog.tsx
+++ b/src/components/ViewTabs/NameViewDialog.tsx
@@ -37,8 +37,11 @@ export default function NameViewDialog({
     }, [isOpen, initialName]);
 
     const trimmed = name.trim();
-    const isTaken = trimmed !== initialName.trim() && takenNames.some((taken) => taken === trimmed);
-    const error = trimmed === '' ? 'A view needs a name.' : isTaken ? 'A view of this name already exists.' : undefined;
+    const isTaken = trimmed !== initialName.trim() && takenNames.includes(trimmed);
+
+    let error: string | undefined;
+    if (trimmed === '') error = 'A view needs a name.';
+    else if (isTaken) error = 'A view of this name already exists.';
 
     return (
         <Dialog

--- a/src/components/ViewTabs/UnresolvedColumnsNotice.tsx
+++ b/src/components/ViewTabs/UnresolvedColumnsNotice.tsx
@@ -17,7 +17,7 @@ type Props = Readonly<{
 const list = (columns: PickerColumn[]): string => {
     const names = columns.map(getColumnHeading);
     if (names.length === 1) return names[0];
-    return `${names.slice(0, -1).join(', ')} and ${names[names.length - 1]}`;
+    return `${names.slice(0, -1).join(', ')} and ${names.at(-1)}`;
 };
 
 /**
@@ -36,14 +36,14 @@ export default function UnresolvedColumnsNotice({ unavailable, storedCount, fell
     const named = unavailable.length > 0 ? list(unavailable) : undefined;
     const shown = storedCount - unavailable.length;
 
+    const subject = named ? `${named} cannot be shown` : "None of this view's columns can be shown";
     const message = fellBackToStandard
-        ? `${named ? `${named} cannot be shown` : "None of this view's columns can be shown"}, so it is showing the standard columns.`
-        : `${named} cannot be shown, so this view is showing ${shown} of its ${storedCount} columns.`;
+        ? `${subject}, so it is showing the standard columns.`
+        : `${subject}, so this view is showing ${shown} of its ${storedCount} columns.`;
 
     return (
-        <div
+        <output
             className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-lg bg-warning-surface px-3 py-2 text-sm text-content"
-            role="status"
             data-testid={dataTestId}
         >
             <TriangleAlert className="size-4 shrink-0 text-warning" aria-hidden="true" />
@@ -53,6 +53,6 @@ export default function UnresolvedColumnsNotice({ unavailable, storedCount, fell
                     Review columns
                 </Button>
             )}
-        </div>
+        </output>
     );
 }

--- a/src/components/ViewTabs/index.tsx
+++ b/src/components/ViewTabs/index.tsx
@@ -366,8 +366,10 @@ export default function ViewTabs({
             }
 
             if (event.key === 'Home' || event.key === 'End') {
+                const target = event.key === 'Home' ? visible.at(0) : visible.at(-1);
+                if (!target) return;
                 event.preventDefault();
-                selectByKeyboard(event.key === 'Home' ? visible[0].id : visible[visible.length - 1].id);
+                selectByKeyboard(target.id);
             }
         },
         [visible, activeId, selectByKeyboard],
@@ -383,6 +385,10 @@ export default function ViewTabs({
                     aria-label="Saved views"
                     className="flex items-center gap-x-1"
                     onKeyDown={onStripKeyDown}
+                    // Keyboard reachability does not depend on this: focus sits on the tabs and the keydown bubbles
+                    // up. It is here because an element carrying an interactive role and a key handler has to be
+                    // focusable, and -1 satisfies that while leaving the tabs as the only tab stops.
+                    tabIndex={-1}
                     data-testid={`${dataTestId}-strip`}
                 >
                     {visible.map((tab) => (

--- a/src/components/WidgetLock/WidgetLock.spec.tsx
+++ b/src/components/WidgetLock/WidgetLock.spec.tsx
@@ -103,6 +103,7 @@ test.describe('WidgetLock', () => {
         await component.locator('[data-testid="widget-lock-refresh"]').click();
 
         await expect.poll(() => refreshCount).toBe(1);
+        expect(refreshCount).toBe(1);
     });
 
     test('should render a custom refresh label when refreshLabel is provided', async ({ mount }) => {

--- a/src/components/_pages/dashboard/DashboardItem/CountBadge.spec.tsx
+++ b/src/components/_pages/dashboard/DashboardItem/CountBadge.spec.tsx
@@ -75,6 +75,7 @@ test.describe('CountBadge', () => {
         await component.locator('[data-testid="widget-lock-refresh"]').click();
 
         await expect.poll(() => refreshCount).toBe(1);
+        expect(refreshCount).toBe(1);
     });
 
     // A null count can mean a denied permission, a down data source or a failed request. The badge

--- a/src/ducks/test-reducers.ts
+++ b/src/ducks/test-reducers.ts
@@ -322,7 +322,7 @@ function brandingTestReducer(state: BrandingTestState = brandingTestInitialState
         case 'branding/getPublicBrandingSuccess':
             return {
                 ...state,
-                publicBranding: (action as { payload?: { branding?: BrandingTestState['publicBranding'] } }).payload?.branding,
+                publicBranding: (action as { payload?: { branding: BrandingTestState['publicBranding'] } }).payload?.branding,
                 publicBrandingReadFailed: false,
             };
         case 'branding/getPublicBrandingFailure':

--- a/src/utils/branding.ts
+++ b/src/utils/branding.ts
@@ -76,12 +76,7 @@ const LOGO_DATA_URI_PATTERN = /^data:([^;,]+);base64,([A-Za-z0-9+/]+={0,2})$/;
  * which carries too few bits to be a byte - an otherwise well-formed payload that simply was not padded is accepted,
  * as `Base64.getDecoder()` accepts it.
  */
-const isDecodableBase64 = (payload: string): boolean => {
-    const padding = payload.length - payload.replace(/=+$/, '').length;
-    const data = payload.length - padding;
-
-    return padding === 0 ? data % 4 !== 1 : (data + padding) % 4 === 0;
-};
+const isDecodableBase64 = (payload: string): boolean => (payload.endsWith('=') ? payload.length % 4 === 0 : payload.length % 4 !== 1);
 
 /**
  * Whether a stored logo is safe to point an `img` at.


### PR DESCRIPTION
Fixes the 21 SonarCloud findings open on `main` that are not part of the deliberate won't-fix set. `main` reports 34 issues — 33 maintainability and 2 reliability, one of which (`S6852`) counts in both.

## Reliability

- **`S8786` — `src/utils/branding.ts`.** The trailing-padding count in `isDecodableBase64` ran `payload.replace(/=+$/, '')`, a backtracking regex, over the whole payload. Both branches only ever depended on *whether* padding is present, never on how much: `replace` shortens the string exactly when the last character is `=`, and `data + padding` is `payload.length` identically. The check is now arithmetic on the length, with no regex.
- **`S6852` — `src/components/ViewTabs`.** The tab strip carries the arrow/Home/End handler, so the element holding the `tablist` role and that handler needs a `tabIndex` to be focusable. `-1`, so the tabs remain the only tab stops; keyboard reachability never depended on the strip, since focus sits on the tabs and the keydown bubbles up.

## Maintainability

| Rule | Where | Change |
|---|---|---|
| `S3358` ×4 | `BrandLogo`, `MultiValueCell`, `NameViewDialog`, `UnresolvedColumnsNotice` | Nested ternaries lifted into a named value, an `if`/`else if`, or a render helper |
| `S4624` | `UnresolvedColumnsNotice` | Shared clause hoisted out, which removed the nested template literal with it |
| `S6819` | `UnresolvedColumnsNotice` | `<div role="status">` → `<output>`, whose implicit role is `status`, matching `Spinner` |
| `S7755` ×2 | `ViewTabs`, `UnresolvedColumnsNotice` | `.at(-1)` in place of `[….length - 1]`, with the undefined case guarded |
| `S7765` | `NameViewDialog` | `takenNames.some((taken) => taken === trimmed)` → `takenNames.includes(trimmed)` |
| `S7784` | `ColumnPickerTestWrapper` | `structuredClone`, and the one-line wrapper helper dropped |
| `S4782` | `src/ducks/test-reducers.ts` | Redundant `?` beside a type that already admits `undefined` |
| `S2699` ×8 | `CustomTable` ×3, `ThemeProvider` ×2, `ThemeToggle`, `WidgetLock`, `CountBadge` | Sonar does not recognise `expect.poll` as an assertion, so a test case whose only assertion is a poll is flagged. Each keeps the poll as the wait and asserts the settled value plainly — the shape already used across the suite |

## Left untouched

The 13 remaining issues are the deliberate set: three `role="button"` (each already inside a real `<button>`, where a nested interactive element would be invalid and less accessible), `S6551` in `AttributeFieldSelect`, the ISO-8601 duration regex `S5843`, array-index keys on raw duplicable scalars `S6479`, and the four `S8783` forced interactions plus three `S2925` fixed waits — all seven of which exist to prove a disabled control does nothing, which needs `force` or a wait by construction. These want marking in SonarCloud rather than editing.

## Verification

`npm run typecheck` clean, `npm run test:vitest` 4006/4006, Playwright CT (chromium) over the touched component areas 277 + 74 pass. The `branding.ts` rewrite was checked exhaustively against the old implementation over every string up to length 7 on `A B = a 0 + /` — no mismatches.