### PR TITLE
Read the filter catalogue once per list visit

### DIFF
--- a/src/components/PagedList/PagedList.tsx
+++ b/src/components/PagedList/PagedList.tsx
@@ -174,6 +174,9 @@ function PagedList<TRow extends object>({
     const [confirmDelete, setConfirmDelete] = useState(false);
     const hasLoadedOnce = useRef(false);
     const hasFetchStarted = useRef(false);
+    // State rather than a ref like its neighbours above: releasing the skeleton has to re-render, and
+    // a page whose request never reaches the paging duck would otherwise sit on it for good.
+    const [hasRequested, setHasRequested] = useState(false);
 
     const onCheckedRowsChanged = useCallback(
         (rows: (string | number)[]) => {
@@ -319,6 +322,7 @@ function PagedList<TRow extends object>({
 
     useEffect(() => {
         getFreshData();
+        setHasRequested(true);
     }, [getFreshData]);
 
     const buttons: WidgetButtonProps[] = useMemo(() => {
@@ -373,7 +377,10 @@ function PagedList<TRow extends object>({
         [effectivePageNumber, totalItems, pageSize],
     );
 
-    if (isFetchingList && columnRows.length === 0 && !hasLoadedOnce.current) {
+    // `!hasRequested` holds the skeleton over the render that precedes the effect above. Painting the
+    // real page there mounts the filter widget, which reads the catalogue, only for the request that
+    // effect sends to replace the page with this skeleton and read it again on the way back.
+    if (columnRows.length === 0 && !hasLoadedOnce.current && (isFetchingList || !hasRequested)) {
         const estimatedButtonCount = (addHidden ? 0 : 1) + (onDeleteCallback ? 1 : 0) + (additionalButtons?.length ?? 0);
         return (
             <PagedListSkeleton

--- a/src/components/PagedList/PagedList.tsx
+++ b/src/components/PagedList/PagedList.tsx
@@ -176,7 +176,7 @@ function PagedList<TRow extends object>({
     const hasFetchStarted = useRef(false);
     // State rather than a ref like its neighbours above: releasing the skeleton has to re-render, and
     // a page whose request never reaches the paging duck would otherwise sit on it for good.
-    const [hasRequested, setHasRequested] = useState(false);
+    const [hasSentFirstRequest, setHasSentFirstRequest] = useState(false);
 
     const onCheckedRowsChanged = useCallback(
         (rows: (string | number)[]) => {
@@ -322,7 +322,7 @@ function PagedList<TRow extends object>({
 
     useEffect(() => {
         getFreshData();
-        setHasRequested(true);
+        setHasSentFirstRequest(true);
     }, [getFreshData]);
 
     const buttons: WidgetButtonProps[] = useMemo(() => {
@@ -377,10 +377,14 @@ function PagedList<TRow extends object>({
         [effectivePageNumber, totalItems, pageSize],
     );
 
-    // `!hasRequested` holds the skeleton over the render that precedes the effect above. Painting the
-    // real page there mounts the filter widget, which reads the catalogue, only for the request that
-    // effect sends to replace the page with this skeleton and read it again on the way back.
-    if (columnRows.length === 0 && !hasLoadedOnce.current && (isFetchingList || !hasRequested)) {
+    // Holds the skeleton over the render that precedes the listing effect. Painting the real page
+    // there mounts the filter widget, and the request that effect sends unmounts it again — the
+    // remount re-read described in the note on `hasLoadedOnce`. Mounting once instead delays the
+    // widget's catalogue read and the view strip's `listViews` read by a round trip, accepted at the
+    // cost of a pinned view reaching the table a paint after the standard columns.
+    const isAwaitingFirstPage = columnRows.length === 0 && !hasLoadedOnce.current && (isFetchingList || !hasSentFirstRequest);
+
+    if (isAwaitingFirstPage) {
         const estimatedButtonCount = (addHidden ? 0 : 1) + (onDeleteCallback ? 1 : 0) + (additionalButtons?.length ?? 0);
         return (
             <PagedListSkeleton

--- a/src/components/PagedList/PagedList.unit.spec.tsx
+++ b/src/components/PagedList/PagedList.unit.spec.tsx
@@ -466,7 +466,7 @@ describe('PagedList unit coverage', () => {
         expect(dialog.textContent).toContain('CBOM');
     });
 
-    it('gives up the skeleton even when the listing request never marks itself in flight', async () => {
+    it('releases the skeleton with no store update behind it, so the flag cannot be a ref', async () => {
         mockState.pagings.pagings[0].paging.totalItems = 0;
 
         await renderPagedList({ data: [], onListCallback: vi.fn(), getAvailableFiltersApi: vi.fn() });

--- a/src/components/PagedList/PagedList.unit.spec.tsx
+++ b/src/components/PagedList/PagedList.unit.spec.tsx
@@ -1,4 +1,4 @@
-import { act } from 'react';
+import { act, useEffect } from 'react';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { createRoot, type Root } from 'react-dom/client';
 
@@ -28,8 +28,15 @@ vi.mock('react-router', () => ({
     useLocation: () => ({ pathname: mockPathname }),
 }));
 
+const filterWidget = vi.hoisted(() => ({ mounts: 0 }));
+
 vi.mock('components/FilterWidget', () => ({
-    default: ({ title }: any) => <div data-testid="filter-widget">{title}</div>,
+    default: ({ title }: any) => {
+        useEffect(() => {
+            filterWidget.mounts += 1;
+        }, []);
+        return <div data-testid="filter-widget">{title}</div>;
+    },
     FilterWidgetSkeleton: ({ title }: any) => <div data-testid="filter-widget-skeleton">{title}</div>,
 }));
 
@@ -141,6 +148,7 @@ describe('PagedList unit coverage', () => {
         dispatch = vi.fn();
         navigate = vi.fn();
         mockPathname = '/test-list';
+        filterWidget.mounts = 0;
         useDispatchMock.mockReturnValue(dispatch);
         useNavigateMock.mockReturnValue(navigate);
 
@@ -456,6 +464,35 @@ describe('PagedList unit coverage', () => {
 
         const dialog = container.querySelector('[data-testid="dialog"]') as HTMLElement;
         expect(dialog.textContent).toContain('CBOM');
+    });
+
+    it('gives up the skeleton even when the listing request never marks itself in flight', async () => {
+        mockState.pagings.pagings[0].paging.totalItems = 0;
+
+        await renderPagedList({ data: [], onListCallback: vi.fn(), getAvailableFiltersApi: vi.fn() });
+
+        expect(container.querySelector('[data-testid="table"]')).toBeTruthy();
+        expect(container.querySelector('[data-testid="filter-widget"]')).toBeTruthy();
+    });
+
+    it('mounts the filter widget once across a page load, so the catalogue is read once', async () => {
+        const paging = mockState.pagings.pagings[0].paging;
+        paging.totalItems = 0;
+
+        // Stands in for the listing epic, which dispatches the in-flight marker synchronously with
+        // the request. Each render below is one the store would have driven.
+        const onListCallback = vi.fn(() => {
+            paging.isFetchingList = true;
+        });
+        const props = { data: [], onListCallback, getAvailableFiltersApi: vi.fn() };
+
+        await renderPagedList(props);
+        await renderPagedList(props);
+
+        paging.isFetchingList = false;
+        await renderPagedList(props);
+
+        expect(filterWidget.mounts).toBe(1);
     });
 
     it('keeps the loaded table mounted while an empty list refetches', async () => {


### PR DESCRIPTION
Opening any list page reads the resource's searchable fields twice. `PagedList` painted the real page on its first render, before its own effect had sent the listing request: `FilterWidget` mounted there and read the catalogue, then that request replaced the page with `PagedListSkeleton`, unmounting the widget, which read the catalogue again when it remounted on the way back.

The first paint was also a frame of the empty page before the skeleton replaced it — the same defect seen from the user's side rather than the network's.

This affects all 21 pages built on `PagedList`, empty or not.

## Change

Holding the skeleton until the first request has been sent leaves the widget to mount once, after the page has something to show.

The flag is state rather than a ref like its neighbours because releasing the skeleton has to re-render: a page whose request never reached the paging duck would sit on the skeleton for good behind a ref. No such page exists today — all 20 list entities dispatch `pagingActions.list` in the synchronous head of their epic's `switchMap`, across three shapes (`store.dispatch` as the first statement, `concat(of(...))`, and `startWith(...)`) — which is also why the skeleton carries straight through from the first paint to the response with no gap. The state costs no extra commit in production, since the store notification and this update fall in the same React batch.

The single mount now lands after the listing response, so the widget's catalogue read and `ViewTabs`' `listViews` read start a round trip later than before. Neither read gates anything the skeleton shows; the visible cost is that a user with a pinned view gets the standard columns painted first, since `ViewTabs` can only apply the pinned view once both reads have landed. The comment on the skeleton predicate records this. Starting either read from `PagedList` instead would not remove that cost on its own — the pinned view waits on both — and starting both would move the single-read guarantee from the widget's mount count to a `hasLoadedFilters` guard inside `FilterWidget`, changing catalogue freshness for its two consumers outside `PagedList`.

## Tests

Two unit tests:

- the filter widget mounts once across a page load, modelling the epic's synchronous in-flight marker and the renders the store would drive (2 mounts before the change, 1 after);
- the skeleton is released on a page whose listing request never marks itself in flight, with no store update behind the release — this pins the flag as state, since it fails if the flag is written as a ref.

`npm run test:vitest` (4160 tests), `npm run typecheck` and `biome check` pass. Playwright CT passes for `PagedList` (35 tests), and the full chromium suite was run on the first revision of this change since it alters first paint for every list page.

Closes #2122
