### PR TITLE
Add regression coverage for key-association saved views

### DIFF
--- a/src/components/ColumnPicker/ColumnPicker.spec.tsx
+++ b/src/components/ColumnPicker/ColumnPicker.spec.tsx
@@ -255,8 +255,8 @@ test.describe('ColumnPicker', () => {
 
     /**
      * A platform default column can be absent from the filter-field catalogue and still renderable —
-     * `CK_ASSOCIATIONS` on the keys inventory is one. Resetting used to mark them unavailable, and
-     * the next Save then silently removed them from the view.
+     * `CK_ASSOCIATIONS` on the keys inventory is one. Reset has to keep such a column available, or
+     * the next Save drops it from the view without saying so.
      */
     test('reset keeps a platform column the catalogue does not publish, and saves it', async ({ mount, page }) => {
         const uncatalogued: ColumnDefinition = {

--- a/src/components/ColumnPicker/ColumnPicker.spec.tsx
+++ b/src/components/ColumnPicker/ColumnPicker.spec.tsx
@@ -255,26 +255,26 @@ test.describe('ColumnPicker', () => {
 
     /**
      * A platform default column can be absent from the filter-field catalogue and still renderable —
-     * the keys inventory ships three such columns. Resetting used to mark them unavailable, and the
-     * next Save then silently removed them from the view.
+     * `CK_ASSOCIATIONS` on the keys inventory is one. Resetting used to mark them unavailable, and
+     * the next Save then silently removed them from the view.
      */
     test('reset keeps a platform column the catalogue does not publish, and saves it', async ({ mount, page }) => {
         const uncatalogued: ColumnDefinition = {
             fieldSource: FilterFieldSource.Property,
-            fieldIdentifier: 'CKI_ENABLED',
-            catalogueLabel: 'Status',
+            fieldIdentifier: 'CK_ASSOCIATIONS',
+            catalogueLabel: 'Associations',
         };
         const saved: ColumnDefinition[][] = [];
         await mount(picker({ columns: [], standardColumns: [commonName, uncatalogued], onSave: (columns) => saved.push(columns) }));
 
         await page.getByTestId('reset-to-standard').click();
 
-        await expect(page.getByTestId('selected-column-property:CKI_ENABLED')).not.toContainText('Unavailable');
+        await expect(page.getByTestId('selected-column-property:CK_ASSOCIATIONS')).not.toContainText('Unavailable');
 
         await page.getByRole('button', { name: 'Save' }).click();
 
         await expect.poll(() => saved.length).toBe(1);
-        expect(saved[0].map((column) => column.fieldIdentifier)).toEqual(['COMMON_NAME', 'CKI_ENABLED']);
+        expect(saved[0].map((column) => column.fieldIdentifier)).toEqual(['COMMON_NAME', 'CK_ASSOCIATIONS']);
     });
 
     test('refills the selected columns from the platform set', async ({ mount, page }) => {

--- a/src/components/_pages/cryptographic-keys/keyTableHelpers.tsx
+++ b/src/components/_pages/cryptographic-keys/keyTableHelpers.tsx
@@ -22,10 +22,9 @@ export interface BuildKeyRowColumnsOpts {
 /**
  * The platform default column set for the cryptographic keys inventory.
  *
- * Three of these are not in the filter-field catalogue today — `CKI_ENABLED`, `CKI_CREATED` and
- * `CK_ASSOCIATIONS` have no `FilterField` entry — so they are shown by the default set but cannot
- * be picked, renamed or sorted until the catalogue carries them. They keep their natural
- * identifiers here so that adding the fields is the only change needed.
+ * `CK_ASSOCIATIONS` counts certificates joined on either `keyUuid` or `altKeyUuid`, which no
+ * `FilterField` can resolve to a scalar path, so the catalogue cannot publish it: it renders but
+ * cannot be picked or sorted, and `toStorableColumns` drops it so the default set still saves.
  */
 export const KEY_COLUMNS: ColumnDefinition[] = [
     {

--- a/src/components/_pages/cryptographic-keys/keyTableHelpers.unit.spec.tsx
+++ b/src/components/_pages/cryptographic-keys/keyTableHelpers.unit.spec.tsx
@@ -4,30 +4,57 @@ import { FilterFieldSource, Resource, type SearchFieldDataByGroupDto } from 'typ
 import { toCreateRequest, toStandardSlice } from 'utils/listViews';
 import { KEY_COLUMNS } from './keyTableHelpers';
 
-const DISPLAY_ONLY = 'CK_ASSOCIATIONS';
+/**
+ * The cryptographic-key property fields core publishes, stated independently of {@link KEY_COLUMNS}
+ * so a default column core does not catalogue fails these tests instead of joining the fixture.
+ * Mirrors `FilterField.java`; `CK_ASSOCIATIONS` is absent there and so is absent here.
+ */
+const CATALOGUED = [
+    'CKI_ENABLED',
+    'CKI_STATE',
+    'CKI_NAME',
+    'CKI_TYPE',
+    'CKI_USAGE',
+    'CKI_CRYPTOGRAPHIC_ALGORITHM',
+    'CKI_LENGTH',
+    'CKI_FORMAT',
+    'CKI_CREATED',
+    'CK_GROUP',
+    'CK_OWNER',
+    'CK_TOKEN_PROFILE',
+    'CK_TOKEN_INSTANCE',
+];
 
 const keysCatalogue = [
     {
         filterFieldSource: FilterFieldSource.Property,
-        searchFieldData: KEY_COLUMNS.filter((column) => column.fieldIdentifier !== DISPLAY_ONLY).map((column) => ({
-            fieldIdentifier: column.fieldIdentifier,
-            fieldLabel: column.catalogueLabel,
-            type: column.type,
-            conditions: [],
-        })),
+        searchFieldData: CATALOGUED.map((fieldIdentifier) => ({ fieldIdentifier, fieldLabel: fieldIdentifier, conditions: [] })),
     },
 ] as unknown as SearchFieldDataByGroupDto[];
 
 describe('KEY_COLUMNS saved as a view', () => {
-    it('carries the display-only associations column, which the catalogue cannot publish', () => {
-        expect(KEY_COLUMNS.map((column) => column.fieldIdentifier)).toContain(DISPLAY_ONLY);
+    it('names exactly one column the catalogue cannot publish', () => {
+        expect(KEY_COLUMNS.map((column) => column.fieldIdentifier).filter((identifier) => !CATALOGUED.includes(identifier))).toEqual([
+            'CK_ASSOCIATIONS',
+        ]);
     });
 
     it('drops that column on write, so saving the platform default set is accepted', () => {
         const request = toCreateRequest('Standard (copy)', Resource.Keys, toStandardSlice(KEY_COLUMNS), keysCatalogue);
 
-        expect(request.columns.map((column) => column.fieldIdentifier)).toEqual(
-            KEY_COLUMNS.filter((column) => column.fieldIdentifier !== DISPLAY_ONLY).map((column) => column.fieldIdentifier),
-        );
+        expect(request.columns.map((column) => column.fieldIdentifier)).toEqual([
+            'CKI_ENABLED',
+            'CKI_STATE',
+            'CKI_NAME',
+            'CKI_TYPE',
+            'CKI_CRYPTOGRAPHIC_ALGORITHM',
+            'CKI_LENGTH',
+            'CKI_FORMAT',
+            'CKI_CREATED',
+            'CK_GROUP',
+            'CK_OWNER',
+            'CK_TOKEN_PROFILE',
+            'CK_TOKEN_INSTANCE',
+        ]);
     });
 });

--- a/src/components/_pages/cryptographic-keys/keyTableHelpers.unit.spec.tsx
+++ b/src/components/_pages/cryptographic-keys/keyTableHelpers.unit.spec.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { FilterFieldSource, Resource, type SearchFieldDataByGroupDto } from 'types/openapi';
+import { toCreateRequest, toStandardSlice } from 'utils/listViews';
+import { KEY_COLUMNS } from './keyTableHelpers';
+
+const DISPLAY_ONLY = 'CK_ASSOCIATIONS';
+
+const keysCatalogue = [
+    {
+        filterFieldSource: FilterFieldSource.Property,
+        searchFieldData: KEY_COLUMNS.filter((column) => column.fieldIdentifier !== DISPLAY_ONLY).map((column) => ({
+            fieldIdentifier: column.fieldIdentifier,
+            fieldLabel: column.catalogueLabel,
+            type: column.type,
+            conditions: [],
+        })),
+    },
+] as unknown as SearchFieldDataByGroupDto[];
+
+describe('KEY_COLUMNS saved as a view', () => {
+    it('carries the display-only associations column, which the catalogue cannot publish', () => {
+        expect(KEY_COLUMNS.map((column) => column.fieldIdentifier)).toContain(DISPLAY_ONLY);
+    });
+
+    it('drops that column on write, so saving the platform default set is accepted', () => {
+        const request = toCreateRequest('Standard (copy)', Resource.Keys, toStandardSlice(KEY_COLUMNS), keysCatalogue);
+
+        expect(request.columns.map((column) => column.fieldIdentifier)).toEqual(
+            KEY_COLUMNS.filter((column) => column.fieldIdentifier !== DISPLAY_ONLY).map((column) => column.fieldIdentifier),
+        );
+    });
+});

--- a/src/components/_pages/cryptographic-keys/keyTableHelpers.unit.spec.tsx
+++ b/src/components/_pages/cryptographic-keys/keyTableHelpers.unit.spec.tsx
@@ -6,7 +6,7 @@ import { KEY_COLUMNS } from './keyTableHelpers';
 
 /**
  * The cryptographic-key property fields core publishes, stated independently of {@link KEY_COLUMNS}
- * so a default column core does not catalogue fails these tests instead of joining the fixture.
+ * so a default column that core does not catalogue fails these tests instead of joining the fixture.
  * Mirrors `FilterField.java`; `CK_ASSOCIATIONS` is absent there and so is absent here.
  */
 const CATALOGUED = [

--- a/src/utils/columnPicker.spec.ts
+++ b/src/utils/columnPicker.spec.ts
@@ -230,16 +230,21 @@ describe('resolveColumns', () => {
 
     /**
      * A platform default column can be absent from the filter-field catalogue and still renderable —
-     * the keys inventory ships three such columns. Marking those unavailable would drop them from the
-     * view on the next save.
+     * `CK_ASSOCIATIONS` on the keys inventory is one. Marking those unavailable would drop them from
+     * the view on the next save.
      */
     it('keeps a platform column the catalogue does not publish available', () => {
         const platform: ColumnDefinition[] = [
-            { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'CKI_ENABLED', catalogueLabel: 'Status', align: 'center' },
+            {
+                fieldSource: FilterFieldSource.Property,
+                fieldIdentifier: 'CK_ASSOCIATIONS',
+                catalogueLabel: 'Associations',
+                align: 'center',
+            },
         ];
 
         expect(resolveColumns(platform, fields, platform)[0]).toMatchObject({
-            catalogueLabel: 'Status',
+            catalogueLabel: 'Associations',
             align: 'center',
             available: true,
         });
@@ -247,7 +252,7 @@ describe('resolveColumns', () => {
 
     it('still marks an unknown column unavailable when a standard set is given', () => {
         const platform: ColumnDefinition[] = [
-            { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'CKI_ENABLED', catalogueLabel: 'Status' },
+            { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'CK_ASSOCIATIONS', catalogueLabel: 'Associations' },
         ];
 
         expect(resolveColumns(stored, fields, platform).map((column) => column.available)).toEqual([true, false, true]);


### PR DESCRIPTION
`CK_ASSOCIATIONS` is in the platform default column set for the cryptographic keys inventory but has no `FilterField` entry, so `ListViewServiceImpl.validateColumns` rejected any view built from that default set — the user picked nothing unusual, they just saved the standard columns.

Of the two options on OmniTrustILM/core#2219, this takes the second: the column stays display-only and the frontend omits it from the write. That behaviour landed with the column-pipeline pilot (#2104), where `toStorableColumns` sieves both the create and the update request against the live catalogue. Option 1 — mapped `@OneToMany` relations on `CryptographicKey` plus aggregate support in `FilterPredicatesBuilder` and `SortOrderBuilder` — is a change to two builders that all sixteen `SearchRequestDto` listings run through, and is only worth costing against a real request to filter or sort by association count.

This change is the remainder.

## Comment accuracy

`keyTableHelpers.tsx` named `CKI_ENABLED`, `CKI_CREATED` and `CK_ASSOCIATIONS` as absent from the filter-field catalogue. core#2163 catalogued the first two, so the note now names only `CK_ASSOCIATIONS` and says why it cannot be catalogued: it counts certificates joined on either `keyUuid` or `altKeyUuid`, which no `FilterField` resolves to a scalar path.

Two sibling comments in `columnPicker.spec.ts` and `ColumnPicker.spec.tsx` stated the same count and used `CKI_ENABLED` as their worked example of an uncatalogued column. Both now use `CK_ASSOCIATIONS`, and neither asserts a count.

## Regression cover

`keyTableHelpers.unit.spec.tsx` pins the reported scenario: a create request built from the real `KEY_COLUMNS` against the key identifiers core publishes drops `CK_ASSOCIATIONS` and keeps the other twelve in order. The catalogue is stated as its own list rather than derived from `KEY_COLUMNS`, so a further default column core does not publish fails the test instead of being absorbed into the fixture.

Closes OmniTrustILM/core#2219