### PR TITLE
Settle an empty list instead of refetching it forever

### DIFF
--- a/src/components/PagedList/PagedList.tsx
+++ b/src/components/PagedList/PagedList.tsx
@@ -173,6 +173,7 @@ function PagedList<TRow extends object>({
 
     const [confirmDelete, setConfirmDelete] = useState(false);
     const hasLoadedOnce = useRef(false);
+    const hasFetchStarted = useRef(false);
 
     const onCheckedRowsChanged = useCallback(
         (rows: (string | number)[]) => {
@@ -181,27 +182,32 @@ function PagedList<TRow extends object>({
         [dispatch, entity],
     );
 
-    const getFreshData = useCallback(() => {
-        onListCallback(
+    const listRequest = useMemo(
+        () =>
             buildListRequest(
                 { itemsPerPage: pageSize, pageNumber: effectivePageNumber, filters: currentFilters },
                 isColumnDriven ? appliedColumns : undefined,
                 appliedSort,
             ),
-        );
+        [currentFilters, pageSize, effectivePageNumber, isColumnDriven, appliedColumns, appliedSort],
+    );
+
+    /**
+     * The fetch is keyed on the request it will send rather than on the values it was built from.
+     * Merging the catalogue's sort capability rebuilds the column objects without changing a byte of
+     * the request — `toRequestColumns` carries only the source and identifier — so depending on the
+     * columns would list a second time for the same request. `listRequestRef` holds the value the
+     * snapshot stands for, and `refreshToken` is read for its identity alone: a change to it means
+     * the page asked to send this same request again.
+     */
+    const listRequestSnapshot = useMemo(() => JSON.stringify(listRequest), [listRequest]);
+    const listRequestRef = useRef(listRequest);
+    listRequestRef.current = listRequest;
+
+    const getFreshData = useCallback(() => {
+        onListCallback(listRequestRef.current);
         onCheckedRowsChanged([]);
-    }, [
-        currentFilters,
-        pageSize,
-        effectivePageNumber,
-        onListCallback,
-        onCheckedRowsChanged,
-        isColumnDriven,
-        appliedColumns,
-        appliedSort,
-        // Read for its identity alone: a change means the page asked to refetch this request.
-        refreshToken,
-    ]);
+    }, [listRequestSnapshot, onListCallback, onCheckedRowsChanged, refreshToken]);
 
     const onPageSizeChanged = useCallback(
         (pageSize: number) => {
@@ -288,7 +294,12 @@ function PagedList<TRow extends object>({
         [isColumnDriven, columnsRows, getRowId, registry, rowOptions, appliedColumns, data],
     );
 
-    if (!isFetchingList && columnRows.length > 0) hasLoadedOnce.current = true;
+    if (isFetchingList) hasFetchStarted.current = true;
+
+    // A finished fetch counts as loaded even when it returned nothing: an empty list that fell back to
+    // the skeleton on every fetch would unmount the filter widget, whose remount re-reads the
+    // catalogue and lists again, and the page would never settle.
+    if (!isFetchingList && (columnRows.length > 0 || hasFetchStarted.current)) hasLoadedOnce.current = true;
 
     useEffect(() => {
         if (listedFiltersSnapshot === currentFiltersSnapshot) return;

--- a/src/components/PagedList/PagedList.unit.spec.tsx
+++ b/src/components/PagedList/PagedList.unit.spec.tsx
@@ -4,6 +4,7 @@ import { createRoot, type Root } from 'react-dom/client';
 
 import PagedList from './PagedList';
 import { EntityType } from 'ducks/filters';
+import { FilterFieldSource, Resource } from 'types/openapi';
 
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -29,6 +30,7 @@ vi.mock('react-router', () => ({
 
 vi.mock('components/FilterWidget', () => ({
     default: ({ title }: any) => <div data-testid="filter-widget">{title}</div>,
+    FilterWidgetSkeleton: ({ title }: any) => <div data-testid="filter-widget-skeleton">{title}</div>,
 }));
 
 vi.mock('components/Widget', () => ({
@@ -454,6 +456,65 @@ describe('PagedList unit coverage', () => {
 
         const dialog = container.querySelector('[data-testid="dialog"]') as HTMLElement;
         expect(dialog.textContent).toContain('CBOM');
+    });
+
+    it('keeps the loaded table mounted while an empty list refetches', async () => {
+        const paging = mockState.pagings.pagings[0].paging;
+        paging.totalItems = 0;
+        paging.isFetchingList = true;
+
+        await renderPagedList({ data: [], getAvailableFiltersApi: vi.fn() });
+        expect(container.querySelector('[data-testid="table"]')).toBeNull();
+
+        paging.isFetchingList = false;
+        await renderPagedList({ data: [], getAvailableFiltersApi: vi.fn() });
+        expect(container.querySelector('[data-testid="table"]')).toBeTruthy();
+
+        paging.isFetchingList = true;
+        await renderPagedList({ data: [], getAvailableFiltersApi: vi.fn() });
+
+        expect(container.querySelector('[data-testid="table"]')).toBeTruthy();
+        expect(container.querySelector('[data-testid="filter-widget"]')).toBeTruthy();
+    });
+
+    it('does not list again when the filter catalogue is re-read', async () => {
+        const onListCallback = vi.fn();
+        const filter = mockState.filters.filters[0].filter;
+
+        await renderPagedList({ onListCallback, getAvailableFiltersApi: vi.fn() });
+        expect(onListCallback).toHaveBeenCalledTimes(1);
+
+        filter.availableFilters = [];
+        await renderPagedList({ onListCallback, getAvailableFiltersApi: vi.fn() });
+
+        expect(onListCallback).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not list again when the catalogue makes a column-driven page sortable', async () => {
+        const onListCallback = vi.fn();
+        const filter = mockState.filters.filters[0].filter;
+
+        // A page ships its column set without sort flags, exactly as the certificate and key
+        // inventories do, so merging the catalogue rebuilds every column object.
+        const configurableColumns = {
+            resource: Resource.Certificates,
+            standardColumns: [{ fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME', catalogueLabel: 'Common Name' }],
+            rows: [],
+            getRowId: (row: any) => row.uuid,
+        };
+
+        await renderPagedList({ onListCallback, configurableColumns, data: undefined, headers: undefined });
+        expect(onListCallback).toHaveBeenCalledTimes(1);
+
+        filter.availableFilters = [
+            {
+                filterFieldSource: FilterFieldSource.Property,
+                searchFieldData: [{ fieldIdentifier: 'COMMON_NAME', fieldLabel: 'Common Name', sortable: true, displayable: true }],
+            },
+        ];
+        await renderPagedList({ onListCallback, configurableColumns, data: undefined, headers: undefined });
+
+        expect(onListCallback).toHaveBeenCalledTimes(1);
     });
 
     it('uses plural entity name in dialog when multiple rows are selected', async () => {


### PR DESCRIPTION
Every list page whose result set was empty re-issued its listing request, its searchable-fields request and its saved-views request without end, and the page visibly blinked. Creating one record stopped it. Reported on TSP Profiles and Signing Records; the cause is in the shared list host, so all 21 pages built on `PagedList` were affected whenever they were empty.

## The loop

1. With zero rows, `hasLoadedOnce` never latched, so every fetch took the early return that renders `PagedListSkeleton` — which unmounts `FilterWidget` and `ViewTabs`.
2. `FilterWidget`'s mount effect re-dispatched `getAvailableFilters`.
3. `getAvailableFiltersSuccess` assigns a fresh `availableFilters` array, changing the `catalogue` identity.
4. `catalogue` flows through `sortableStandardColumns` → `appliedColumns` → `getFreshData`, so the callback was rebuilt.
5. `useEffect(() => getFreshData(), [getFreshData])` listed again, showing the skeleton — back to step 1.

A non-empty list broke the chain because `hasLoadedOnce` latched on the first loaded row, the skeleton stopped replacing the tree, and the filter widget stayed mounted.

## Changes

**A finished fetch counts as loaded whatever it returned.** This breaks the cycle: the skeleton can no longer replace a loaded page, so nothing remounts to re-read the catalogue. An empty list that refetches now shows the table's own loading state, the same treatment a non-empty list already got.

**The fetch is keyed on the request it will send, not on the values it was built from.** Merging the catalogue's sort capability rebuilds every column object, but `toRequestColumns` carries only the field source and identifier, so the request is unchanged — and a column-driven page therefore listed twice for one request on every catalogue read. Keying on the serialized request makes that structural rather than dependent on which sort flags a page's shipped column set happens to declare.

## Tests

Three unit tests, each verified to fail without the change: the table stays mounted while an empty list refetches, a catalogue re-read does not list again, and a catalogue re-read that makes a column-driven page's columns sortable does not list again either.

`npm run test:vitest` (4156 tests), `npm run typecheck` and `biome check` pass. The Playwright CT suites for `PagedList`, `FilterWidget` and `ViewTabs` pass (149 tests, chromium).

Closes #2120