### PR TITLE
Label the dashboard count axes with whole numbers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,6 +212,16 @@ and asserts WCAG AA (4.5:1) contrast for every text/background pairing, in both 
 non-text contrast (WCAG 1.4.11, 3:1) for `outline` and each `-solid` status token against
 `surface-raised`. Changing a token value to something that fails either threshold fails the suite.
 
+### Charts
+
+The dashboard charts plot counts, so their value axis must be a whole-number axis. Recharts divides
+a small automatic domain into fractional ticks, and formatting those ticks as integers collapses
+them into duplicate labels — a maximum of two signings renders as `0 1 1 2 2`. A count axis
+therefore sets `allowDecimals={false}` and takes its domain from `countAxisDomain` in
+`src/utils/chart-axis.ts`, which pins the top to the highest count while the domain is too narrow
+for recharts to step in whole numbers. Rounding the tick labels instead is what causes the
+duplicates, so a count axis carries no `tickFormatter`.
+
 ### Code Style
 
 Biome enforces linting and formatting: 4-space indent, 140-char line width, single quotes, trailing commas everywhere, semicolons required. Suppress rules only with a justified `biome-ignore` comment.

--- a/src/components/_pages/dashboard/DashboardItem/HorizontalBarChart.spec.tsx
+++ b/src/components/_pages/dashboard/DashboardItem/HorizontalBarChart.spec.tsx
@@ -19,6 +19,20 @@ test.describe('HorizontalBarChart', () => {
         await expect(component.getByText('+4 more')).toBeVisible();
     });
 
+    test('the count axis labels counts as distinct whole numbers', async ({ mount }) => {
+        const component = await mount(
+            <HorizontalBarChartWithStore
+                title="Top Requesters"
+                data={{ alice: 2, bob: 1 }}
+                entity={EntityType.SIGNING_RECORD}
+                redirect="/signingrecords"
+                onSetFilter={() => []}
+            />,
+        );
+        const ticks = component.locator('.recharts-xAxis-tick-labels .recharts-cartesian-axis-tick-value');
+        await expect(ticks).toHaveText(['0', '1', '2']);
+    });
+
     test('omits the overflow caption when nothing overflows', async ({ mount }) => {
         const component = await mount(
             <HorizontalBarChartWithStore

--- a/src/components/_pages/dashboard/DashboardItem/HorizontalBarChart.tsx
+++ b/src/components/_pages/dashboard/DashboardItem/HorizontalBarChart.tsx
@@ -5,6 +5,7 @@ import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router';
 import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import type { SearchFilterModel } from 'types/certificate';
+import { countAxisDomain } from 'utils/chart-axis';
 import { getDonutChartColorsByRandomNumberOfOptions } from 'utils/dashboard';
 import type { ColorOptions } from './DonutChart';
 
@@ -73,7 +74,8 @@ function HorizontalBarChart({ title, data = {}, entity, redirect, onSetFilter, o
                     <CartesianGrid vertical={false} stroke={themeColors.grid} strokeDasharray="4" />
                     <XAxis
                         type="number"
-                        tickFormatter={(value: number) => String(Math.round(value))}
+                        allowDecimals={false}
+                        domain={countAxisDomain(chartData.map((bar) => bar.value))}
                         tick={{ fontSize: 12 }}
                         stroke={themeColors.axis}
                         axisLine={false}

--- a/src/components/_pages/dashboard/DashboardItem/TimeSeriesChart.spec.tsx
+++ b/src/components/_pages/dashboard/DashboardItem/TimeSeriesChart.spec.tsx
@@ -56,6 +56,20 @@ test.describe('TimeSeriesChart', () => {
         await expect(page.getByTestId('landed-on-redirect')).toBeVisible();
     });
 
+    test('the y-axis labels counts as distinct whole numbers', async ({ mount }) => {
+        const component = await mount(
+            <TimeSeriesChartWithStore
+                title="Signings over Time"
+                data={{ '2026-06-18T00:00:00Z': 1, '2026-06-18T01:00:00Z': 2, '2026-06-18T02:00:00Z': 2 }}
+                entity={EntityType.SIGNING_RECORD}
+                redirect="/signingrecords"
+                onSetFilter={() => []}
+            />,
+        );
+        const ticks = component.locator('.recharts-yAxis-tick-labels .recharts-cartesian-axis-tick-value');
+        await expect(ticks).toHaveText(['0', '1', '2']);
+    });
+
     test('clicking empty plot space does not navigate', async ({ mount, page }) => {
         const component = await mount(
             <TimeSeriesChartNavHarness title="Signings over Time" data={data} entity={EntityType.SIGNING_RECORD} onSetFilter={() => []} />,

--- a/src/components/_pages/dashboard/DashboardItem/TimeSeriesChart.tsx
+++ b/src/components/_pages/dashboard/DashboardItem/TimeSeriesChart.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router';
 import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 import { SigningRecordStatisticsPeriod } from 'types/openapi';
 import type { SearchFilterModel } from 'types/certificate';
+import { countAxisDomain } from 'utils/chart-axis';
 import type { ColorOptions } from './DonutChart';
 
 const CHART_COLORS = {
@@ -138,7 +139,8 @@ function TimeSeriesChart({
                         tickLine={false}
                     />
                     <YAxis
-                        tickFormatter={(value: number) => String(Math.round(value))}
+                        allowDecimals={false}
+                        domain={countAxisDomain(chartData.map((point) => point.value))}
                         tick={{ fontSize: 12 }}
                         stroke={colors.axis}
                         axisLine={false}

--- a/src/utils/chart-axis.spec.ts
+++ b/src/utils/chart-axis.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { AXIS_TICK_COUNT, countAxisDomain } from './chart-axis';
+
+describe('countAxisDomain', () => {
+    it('pins the top to the highest count while recharts would subdivide into fractions', () => {
+        expect(countAxisDomain([1, 2, 2])).toEqual([0, 2]);
+        expect(countAxisDomain([0, 3, 1])).toEqual([0, 3]);
+        expect(countAxisDomain([4])).toEqual([0, 4]);
+    });
+
+    it('leaves the top automatic once the counts are high enough to tick in whole numbers', () => {
+        expect(countAxisDomain([AXIS_TICK_COUNT])).toEqual([0, 'auto']);
+        expect(countAxisDomain([3, 12, 7])).toEqual([0, 'auto']);
+    });
+
+    it('spans a single step when there is nothing to plot', () => {
+        expect(countAxisDomain([])).toEqual([0, 1]);
+        expect(countAxisDomain([0, 0])).toEqual([0, 1]);
+    });
+
+    it('ignores counts below zero, which no count can be', () => {
+        expect(countAxisDomain([-4, 2])).toEqual([0, 2]);
+    });
+
+    it('rounds a fractional maximum up to the whole number above it', () => {
+        expect(countAxisDomain([1.2])).toEqual([0, 2]);
+    });
+});

--- a/src/utils/chart-axis.ts
+++ b/src/utils/chart-axis.ts
@@ -1,0 +1,20 @@
+/**
+ * The number of ticks recharts aims for on a value axis. Its automatic domain is only divided into
+ * whole-number steps once the domain spans at least this many of them.
+ */
+export const AXIS_TICK_COUNT = 5;
+
+/**
+ * The domain a count axis should span, given the counts plotted on it.
+ *
+ * Counts are whole numbers, so the axis over them must not be divided into fractions: formatting
+ * fractional ticks as integers collapses them into duplicate labels, turning a maximum of two into
+ * `0 1 1 2 2`. Recharts divides a wide enough automatic domain into whole numbers on its own, so
+ * only the small maxima need their top pinned — which also keeps the plot filling the widget
+ * instead of trailing along the bottom of a rounded-up ceiling.
+ */
+export const countAxisDomain = (values: readonly number[]): [number, number | 'auto'] => {
+    const max = Math.ceil(Math.max(0, ...values));
+
+    return max < AXIS_TICK_COUNT ? [0, Math.max(1, max)] : [0, 'auto'];
+};


### PR DESCRIPTION
## Summary

The **Signings over time** chart rendered duplicate Y-axis labels for low signing counts — a maximum of two showed as `0, 1, 1, 2, 2`.

Recharts divides a small automatic domain into fractional ticks (`0, 0.5, 1, 1.5, 2`), and the axis formatted those ticks as integers, collapsing them into repeated labels.

## Changes

- Added `countAxisDomain` in `src/utils/chart-axis.ts`, which pins an axis top to the highest count while the domain is too narrow for recharts to step in whole numbers.
- The signings time-series axis and the horizontal bar chart's count axis now set `allowDecimals={false}` and take their domain from that helper. Both dropped the rounding `tickFormatter` that produced the duplicates.
- Documented the count-axis rule in `CLAUDE.md`.

Closes #2062
