### PR TITLE
Patch the base image's util-linux CVEs to unblock the Trivy gate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,14 @@ FROM nginxinc/nginx-unprivileged:1.31.5-alpine
 
 # Patch base-image OS packages for known CVEs (c-ares CVE-2026-33630;
 # curl/libcurl CVE-2026-5773, CVE-2026-6276; openssl CVE-2026-14456;
-# expat CVE-2026-66046, CVE-2026-76641).
+# expat CVE-2026-66046, CVE-2026-76641; util-linux CVE-2026-53612,
+# CVE-2026-53613, CVE-2026-53614, CVE-2026-76642, CVE-2026-78408,
+# CVE-2026-78409, CVE-2026-78410).
 # Pin the minimum fixed version so the build fails fast if the patched package
 # is ever unavailable, keeping the Trivy scan gate reliably green.
 USER root
 RUN apk add --no-cache --upgrade "c-ares>=1.34.8-r0" "curl>=8.20.0-r0" "libcrypto3>=3.5.8-r0" \
-    "libcurl>=8.20.0-r0" "libexpat>=2.8.4-r0" "libssl3>=3.5.8-r0"
+    "libcurl>=8.20.0-r0" "libexpat>=2.8.4-r0" "libssl3>=3.5.8-r0" "libuuid>=2.42.3-r1"
 USER 101
 
 WORKDIR /usr/share/nginx/html


### PR DESCRIPTION
Trivy's vulnerability database picked up seven HIGH util-linux advisories against `libuuid` 2.42.1-r0, the version shipped by the `nginxinc/nginx-unprivileged:1.31.5-alpine` digest CI was resolving. The container scan in `test_docker_image.yaml` fails on every open pull request as a result — `test / Build amd64` and `test / Build arm64` — because the finding comes from the base layer rather than from anything under review.

| CVE | Fixed in |
|---|---|
| CVE-2026-53612, CVE-2026-53613, CVE-2026-53614, CVE-2026-76642, CVE-2026-78409, CVE-2026-78410 | 2.42.3-r0 |
| CVE-2026-78408 | 2.42.3-r1 |

`libuuid>=2.42.3-r1` joins the `apk add --no-cache --upgrade` pin set in the final stage, which already patches c-ares, curl, openssl and expat for the same reason, and the comment above it lists the new CVEs alongside those.

Verified by building against the affected digest (`sha256:aa8c9087d36d93e9d650c5365f883b421e8214aedbad24ade52b844c583358f1`): the pin upgrades `libuuid` from 2.42.1-r0 to 2.42.3-r1, and `trivy image --severity HIGH,CRITICAL` then reports no findings and exits 0.

The `1.31.5-alpine` tag has since been rebuilt upstream and now ships 2.42.3-r1 itself, so the pin is currently a no-op at build time. It stays as the fail-fast guard the existing pin list exists to provide: Renovate cannot see a rebuild of an unchanged tag, so nothing else would catch a recurrence.
