### PR TITLE
Drive the remaining five inventories from the configurable-column pipeline

### DIFF
--- a/src/components/PagedList/PagedList.tsx
+++ b/src/components/PagedList/PagedList.tsx
@@ -357,20 +357,22 @@ function PagedList<TRow extends object>({
         return result.sort((a, b) => (a.icon === 'plus' ? -1 : 1));
     }, [checkedRows, additionalButtons, navigate, addHidden, onDeleteCallback]);
 
-    // An applied ordering counts, or there would be no way back from it.
-    const hasNonDefaultViewState = currentFilters.length > 0 || pageNumber > 1 || pageSize !== 10 || appliedSort !== undefined;
+    // An ordering the page did not declare counts, or there would be no way back from it. Measured
+    // against `defaultSort` rather than against no ordering at all, so a page that opens sorted is not
+    // permanently offering to reset itself to the state it is already in.
+    const hasNonDefaultViewState = currentFilters.length > 0 || pageNumber > 1 || pageSize !== 10 || !isSameSort(appliedSort, defaultSort);
 
     const onResetView = useCallback(() => {
         dispatch(filterActions.setCurrentFilters({ entity, currentFilters: [] }));
         dispatch(filterActions.setPreservedFilters({ entity, preservedFilters: [] }));
         dispatch(actions.resetPaging({ entity }));
         // The columns stay: they belong to the tab the strip is on, and the strip offers Revert.
-        setSortSelection(undefined);
+        setSortSelection(defaultSort);
         const rootRoute = location.pathname.split('/')[1] ?? '';
         if (rootRoute) {
             dispatch(tablePaginationActions.clearPaginationByRootRoute({ rootRoute }));
         }
-    }, [dispatch, entity, location.pathname]);
+    }, [dispatch, entity, location.pathname, defaultSort]);
 
     const paginationData = useMemo(
         () => ({
@@ -406,6 +408,7 @@ function PagedList<TRow extends object>({
                     catalogue={catalogue}
                     isCatalogueLoaded={hasLoadedCatalogue}
                     standardColumns={sortableStandardColumns}
+                    standardSort={defaultSort}
                     renderableProperties={renderableProperties}
                     columns={appliedColumns}
                     filters={currentFilters}

--- a/src/components/PagedList/PagedList.tsx
+++ b/src/components/PagedList/PagedList.tsx
@@ -24,6 +24,7 @@ import {
     toColumnSortFromHeader,
     toDisplayableSort,
     withCatalogueSortability,
+    withDeclaredSortability,
 } from './columnState';
 import PagedListSkeleton from './PagedListSkeleton';
 import type { IconName } from 'types/icons';
@@ -131,9 +132,6 @@ function PagedList<TRow extends object>({
     const catalogue = useSelector(filterSelectors.availableFilters(entity));
     const hasLoadedCatalogue = useSelector(filterSelectors.hasLoadedFilters(entity));
 
-    const [columnSelection, setColumnSelection] = useState<ColumnDefinition[]>(NO_COLUMNS);
-    const [sortSelection, setSortSelection] = useState<ColumnSort | undefined>(configurableColumns?.defaultSort);
-
     // Taken apart rather than depended on whole: an unmemoised config would rebuild `getFreshData`
     // every render, and the effect watching it would refetch forever.
     const isColumnDriven = configurableColumns !== undefined;
@@ -146,13 +144,20 @@ function PagedList<TRow extends object>({
         rowOptions,
         headerInfo,
         resourceLabel,
+        defaultSort,
     } = configurableColumns ?? ({} as Partial<ConfigurableColumns<TRow>>);
+
+    const [columnSelection, setColumnSelection] = useState<ColumnDefinition[]>(NO_COLUMNS);
+    const [sortSelection, setSortSelection] = useState<ColumnSort | undefined>(defaultSort);
 
     const renderableProperties = useMemo(() => getRenderableProperties(registry), [registry]);
 
     const sortableStandardColumns = useMemo(
-        () => (hasLoadedCatalogue ? withCatalogueSortability(standardColumns ?? NO_COLUMNS, catalogue) : (standardColumns ?? NO_COLUMNS)),
-        [hasLoadedCatalogue, standardColumns, catalogue],
+        () =>
+            hasLoadedCatalogue
+                ? withCatalogueSortability(standardColumns ?? NO_COLUMNS, catalogue)
+                : withDeclaredSortability(standardColumns ?? NO_COLUMNS, defaultSort),
+        [hasLoadedCatalogue, standardColumns, catalogue, defaultSort],
     );
 
     // Holds only the deviation and falls back, so a config arriving after the first render cannot

--- a/src/components/PagedList/PagedList.tsx
+++ b/src/components/PagedList/PagedList.tsx
@@ -48,6 +48,11 @@ export interface ConfigurableColumns<TRow extends object> {
     rowOptions?: (row: TRow) => TableDataRow['options'];
     headerInfo?: Readonly<Record<string, ReactNode>>;
     resourceLabel?: string;
+    /**
+     * The ordering the page opens on. A page that sorted client-side before it was column-driven has to name it here,
+     * because a column-driven table hands sorting to the server and would otherwise open in API order.
+     */
+    defaultSort?: ColumnSort;
 }
 
 type Props<TRow extends object> = {
@@ -127,7 +132,7 @@ function PagedList<TRow extends object>({
     const hasLoadedCatalogue = useSelector(filterSelectors.hasLoadedFilters(entity));
 
     const [columnSelection, setColumnSelection] = useState<ColumnDefinition[]>(NO_COLUMNS);
-    const [sortSelection, setSortSelection] = useState<ColumnSort | undefined>(undefined);
+    const [sortSelection, setSortSelection] = useState<ColumnSort | undefined>(configurableColumns?.defaultSort);
 
     // Taken apart rather than depended on whole: an unmemoised config would rebuild `getFreshData`
     // every render, and the effect watching it would refetch forever.

--- a/src/components/PagedList/PagedList.unit.spec.tsx
+++ b/src/components/PagedList/PagedList.unit.spec.tsx
@@ -542,6 +542,40 @@ describe('PagedList unit coverage', () => {
         );
     });
 
+    it('names the page default ordering before the catalogue has been read', async () => {
+        const onListCallback = vi.fn();
+        const configurableColumns = {
+            resource: Resource.Certificates,
+            standardColumns: [{ fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME', catalogueLabel: 'Common Name' }],
+            rows: [],
+            getRowId: (row: any) => row.uuid,
+            defaultSort: { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME', direction: 'asc' as const },
+        };
+        const filter = mockState.filters.filters[0].filter;
+        filter.hasLoadedFilters = false;
+        filter.availableFilters = [];
+
+        await renderPagedList({ onListCallback, configurableColumns, data: undefined, headers: undefined });
+
+        expect(onListCallback).toHaveBeenCalledWith(
+            expect.objectContaining({
+                sort: { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME', direction: 'asc' },
+            }),
+        );
+
+        // The catalogue agrees, so the request it was already sending stands and no second listing follows.
+        filter.hasLoadedFilters = true;
+        filter.availableFilters = [
+            {
+                filterFieldSource: FilterFieldSource.Property,
+                searchFieldData: [{ fieldIdentifier: 'COMMON_NAME', fieldLabel: 'Common Name', sortable: true, displayable: true }],
+            },
+        ];
+        await renderPagedList({ onListCallback, configurableColumns, data: undefined, headers: undefined });
+
+        expect(onListCallback).toHaveBeenCalledTimes(1);
+    });
+
     it('uses plural entity name in dialog when multiple rows are selected', async () => {
         mockState.pagings.pagings[0].paging.checkedRows = ['row-1', 'row-2'];
         await renderPagedList({ addHidden: true, onDeleteCallback: vi.fn() });

--- a/src/components/PagedList/PagedList.unit.spec.tsx
+++ b/src/components/PagedList/PagedList.unit.spec.tsx
@@ -517,6 +517,31 @@ describe('PagedList unit coverage', () => {
         expect(onListCallback).toHaveBeenCalledTimes(1);
     });
 
+    it('names the page default ordering in the first listing request', async () => {
+        const onListCallback = vi.fn();
+        const configurableColumns = {
+            resource: Resource.Certificates,
+            standardColumns: [{ fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME', catalogueLabel: 'Common Name' }],
+            rows: [],
+            getRowId: (row: any) => row.uuid,
+            defaultSort: { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME', direction: 'asc' as const },
+        };
+        mockState.filters.filters[0].filter.availableFilters = [
+            {
+                filterFieldSource: FilterFieldSource.Property,
+                searchFieldData: [{ fieldIdentifier: 'COMMON_NAME', fieldLabel: 'Common Name', sortable: true, displayable: true }],
+            },
+        ];
+
+        await renderPagedList({ onListCallback, configurableColumns, data: undefined, headers: undefined });
+
+        expect(onListCallback).toHaveBeenCalledWith(
+            expect.objectContaining({
+                sort: { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME', direction: 'asc' },
+            }),
+        );
+    });
+
     it('uses plural entity name in dialog when multiple rows are selected', async () => {
         mockState.pagings.pagings[0].paging.checkedRows = ['row-1', 'row-2'];
         await renderPagedList({ addHidden: true, onDeleteCallback: vi.fn() });

--- a/src/components/PagedList/PagedListColumns.spec.tsx
+++ b/src/components/PagedList/PagedListColumns.spec.tsx
@@ -83,6 +83,16 @@ const listRequests = async (page: Page): Promise<SearchRequestModel[]> =>
 
 const lastRequest = async (page: Page): Promise<SearchRequestModel | undefined> => (await listRequests(page)).at(-1);
 
+/** The ordering of every request so far, so a later one dropping it cannot pass unnoticed. */
+const requestSorts = async (page: Page): Promise<Array<SearchRequestModel['sort']>> =>
+    (await listRequests(page)).map((request) => request.sort);
+
+const commonNameAsc = {
+    fieldSource: FilterFieldSource.Property,
+    fieldIdentifier: 'COMMON_NAME',
+    direction: SortDirection.Asc,
+};
+
 /** The displayed columns, by header id: a heading's text carries legends and the checkbox has none. */
 const headings = async (page: Page): Promise<string[]> => {
     const ids = await page.locator('thead th[data-id]').evaluateAll((cells) => cells.map((cell) => cell.getAttribute('data-id') ?? ''));
@@ -363,6 +373,49 @@ test.describe('PagedList · configurable columns', () => {
         await page.getByRole('tab', { name: 'Standard' }).click();
 
         await expect(page.getByTestId('current-filters')).not.toContainText('from-a-deep-link');
+    });
+
+    /**
+     * The declared ordering has to survive the Standard view opening over it. The strip waits for its
+     * view list and the catalogue, then applies a slice — so an ordering the first render merely held
+     * is cleared a moment after the page appears, and the inventory lists in API order.
+     */
+    test('keeps the page default ordering when the Standard view opens over it', async ({ mount, page }) => {
+        await mount(
+            <PagedListColumnsWithStore rows={rows} standardColumns={standardColumns} catalogue={catalogue} defaultSort={commonNameAsc} />,
+        );
+
+        // The summary bar first: it names the ordering the table settled on, so the request assertion
+        // below cannot pass on the pre-strip render and miss a clear that arrives a tick later.
+        await expect(page.getByTestId('view-tabs-summary-sort')).toContainText('Sorted by Common Name');
+
+        await expect.poll(() => requestSorts(page)).toEqual([commonNameAsc]);
+    });
+
+    test('restores the page default ordering when the view is reset, rather than clearing it', async ({ mount, page }) => {
+        await mount(
+            <PagedListColumnsWithStore rows={rows} standardColumns={standardColumns} catalogue={catalogue} defaultSort={commonNameAsc} />,
+        );
+        await expect(page.getByRole('tab', { name: 'Standard' })).toBeVisible();
+
+        await page.getByRole('button', { name: 'Expires At' }).click();
+        await expect.poll(async () => (await lastRequest(page))?.sort?.fieldIdentifier).toBe('NOT_AFTER');
+
+        await page.getByTestId('reset-view-icon').click();
+
+        await expect.poll(async () => (await lastRequest(page))?.sort).toEqual(commonNameAsc);
+    });
+
+    /** The declared ordering is the page's resting state, so neither surface may report it as a deviation. */
+    test('reports a page under its declared ordering as untouched, offering neither reset nor save', async ({ mount, page }) => {
+        await mount(
+            <PagedListColumnsWithStore rows={rows} standardColumns={standardColumns} catalogue={catalogue} defaultSort={commonNameAsc} />,
+        );
+
+        await expect(page.getByTestId('view-tabs-summary-sort')).toContainText('Sorted by Common Name');
+
+        await expect(page.getByTestId('view-tabs-summary-unsaved')).toHaveCount(0);
+        await expect(page.getByTestId('reset-view-icon')).toHaveCount(0);
     });
 
     test('refetches its own request, columns and ordering included, when the page asks for a refresh', async ({ mount, page }) => {

--- a/src/components/PagedList/PagedListColumnsWithStore.tsx
+++ b/src/components/PagedList/PagedListColumnsWithStore.tsx
@@ -10,6 +10,7 @@ import type { SearchFieldListModel, SearchFilterModel, SearchRequestModel } from
 import type { ListViewModel } from 'types/listViews';
 import { FilterFieldSource, Resource } from 'types/openapi';
 import type { ColumnDefinition } from 'types/tableColumns';
+import type { ColumnSort } from 'utils/tableColumns';
 import { createMockStore } from 'utils/test-helpers';
 import PagedList from './PagedList';
 
@@ -25,6 +26,8 @@ type Props = Readonly<{
     standardColumns: ColumnDefinition[];
     catalogue: SearchFieldListModel[];
     views?: ListViewModel[];
+    /** The ordering the page declares as its own, as the connector and discovery inventories do. */
+    defaultSort?: ColumnSort;
     withheldCatalogue?: boolean;
     /** Filters already in the duck when the host mounts, as a deep link leaves them. */
     initialFilters?: SearchFilterModel[];
@@ -88,6 +91,7 @@ export default function PagedListColumnsWithStore({
     standardColumns,
     catalogue,
     views = [],
+    defaultSort,
     withheldCatalogue = false,
     initialFilters = [],
     withRefreshControl = false,
@@ -149,9 +153,10 @@ export default function PagedListColumnsWithStore({
                       registry,
                       headerInfo: { [`${FilterFieldSource.Property}:COMMON_NAME`]: <span data-testid="cn-legend">legend</span> },
                       resourceLabel: 'Certificates',
+                      defaultSort,
                   }
                 : undefined,
-        [configReady, standardColumns, rows],
+        [configReady, standardColumns, rows, defaultSort],
     );
 
     return (

--- a/src/components/PagedList/columnState.spec.ts
+++ b/src/components/PagedList/columnState.spec.ts
@@ -9,6 +9,7 @@ import {
     toColumnSortFromHeader,
     toDisplayableSort,
     withCatalogueSortability,
+    withDeclaredSortability,
 } from './columnState';
 
 const columns: ColumnDefinition[] = [
@@ -245,5 +246,41 @@ describe('withCatalogueSortability', () => {
 
         expect(merged[0]).toBe(standard[0]);
         expect(merged[1]).toBe(standard[1]);
+    });
+});
+
+describe('withDeclaredSortability', () => {
+    const standard: ColumnDefinition[] = [
+        { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'CONNECTOR_NAME', catalogueLabel: 'Name' },
+        { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'CONNECTOR_URL', catalogueLabel: 'URL' },
+    ];
+    const sort = { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'CONNECTOR_NAME', direction: SortDirection.Asc };
+
+    it('marks the column the page declared its ordering on as sortable', () => {
+        expect(withDeclaredSortability(standard, sort)[0].sortable).toBe(true);
+    });
+
+    it('leaves every other column alone', () => {
+        expect(withDeclaredSortability(standard, sort)[1]).toBe(standard[1]);
+    });
+
+    it('keeps the display properties the page shipped', () => {
+        const shipped: ColumnDefinition[] = [{ ...standard[0], align: 'center', label: 'Connector' }];
+
+        expect(withDeclaredSortability(shipped, sort)[0]).toEqual({ ...shipped[0], sortable: true });
+    });
+
+    it('returns the same set when the page declared no ordering', () => {
+        expect(withDeclaredSortability(standard, undefined)).toBe(standard);
+    });
+
+    it('marks nothing when the declared ordering names no shipped column', () => {
+        const missing = { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'CONNECTOR_STATUS', direction: SortDirection.Asc };
+
+        expect(withDeclaredSortability(standard, missing).some((column) => column.sortable === true)).toBe(false);
+    });
+
+    it('keeps the declared ordering displayable, so the first listing request carries it', () => {
+        expect(toDisplayableSort(sort, withDeclaredSortability(standard, sort))).toEqual(sort);
     });
 });

--- a/src/components/PagedList/columnState.ts
+++ b/src/components/PagedList/columnState.ts
@@ -60,6 +60,20 @@ export function withCatalogueSortability(
 }
 
 /**
+ * A platform column set with the page's own declared ordering marked sortable. The catalogue is the authority on
+ * sortability, but it arrives after the first render, and until it does no column carries the flag — so
+ * `toDisplayableSort` would drop the declared ordering and the first listing request would go out in API order, to be
+ * corrected by a second one. A page naming a `defaultSort` asserts the API can order by that column, which is the same
+ * assertion its static column set already makes; the catalogue still overrules it once read.
+ */
+export function withDeclaredSortability(columns: ColumnDefinition[], sort: ColumnSort | undefined): ColumnDefinition[] {
+    if (!sort) return columns;
+
+    const key = getSortKey(sort);
+    return columns.map((column) => (getColumnKey(column) === key && column.sortable !== true ? { ...column, sortable: true } : column));
+}
+
+/**
  * The listing request for a page state. `columns` and `sort` are spread in only when they carry
  * something, so a request with neither is byte-identical to one written before the contract had them.
  */

--- a/src/components/ViewTabs/index.tsx
+++ b/src/components/ViewTabs/index.tsx
@@ -50,6 +50,11 @@ export type ViewTabsProps = Readonly<{
     isCatalogueLoaded?: boolean;
     /** The platform default column set for this page, which is what the Standard tab shows. */
     standardColumns: ColumnDefinition[];
+    /**
+     * The ordering the Standard tab lists under, i.e. the page's declared default. Part of Standard,
+     * so returning to the tab restores it and a page opening on it is not reported as drifted.
+     */
+    standardSort?: ColumnSort;
     /** The column keys the page has a cell renderer for; gates a stored view's columns and the picker. */
     renderableProperties?: ReadonlySet<string>;
     /** The columns the table is showing, which a saved view may since have drifted from. */
@@ -85,6 +90,7 @@ export default function ViewTabs({
     catalogue,
     isCatalogueLoaded,
     standardColumns,
+    standardSort,
     renderableProperties,
     columns,
     filters,
@@ -142,11 +148,11 @@ export default function ViewTabs({
      * offering a Save that changes nothing.
      */
     const storedSlice = useMemo(() => {
-        if (!activeView) return toStandardSlice(standardColumns);
+        if (!activeView) return toStandardSlice(standardColumns, standardSort);
 
         const slice = toViewSlice(activeView, fields, standardColumns);
         return { ...slice, filters: toStorableFilters(slice.filters, catalogue) };
-    }, [activeView, fields, standardColumns, catalogue]);
+    }, [activeView, fields, standardColumns, standardSort, catalogue]);
 
     /** The stored columns this table cannot render, which the notice names and the picker can remove. */
     const unavailable = useMemo(() => resolved?.columns.filter((column) => !column.available) ?? [], [resolved]);
@@ -182,9 +188,9 @@ export default function ViewTabs({
 
     const apply = useCallback(
         (view: ListViewModel | undefined) => {
-            applyRef.current(view ? toViewSlice(view, fields, standardColumns) : toStandardSlice(standardColumns));
+            applyRef.current(view ? toViewSlice(view, fields, standardColumns) : toStandardSlice(standardColumns, standardSort));
         },
-        [fields, standardColumns],
+        [fields, standardColumns, standardSort],
     );
 
     const select = useCallback(
@@ -210,10 +216,10 @@ export default function ViewTabs({
         setActiveId(initial);
         applyRef.current(
             initial === STANDARD_VIEW_ID
-                ? toStandardSlice(standardColumns)
+                ? toStandardSlice(standardColumns, standardSort)
                 : toViewSlice(views.find((view) => view.uuid === initial) as ListViewModel, fields, standardColumns),
         );
-    }, [resource, isReady, views, fields, standardColumns]);
+    }, [resource, isReady, views, fields, standardColumns, standardSort]);
 
     // The tab the strip was on when a create started, so a create that fails has somewhere to go back
     // to instead of leaving the strip pointing at a row the rollback has taken away.

--- a/src/components/_pages/cboms/cbomTableHelpers.tsx
+++ b/src/components/_pages/cboms/cbomTableHelpers.tsx
@@ -1,0 +1,113 @@
+import type { ReactNode } from 'react';
+import { Link } from 'react-router';
+import type { CellRegistry } from 'components/CustomTable/columns';
+import type { EnumItemModel } from 'types/enums';
+import type { CbomDto } from 'types/openapi';
+import { FilterFieldSource, FilterFieldType } from 'types/openapi';
+import type { ColumnDefinition } from 'types/tableColumns';
+
+type PlatformEnumMap = { [key: string]: EnumItemModel } | undefined;
+
+export interface BuildCbomCellsOpts {
+    assetSyncStateEnum: PlatformEnumMap;
+    getEnumLabel: (enumMap: PlatformEnumMap, key: string) => string;
+    dateFormatter: (date: string | Date) => string;
+    renderActions: (cbom: CbomDto) => ReactNode;
+}
+
+/** A count the API may send as null or a non-number, rendered as a number either way. */
+export function toFiniteNumber(value: unknown): number {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+}
+
+/** The platform default column set for the CBOM inventory: what the page shipped before the picker. */
+export const CBOM_COLUMNS: ColumnDefinition[] = [
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'CBOM_SERIAL_NUMBER',
+        catalogueLabel: 'Serial Number',
+        label: 'Serial number',
+        type: FilterFieldType.String,
+    },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'CBOM_VERSION',
+        catalogueLabel: 'Version',
+        label: 'Ver.',
+        type: FilterFieldType.Number,
+        align: 'center',
+    },
+    { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'CBOM_SOURCE', catalogueLabel: 'Source', type: FilterFieldType.String },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'CBOM_ALGORITHMS_COUNT',
+        catalogueLabel: 'Algorithms Count',
+        label: 'Alg.',
+        type: FilterFieldType.Number,
+        align: 'center',
+    },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'CBOM_CERTIFICATES_COUNT',
+        catalogueLabel: 'Certificates Count',
+        label: 'Certs',
+        type: FilterFieldType.Number,
+        align: 'center',
+    },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'CBOM_PROTOCOLS_COUNT',
+        catalogueLabel: 'Protocols Count',
+        label: 'Proto.',
+        type: FilterFieldType.Number,
+        align: 'center',
+    },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'CBOM_CRYPTO_MATERIAL_COUNT',
+        catalogueLabel: 'Crypto Material Count',
+        label: 'Material',
+        type: FilterFieldType.Number,
+        align: 'center',
+    },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'CBOM_TOTAL_ASSETS_COUNT',
+        catalogueLabel: 'Total Assets Count',
+        label: 'Assets',
+        type: FilterFieldType.Number,
+        align: 'center',
+    },
+];
+
+export function buildCbomCellRegistry({
+    assetSyncStateEnum,
+    getEnumLabel,
+    dateFormatter,
+    renderActions,
+}: BuildCbomCellsOpts): CellRegistry<CbomDto> {
+    return {
+        // The row actions ride in this cell rather than a column of their own: an uncatalogued column is stripped
+        // from a saved view on write and the picker cannot offer it back, which would leave every view without them.
+        'property:CBOM_SERIAL_NUMBER': (cbom) => (
+            <span className="flex items-center gap-2 whitespace-nowrap">
+                <Link to={`./detail/${cbom.uuid}`}>{cbom.serialNumber}</Link>
+                {renderActions(cbom)}
+            </span>
+        ),
+        'property:CBOM_VERSION': (cbom) => toFiniteNumber(cbom.version),
+        'property:CBOM_SOURCE': (cbom) => cbom.source,
+        'property:CBOM_ALGORITHMS_COUNT': (cbom) => toFiniteNumber(cbom.algorithms),
+        'property:CBOM_CERTIFICATES_COUNT': (cbom) => toFiniteNumber(cbom.certificates),
+        'property:CBOM_PROTOCOLS_COUNT': (cbom) => toFiniteNumber(cbom.protocols),
+        'property:CBOM_CRYPTO_MATERIAL_COUNT': (cbom) => toFiniteNumber(cbom.cryptoMaterial),
+        'property:CBOM_TOTAL_ASSETS_COUNT': (cbom) => toFiniteNumber(cbom.totalAssets),
+        // Beyond the default set: catalogued and renderable, so the picker offers them.
+        'property:CBOM_TIMESTAMP': (cbom) =>
+            cbom.timestamp ? <span className="whitespace-nowrap">{dateFormatter(cbom.timestamp)}</span> : null,
+        'property:CBOM_ASSET_SYNC_STATE': (cbom) => (cbom.assetSyncState ? getEnumLabel(assetSyncStateEnum, cbom.assetSyncState) : null),
+        'property:CBOM_ASSETS_SYNCED_AT': (cbom) =>
+            cbom.assetSyncedAt ? <span className="whitespace-nowrap">{dateFormatter(cbom.assetSyncedAt)}</span> : null,
+    };
+}

--- a/src/components/_pages/cboms/cbomTableHelpers.tsx
+++ b/src/components/_pages/cboms/cbomTableHelpers.tsx
@@ -21,6 +21,18 @@ export function toFiniteNumber(value: unknown): number {
     return Number.isFinite(parsed) ? parsed : 0;
 }
 
+/** A centred numeric column. Every count this inventory shows is one, differing only in its identifier and headings. */
+function countColumn(fieldIdentifier: string, catalogueLabel: string, label: string): ColumnDefinition {
+    return {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier,
+        catalogueLabel,
+        label,
+        type: FilterFieldType.Number,
+        align: 'center',
+    };
+}
+
 /** The platform default column set for the CBOM inventory: what the page shipped before the picker. */
 export const CBOM_COLUMNS: ColumnDefinition[] = [
     {
@@ -30,55 +42,13 @@ export const CBOM_COLUMNS: ColumnDefinition[] = [
         label: 'Serial number',
         type: FilterFieldType.String,
     },
-    {
-        fieldSource: FilterFieldSource.Property,
-        fieldIdentifier: 'CBOM_VERSION',
-        catalogueLabel: 'Version',
-        label: 'Ver.',
-        type: FilterFieldType.Number,
-        align: 'center',
-    },
+    countColumn('CBOM_VERSION', 'Version', 'Ver.'),
     { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'CBOM_SOURCE', catalogueLabel: 'Source', type: FilterFieldType.String },
-    {
-        fieldSource: FilterFieldSource.Property,
-        fieldIdentifier: 'CBOM_ALGORITHMS_COUNT',
-        catalogueLabel: 'Algorithms Count',
-        label: 'Alg.',
-        type: FilterFieldType.Number,
-        align: 'center',
-    },
-    {
-        fieldSource: FilterFieldSource.Property,
-        fieldIdentifier: 'CBOM_CERTIFICATES_COUNT',
-        catalogueLabel: 'Certificates Count',
-        label: 'Certs',
-        type: FilterFieldType.Number,
-        align: 'center',
-    },
-    {
-        fieldSource: FilterFieldSource.Property,
-        fieldIdentifier: 'CBOM_PROTOCOLS_COUNT',
-        catalogueLabel: 'Protocols Count',
-        label: 'Proto.',
-        type: FilterFieldType.Number,
-        align: 'center',
-    },
-    {
-        fieldSource: FilterFieldSource.Property,
-        fieldIdentifier: 'CBOM_CRYPTO_MATERIAL_COUNT',
-        catalogueLabel: 'Crypto Material Count',
-        label: 'Material',
-        type: FilterFieldType.Number,
-        align: 'center',
-    },
-    {
-        fieldSource: FilterFieldSource.Property,
-        fieldIdentifier: 'CBOM_TOTAL_ASSETS_COUNT',
-        catalogueLabel: 'Total Assets Count',
-        label: 'Assets',
-        type: FilterFieldType.Number,
-        align: 'center',
-    },
+    countColumn('CBOM_ALGORITHMS_COUNT', 'Algorithms Count', 'Alg.'),
+    countColumn('CBOM_CERTIFICATES_COUNT', 'Certificates Count', 'Certs'),
+    countColumn('CBOM_PROTOCOLS_COUNT', 'Protocols Count', 'Proto.'),
+    countColumn('CBOM_CRYPTO_MATERIAL_COUNT', 'Crypto Material Count', 'Material'),
+    countColumn('CBOM_TOTAL_ASSETS_COUNT', 'Total Assets Count', 'Assets'),
 ];
 
 export function buildCbomCellRegistry({

--- a/src/components/_pages/cboms/list/index.tsx
+++ b/src/components/_pages/cboms/list/index.tsx
@@ -15,7 +15,8 @@ import { dateFormatter } from 'utils/dateUtil';
 import { buildCbomCellRegistry, CBOM_COLUMNS } from '../cbomTableHelpers';
 import type { SearchRequestModel } from 'types/certificate';
 import { type ApiClients, backendClient } from 'src/api';
-import { EntityType } from 'ducks/filters';
+import { EntityType, actions as filterActions } from 'ducks/filters';
+import { actions as pagingActions } from 'ducks/paging';
 
 function CbomsList() {
     const dispatch = useDispatch();
@@ -150,10 +151,23 @@ function CbomsList() {
     const isUploadSuccess = useSelector(selectors.selectIsUploadSuccess);
     const syncSucceeded = useSelector(selectors.selectSyncSucceeded);
 
+    // Back to an unfiltered first page, so the CBOM the upload produced is on it. The refresh goes
+    // through the token rather than a request assembled here, which would carry no columns and no
+    // ordering — blanking every picker-added column and dropping the applied sort.
+    const [pageRefreshToken, setPageRefreshToken] = useState(0);
+    const deleteRefreshToken = useSelector(selectors.selectListRefreshToken);
+    const refreshToken = pageRefreshToken + deleteRefreshToken;
+
+    const refreshFromFirstPage = useCallback(() => {
+        dispatch(filterActions.setCurrentFilters({ entity: EntityType.CBOM, currentFilters: [] }));
+        dispatch(pagingActions.resetPaging({ entity: EntityType.CBOM }));
+        setPageRefreshToken((token) => token + 1);
+    }, [dispatch]);
+
     useRunOnSuccessfulFinish(isUploading, isUploadSuccess, () => {
         setIsUploadOpen(false);
         setHighlightedCbomUuid(cboms[0]?.uuid);
-        onList({ itemsPerPage: 10, pageNumber: 1, filters: [] });
+        refreshFromFirstPage();
     });
 
     useEffect(() => {
@@ -165,9 +179,7 @@ function CbomsList() {
         return () => globalThis.clearTimeout(timeoutId);
     }, [highlightedCbomUuid]);
 
-    useRunOnSuccessfulFinish(isSyncing, syncSucceeded, () => {
-        onList({ itemsPerPage: 10, pageNumber: 1, filters: [] });
-    });
+    useRunOnSuccessfulFinish(isSyncing, syncSucceeded, refreshFromFirstPage);
 
     return (
         <>
@@ -195,6 +207,7 @@ function CbomsList() {
                 hasCheckboxes={true}
                 additionalButtons={additionalButtons}
                 pageWidgetLockName={LockWidgetNameEnum.ListOfCboms}
+                refreshToken={refreshToken}
             />
 
             <Dialog

--- a/src/components/_pages/cboms/list/index.tsx
+++ b/src/components/_pages/cboms/list/index.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Link } from 'react-router';
 import { firstValueFrom } from 'rxjs';
 import WidgetButtons, { type WidgetButtonProps } from 'components/WidgetButtons';
 import Dialog from 'components/Dialog';
@@ -9,42 +8,26 @@ import CbomUploadDialog from '../CbomUploadDialog';
 import { actions as alertActions } from 'ducks/alerts';
 import { actions, selectors } from 'ducks/cbom';
 import PagedList from 'components/PagedList/PagedList';
-import type { TableDataRow, TableHeader } from 'components/CustomTable';
 import { LockWidgetNameEnum } from 'types/user-interface';
+import { type CbomDto, PlatformEnum, Resource } from 'types/openapi';
+import { selectors as enumSelectors, getEnumLabel } from 'ducks/enums';
+import { dateFormatter } from 'utils/dateUtil';
+import { buildCbomCellRegistry, CBOM_COLUMNS } from '../cbomTableHelpers';
 import type { SearchRequestModel } from 'types/certificate';
 import { type ApiClients, backendClient } from 'src/api';
 import { EntityType } from 'ducks/filters';
-
-const toFiniteNumber = (value: unknown): number => {
-    const parsed = typeof value === 'number' ? value : Number(value);
-    return Number.isFinite(parsed) ? parsed : 0;
-};
 
 function CbomsList() {
     const dispatch = useDispatch();
 
     const cboms = useSelector(selectors.selectCbomList);
+    const assetSyncStateEnum = useSelector(enumSelectors.platformEnum(PlatformEnum.CbomAssetSyncState));
     const isFetching = useSelector(selectors.selectIsFetchingList);
     const isDeleting = useSelector(selectors.selectIsDeleting);
     const isBulkDeleting = useSelector(selectors.selectIsBulkDeleting);
     const isSyncing = useSelector(selectors.selectIsSyncing);
 
     const isBusy = isFetching || isDeleting || isBulkDeleting || isSyncing;
-
-    const headers: TableHeader[] = useMemo(
-        () => [
-            { content: 'Serial number', sortable: true, id: 'serial' },
-            { content: 'Ver.', sortable: true, id: 'version', align: 'center', sortType: 'numeric' },
-            { content: 'Source', sortable: true, id: 'source' },
-            { content: 'Alg.', sortable: true, id: 'algorithm', align: 'center', sortType: 'numeric' },
-            { content: 'Certs', sortable: true, id: 'certificates', align: 'center', sortType: 'numeric' },
-            { content: 'Proto.', sortable: true, id: 'protocol', align: 'center', sortType: 'numeric' },
-            { content: 'Material', sortable: true, id: 'material', align: 'center', sortType: 'numeric' },
-            { content: 'Assets', sortable: true, id: 'assets', align: 'center', sortType: 'numeric' },
-            { content: 'Action', sortable: false, id: 'action', align: 'center' },
-        ],
-        [],
-    );
 
     const copyToClipboard = useCopyToClipboard();
     const [isUploadOpen, setIsUploadOpen] = useState(false);
@@ -106,54 +89,59 @@ function CbomsList() {
         [dispatch, getCbomJson],
     );
 
-    const rows: TableDataRow[] = useMemo(
-        () =>
-            cboms.map((c) => ({
-                id: c.uuid,
-                options: {
-                    rowClassName: c.uuid === highlightedCbomUuid ? 'bg-success-surface' : undefined,
-                },
-                columns: [
-                    <Link key="serial" to={`./detail/${c.uuid}`}>
-                        {c.serialNumber}
-                    </Link>,
-                    toFiniteNumber(c.version),
-                    c.source || '-',
-                    toFiniteNumber(c.algorithms),
-                    toFiniteNumber(c.certificates),
-                    toFiniteNumber(c.protocols),
-                    toFiniteNumber(c.cryptoMaterial),
-                    toFiniteNumber(c.totalAssets),
-                    <WidgetButtons
-                        key={`actions-${c.uuid}`}
-                        buttons={
-                            [
-                                {
-                                    id: 'copy',
-                                    icon: 'copy',
-                                    disabled: false,
-                                    tooltip: 'Copy JSON',
-                                    onClick: (e) => {
-                                        e.stopPropagation();
-                                        void handleCopyCbomJson(c.uuid);
-                                    },
-                                },
-                                {
-                                    id: 'download',
-                                    icon: 'download',
-                                    disabled: false,
-                                    tooltip: 'Download JSON',
-                                    onClick: (e) => {
-                                        e.stopPropagation();
-                                        void handleDownloadCbomJson(c.uuid, c.serialNumber, c.version);
-                                    },
-                                },
-                            ] as WidgetButtonProps[]
-                        }
-                    />,
-                ],
-            })),
-        [cboms, handleCopyCbomJson, handleDownloadCbomJson, highlightedCbomUuid],
+    const renderActions = useCallback(
+        (cbom: CbomDto) => (
+            <WidgetButtons
+                buttons={
+                    [
+                        {
+                            id: 'copy',
+                            icon: 'copy',
+                            disabled: false,
+                            tooltip: 'Copy JSON',
+                            onClick: (e) => {
+                                e.stopPropagation();
+                                void handleCopyCbomJson(cbom.uuid);
+                            },
+                        },
+                        {
+                            id: 'download',
+                            icon: 'download',
+                            disabled: false,
+                            tooltip: 'Download JSON',
+                            onClick: (e) => {
+                                e.stopPropagation();
+                                void handleDownloadCbomJson(cbom.uuid, cbom.serialNumber, cbom.version);
+                            },
+                        },
+                    ] as WidgetButtonProps[]
+                }
+            />
+        ),
+        [handleCopyCbomJson, handleDownloadCbomJson],
+    );
+
+    const registry = useMemo(
+        () => buildCbomCellRegistry({ assetSyncStateEnum, getEnumLabel, dateFormatter, renderActions }),
+        [assetSyncStateEnum, renderActions],
+    );
+
+    const rowOptions = useCallback(
+        (cbom: CbomDto) => (cbom.uuid === highlightedCbomUuid ? { rowClassName: 'bg-success-surface' } : undefined),
+        [highlightedCbomUuid],
+    );
+
+    const configurableColumns = useMemo(
+        () => ({
+            resource: Resource.Cboms,
+            standardColumns: CBOM_COLUMNS,
+            rows: cboms,
+            getRowId: (cbom: CbomDto) => cbom.uuid,
+            registry,
+            rowOptions,
+            resourceLabel: 'CBOMs',
+        }),
+        [cboms, registry, rowOptions],
     );
 
     const onList = useCallback((filters: SearchRequestModel) => dispatch(actions.listCboms(filters)), [dispatch]);
@@ -198,8 +186,7 @@ function CbomsList() {
                 }}
                 getAvailableFiltersApi={useCallback((apiClients: ApiClients) => apiClients.cbomManagement.getCbomSearchableFields(), [])}
                 filterTitle="CBOMs Filter"
-                headers={headers}
-                data={rows}
+                configurableColumns={configurableColumns}
                 isBusy={isBusy}
                 title="CBOMs"
                 entityNameSingular="a CBOM"

--- a/src/components/_pages/connectors/connectorTableHelpers.tsx
+++ b/src/components/_pages/connectors/connectorTableHelpers.tsx
@@ -1,0 +1,135 @@
+import type { ReactNode } from 'react';
+import { Link } from 'react-router';
+import Badge from 'components/Badge';
+import type { CellRegistry } from 'components/CustomTable/columns';
+import type { ConnectorResponseModel } from 'types/connectors';
+import type { EnumItemModel } from 'types/enums';
+import { FilterFieldSource, FilterFieldType } from 'types/openapi';
+import type { ColumnDefinition } from 'types/tableColumns';
+import { getConnectorCapabilities, inventoryStatus } from 'utils/connector';
+import ConnectorCapabilityBadges from './list/ConnectorCapabilityBadges';
+
+type PlatformEnumMap = { [key: string]: EnumItemModel } | undefined;
+
+export interface BuildConnectorCellsOpts {
+    interfaceEnum: PlatformEnumMap;
+    featureEnum: PlatformEnumMap;
+    functionGroupEnum: PlatformEnumMap;
+    authTypeEnum: PlatformEnumMap;
+    getEnumLabel: (enumMap: PlatformEnumMap, key: string) => string;
+    onOverflowClick: (connector: ConnectorResponseModel) => void;
+}
+
+/**
+ * The platform default column set for the connectors inventory, which depends on whether proxies are enabled: the
+ * proxy column is not in the filter-field catalogue and is display-only, so a build with proxies off must not ship it
+ * at all rather than ship it empty.
+ */
+export function buildConnectorColumns(isProxiesEnabled: boolean): ColumnDefinition[] {
+    return [
+        {
+            fieldSource: FilterFieldSource.Property,
+            fieldIdentifier: 'CONNECTOR_NAME',
+            catalogueLabel: 'Name',
+            type: FilterFieldType.String,
+        },
+        {
+            fieldSource: FilterFieldSource.Property,
+            fieldIdentifier: 'CONNECTOR_VERSION',
+            catalogueLabel: 'Version',
+            label: 'Ver',
+            type: FilterFieldType.List,
+            align: 'center',
+        },
+        {
+            fieldSource: FilterFieldSource.Property,
+            fieldIdentifier: 'CONNECTOR_INTERFACE',
+            catalogueLabel: 'Interface',
+            label: 'Interfaces / Function Groups',
+            type: FilterFieldType.List,
+        },
+        {
+            fieldSource: FilterFieldSource.Property,
+            fieldIdentifier: 'CONNECTOR_FEATURES',
+            catalogueLabel: 'Features',
+            label: 'Features / Kinds',
+            type: FilterFieldType.List,
+        },
+        ...(isProxiesEnabled
+            ? [{ fieldSource: FilterFieldSource.Property, fieldIdentifier: 'CONNECTOR_PROXY', catalogueLabel: 'Proxy' }]
+            : []),
+        { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'CONNECTOR_URL', catalogueLabel: 'URL', type: FilterFieldType.String },
+        {
+            fieldSource: FilterFieldSource.Property,
+            fieldIdentifier: 'CONNECTOR_STATUS',
+            catalogueLabel: 'Status',
+            type: FilterFieldType.List,
+        },
+    ];
+}
+
+export function buildConnectorCellRegistry({
+    interfaceEnum,
+    featureEnum,
+    functionGroupEnum,
+    authTypeEnum,
+    getEnumLabel,
+    onOverflowClick,
+}: BuildConnectorCellsOpts): CellRegistry<ConnectorResponseModel> {
+    const capabilities = (connector: ConnectorResponseModel) =>
+        getConnectorCapabilities(connector, { interfaceEnum, featureEnum, functionGroupEnum });
+
+    return {
+        'property:CONNECTOR_NAME': (connector) => (
+            <span className="whitespace-nowrap">
+                <Link to={`./detail/${connector.uuid}`}>{connector.name}</Link>
+            </span>
+        ),
+        'property:CONNECTOR_VERSION': (connector) => <span className="whitespace-nowrap">{connector.version}</span>,
+        'property:CONNECTOR_INTERFACE': (connector) => {
+            const { isV2, capabilityLabels } = capabilities(connector);
+            return (
+                <ConnectorCapabilityBadges
+                    labels={capabilityLabels}
+                    color="primary"
+                    testIdPrefix={`interfaces-${connector.uuid}`}
+                    overflowTitle={isV2 ? 'Show all interfaces' : 'Show all function groups'}
+                    onOverflowClick={() => onOverflowClick(connector)}
+                />
+            );
+        },
+        'property:CONNECTOR_FEATURES': (connector) => {
+            const { isV2, featureLabels } = capabilities(connector);
+            return (
+                <ConnectorCapabilityBadges
+                    labels={featureLabels}
+                    color="secondary"
+                    testIdPrefix={`features-${connector.uuid}`}
+                    overflowTitle={isV2 ? 'Show all features' : 'Show all kinds'}
+                    onOverflowClick={() => onOverflowClick(connector)}
+                />
+            );
+        },
+        'property:CONNECTOR_PROXY': (connector) =>
+            connector.proxy ? (
+                <span className="whitespace-nowrap">
+                    <Link to={`../proxies/detail/${connector.proxy.uuid}`}>{connector.proxy.name}</Link>
+                </span>
+            ) : null,
+        'property:CONNECTOR_URL': (connector) => <span className="whitespace-nowrap">{connector.url}</span>,
+        'property:CONNECTOR_STATUS': (connector) => {
+            const [label, color] = inventoryStatus(connector.status);
+            return <Badge color={color}>{label}</Badge>;
+        },
+        // Beyond the default set: catalogued and renderable, so the picker offers them.
+        'property:CONNECTOR_AUTH_TYPE': (connector) => (connector.authType ? getEnumLabel(authTypeEnum, connector.authType) : null),
+        // The interfaces cell renders these only for a v1 connector, so a v2 connector's function groups
+        // are reachable nowhere else.
+        'property:CONNECTOR_FUNCTION_GROUP': (connector) => {
+            const labels = (connector.functionGroups ?? []).map((group) =>
+                getEnumLabel(functionGroupEnum, group.functionGroupCode ?? group.name),
+            );
+            return labels.length > 0 ? labels.join(', ') : null;
+        },
+    } satisfies Record<string, (connector: ConnectorResponseModel) => ReactNode>;
+}

--- a/src/components/_pages/connectors/connectorTableHelpers.tsx
+++ b/src/components/_pages/connectors/connectorTableHelpers.tsx
@@ -7,9 +7,17 @@ import type { EnumItemModel } from 'types/enums';
 import { FilterFieldSource, FilterFieldType } from 'types/openapi';
 import type { ColumnDefinition } from 'types/tableColumns';
 import { getConnectorCapabilities, inventoryStatus } from 'utils/connector';
+import type { ColumnSort } from 'utils/tableColumns';
 import ConnectorCapabilityBadges from './list/ConnectorCapabilityBadges';
 
 type PlatformEnumMap = { [key: string]: EnumItemModel } | undefined;
+
+/** The ordering the inventory opens on, which it sorted client-side before it was column-driven. */
+export const CONNECTOR_DEFAULT_SORT: ColumnSort = {
+    fieldSource: FilterFieldSource.Property,
+    fieldIdentifier: 'CONNECTOR_NAME',
+    direction: 'asc',
+};
 
 export interface BuildConnectorCellsOpts {
     interfaceEnum: PlatformEnumMap;
@@ -85,7 +93,8 @@ export function buildConnectorCellRegistry({
                 <Link to={`./detail/${connector.uuid}`}>{connector.name}</Link>
             </span>
         ),
-        'property:CONNECTOR_VERSION': (connector) => <span className="whitespace-nowrap">{connector.version}</span>,
+        'property:CONNECTOR_VERSION': (connector) =>
+            connector.version ? <span className="whitespace-nowrap">{connector.version}</span> : null,
         'property:CONNECTOR_INTERFACE': (connector) => {
             const { isV2, capabilityLabels } = capabilities(connector);
             return (

--- a/src/components/_pages/connectors/list/index.tsx
+++ b/src/components/_pages/connectors/list/index.tsx
@@ -15,9 +15,9 @@ import { EntityType } from 'ducks/filters';
 import { selectors as enumSelectors, getEnumLabel } from 'ducks/enums';
 import { selectors as pagingSelectors } from 'ducks/paging';
 import type { SearchRequestModel } from 'types/certificate';
-import { FilterFieldSource, PlatformEnum, Resource } from 'types/openapi';
+import { PlatformEnum, Resource } from 'types/openapi';
 import type { ConnectorResponseModel } from 'types/connectors';
-import { buildConnectorCellRegistry, buildConnectorColumns } from '../connectorTableHelpers';
+import { buildConnectorCellRegistry, buildConnectorColumns, CONNECTOR_DEFAULT_SORT } from '../connectorTableHelpers';
 import { LockWidgetNameEnum } from 'types/user-interface';
 import { getConnectorCapabilities } from 'utils/connector';
 import { featureFlags } from 'utils/feature-flags';
@@ -183,7 +183,7 @@ export default function ConnectorList() {
             rows: connectors,
             getRowId: (connector: ConnectorResponseModel) => connector.uuid,
             registry,
-            defaultSort: { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'CONNECTOR_NAME', direction: 'asc' as const },
+            defaultSort: CONNECTOR_DEFAULT_SORT,
             resourceLabel: 'Connectors',
         }),
         [connectors, registry, standardColumns],

--- a/src/components/_pages/connectors/list/index.tsx
+++ b/src/components/_pages/connectors/list/index.tsx
@@ -1,27 +1,25 @@
 import { type ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 import { useRunOnSuccessfulFinish } from 'utils/common-hooks';
 import { useDispatch, useSelector } from 'react-redux';
-import { Link } from 'react-router';
 
-import Badge from 'components/Badge';
 import { actions, selectors } from 'ducks/connectors';
 
-import type { TableDataRow, TableHeader } from 'components/CustomTable';
 import ForceDeleteErrorTable from 'components/ForceDeleteErrorTable';
 import Dialog from 'components/Dialog';
 import type { WidgetButtonProps } from 'components/WidgetButtons';
 import ConnectorForm from '../form';
-import ConnectorCapabilityBadges from './ConnectorCapabilityBadges';
 import ConnectorCapabilitiesMatrix from './ConnectorCapabilitiesMatrix';
 import PagedList from 'components/PagedList/PagedList';
 
 import { EntityType } from 'ducks/filters';
-import { selectors as enumSelectors } from 'ducks/enums';
+import { selectors as enumSelectors, getEnumLabel } from 'ducks/enums';
 import { selectors as pagingSelectors } from 'ducks/paging';
 import type { SearchRequestModel } from 'types/certificate';
-import { PlatformEnum } from 'types/openapi';
+import { FilterFieldSource, PlatformEnum, Resource } from 'types/openapi';
+import type { ConnectorResponseModel } from 'types/connectors';
+import { buildConnectorCellRegistry, buildConnectorColumns } from '../connectorTableHelpers';
 import { LockWidgetNameEnum } from 'types/user-interface';
-import { getConnectorCapabilities, inventoryStatus } from 'utils/connector';
+import { getConnectorCapabilities } from 'utils/connector';
 import { featureFlags } from 'utils/feature-flags';
 
 import type { ApiClients } from '../../../../api';
@@ -33,6 +31,7 @@ export default function ConnectorList() {
     const connectors = useSelector(selectors.connectors);
 
     const connectorInterfaceEnum = useSelector(enumSelectors.platformEnum(PlatformEnum.ConnectorInterface));
+    const authTypeEnum = useSelector(enumSelectors.platformEnum(PlatformEnum.AuthType));
     const featureFlagEnum = useSelector(enumSelectors.platformEnum(PlatformEnum.FeatureFlag));
     const functionGroupCodeEnum = useSelector(enumSelectors.platformEnum(PlatformEnum.FunctionGroupCode));
 
@@ -150,126 +149,51 @@ export default function ConnectorList() {
         />
     );
 
-    const connectorsRowHeaders: TableHeader[] = useMemo(
-        () => [
-            {
-                content: 'Name',
-                sortable: true,
-                sort: 'asc',
-                id: 'connectorName',
-                width: '25%',
-            },
-            {
-                content: 'Ver',
-                sortable: true,
-                id: 'connectorVersion',
-                align: 'center',
-                width: '5%',
-            },
-            {
-                content: 'Interfaces / Function Groups',
-                id: 'connectorInterfaces',
-                width: '15%',
-            },
-            {
-                content: 'Features / Kinds',
-                id: 'connectorFeatures',
-                width: '15%',
-                minWidth: '180px',
-            },
-            ...(featureFlags.isProxiesEnabled
-                ? [
-                      {
-                          content: 'Proxy',
-                          sortable: true,
-                          id: 'connectorProxy',
-                          width: '15%',
-                      } as TableHeader,
-                  ]
-                : []),
-            {
-                content: 'URL',
-                sortable: true,
-                id: 'connectorUrl',
-            },
-            {
-                content: 'Status',
-                sortable: true,
-                id: 'connectorStatus',
-                width: '5%',
-            },
-        ],
-        [],
+    const onOverflowClick = useCallback(
+        (connector: ConnectorResponseModel) => {
+            const { caption } = getConnectorCapabilities(connector, {
+                interfaceEnum: connectorInterfaceEnum,
+                featureEnum: featureFlagEnum,
+                functionGroupEnum: functionGroupCodeEnum,
+            });
+            setCapabilitiesModal({ caption, content: <ConnectorCapabilitiesMatrix connector={connector} /> });
+        },
+        [connectorInterfaceEnum, featureFlagEnum, functionGroupCodeEnum],
     );
 
-    const connectorList: TableDataRow[] = useMemo(
+    const registry = useMemo(
         () =>
-            connectors.map((connector) => {
-                const connectorStatus = inventoryStatus(connector.status);
-
-                const { isV2, caption, capabilityLabels, featureLabels } = getConnectorCapabilities(connector, {
-                    interfaceEnum: connectorInterfaceEnum,
-                    featureEnum: featureFlagEnum,
-                    functionGroupEnum: functionGroupCodeEnum,
-                });
-
-                const openCapabilitiesModal = () =>
-                    setCapabilitiesModal({ caption, content: <ConnectorCapabilitiesMatrix connector={connector} /> });
-
-                return {
-                    id: connector.uuid,
-                    columns: [
-                        <span key="name" style={{ whiteSpace: 'nowrap' }}>
-                            <Link to={`./detail/${connector.uuid}`}>{connector.name}</Link>
-                        </span>,
-                        <span key="version" style={{ whiteSpace: 'nowrap' }}>
-                            {connector.version || '-'}
-                        </span>,
-                        <ConnectorCapabilityBadges
-                            key="interfaces"
-                            labels={capabilityLabels}
-                            color="primary"
-                            testIdPrefix={`interfaces-${connector.uuid}`}
-                            overflowTitle={isV2 ? 'Show all interfaces' : 'Show all function groups'}
-                            onOverflowClick={openCapabilitiesModal}
-                        />,
-                        <ConnectorCapabilityBadges
-                            key="features"
-                            labels={featureLabels}
-                            color="secondary"
-                            testIdPrefix={`features-${connector.uuid}`}
-                            overflowTitle={isV2 ? 'Show all features' : 'Show all kinds'}
-                            onOverflowClick={openCapabilitiesModal}
-                        />,
-                        ...(featureFlags.isProxiesEnabled
-                            ? [
-                                  <span key="proxy" style={{ whiteSpace: 'nowrap' }}>
-                                      {connector.proxy ? (
-                                          <Link to={`../proxies/detail/${connector.proxy.uuid}`}>{connector.proxy.name}</Link>
-                                      ) : (
-                                          '-'
-                                      )}
-                                  </span>,
-                              ]
-                            : []),
-                        <span key="url" style={{ whiteSpace: 'nowrap' }}>
-                            {connector.url}
-                        </span>,
-                        <Badge key="badge" color={connectorStatus[1]}>
-                            {connectorStatus[0]}
-                        </Badge>,
-                    ],
-                };
+            buildConnectorCellRegistry({
+                interfaceEnum: connectorInterfaceEnum,
+                featureEnum: featureFlagEnum,
+                functionGroupEnum: functionGroupCodeEnum,
+                authTypeEnum,
+                getEnumLabel,
+                onOverflowClick,
             }),
-        [connectors, connectorInterfaceEnum, featureFlagEnum, functionGroupCodeEnum],
+        [connectorInterfaceEnum, featureFlagEnum, functionGroupCodeEnum, authTypeEnum, onOverflowClick],
+    );
+
+    const standardColumns = useMemo(() => buildConnectorColumns(featureFlags.isProxiesEnabled), []);
+
+    const configurableColumns = useMemo(
+        () => ({
+            resource: Resource.Connectors,
+            standardColumns,
+            rows: connectors,
+            getRowId: (connector: ConnectorResponseModel) => connector.uuid,
+            registry,
+            defaultSort: { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'CONNECTOR_NAME', direction: 'asc' as const },
+            resourceLabel: 'Connectors',
+        }),
+        [connectors, registry, standardColumns],
     );
 
     return (
         <div className="space-y-4">
             <PagedList
                 entity={EntityType.CONNECTOR}
-                headers={connectorsRowHeaders}
-                data={connectorList}
+                configurableColumns={configurableColumns}
                 isBusy={isBusy}
                 onListCallback={onListCallback}
                 getAvailableFiltersApi={useCallback((apiClients: ApiClients) => apiClients.connectorsV2.getConnectorSearchableFields(), [])}

--- a/src/components/_pages/connectors/list/index.tsx
+++ b/src/components/_pages/connectors/list/index.tsx
@@ -104,6 +104,9 @@ export default function ConnectorList() {
         [dispatch],
     );
 
+    // An approval re-reads through the host so the replayed request keeps the applied columns and ordering.
+    const refreshToken = useSelector(selectors.listRefreshToken);
+
     const buttons: WidgetButtonProps[] = useMemo(
         () => [
             {
@@ -202,6 +205,7 @@ export default function ConnectorList() {
                 addHidden
                 additionalButtons={buttons}
                 pageWidgetLockName={LockWidgetNameEnum.ConnectorStore}
+                refreshToken={refreshToken}
             />
 
             <Dialog

--- a/src/components/_pages/discoveries/discoveryTableHelpers.tsx
+++ b/src/components/_pages/discoveries/discoveryTableHelpers.tsx
@@ -5,12 +5,20 @@ import type { CellRegistry } from 'components/CustomTable/columns';
 import type { DiscoveryResponseModel } from 'types/discoveries';
 import { FilterFieldSource, FilterFieldType } from 'types/openapi';
 import type { ColumnDefinition } from 'types/tableColumns';
+import type { ColumnSort } from 'utils/tableColumns';
 import DiscoveryStatus from './DiscoveryStatus';
 
 export interface BuildDiscoveryCellsOpts {
     dateFormatter: (date: string | Date) => string;
     durationFormatter: (start?: string | null, end?: string | null) => string;
 }
+
+/** The ordering the inventory opens on, which it sorted client-side before it was column-driven. */
+export const DISCOVERY_DEFAULT_SORT: ColumnSort = {
+    fieldSource: FilterFieldSource.Property,
+    fieldIdentifier: 'DISCOVERY_NAME',
+    direction: 'asc',
+};
 
 /**
  * The platform default column set for the discoveries inventory.

--- a/src/components/_pages/discoveries/discoveryTableHelpers.tsx
+++ b/src/components/_pages/discoveries/discoveryTableHelpers.tsx
@@ -1,0 +1,87 @@
+import { Link } from 'react-router';
+import Badge from 'components/Badge';
+import ConnectorLink from 'components/ConnectorLink';
+import type { CellRegistry } from 'components/CustomTable/columns';
+import type { DiscoveryResponseModel } from 'types/discoveries';
+import { FilterFieldSource, FilterFieldType } from 'types/openapi';
+import type { ColumnDefinition } from 'types/tableColumns';
+import DiscoveryStatus from './DiscoveryStatus';
+
+export interface BuildDiscoveryCellsOpts {
+    dateFormatter: (date: string | Date) => string;
+    durationFormatter: (start?: string | null, end?: string | null) => string;
+}
+
+/**
+ * The platform default column set for the discoveries inventory.
+ *
+ * `DISCOVERY_DURATION` is not in the filter-field catalogue: it is computed from the start and end times rather than
+ * stored, so no `FilterField` resolves it. It is display-only — shown here, absent from the picker, not sortable, and
+ * dropped on write by `toStorableColumns`. It keeps a natural identifier so that cataloguing it is the only change
+ * needed.
+ */
+export const DISCOVERY_COLUMNS: ColumnDefinition[] = [
+    { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'DISCOVERY_NAME', catalogueLabel: 'Name', type: FilterFieldType.String },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'DISCOVERY_CONNECTOR_NAME',
+        catalogueLabel: 'Discovery provider',
+        label: 'Discovery Provider',
+        type: FilterFieldType.String,
+        align: 'center',
+    },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'DISCOVERY_KIND',
+        catalogueLabel: 'Kind',
+        label: 'Kinds',
+        type: FilterFieldType.String,
+        align: 'center',
+    },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'DISCOVERY_START_TIME',
+        catalogueLabel: 'Start time',
+        type: FilterFieldType.Date,
+        align: 'center',
+    },
+    { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'DISCOVERY_DURATION', catalogueLabel: 'Duration', align: 'center' },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'DISCOVERY_STATUS',
+        catalogueLabel: 'Status',
+        type: FilterFieldType.List,
+        align: 'center',
+    },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'DISCOVERY_TOTAL_CERT_DISCOVERED',
+        catalogueLabel: 'Total certificate discovered',
+        label: 'Total Certificates',
+        type: FilterFieldType.Number,
+        align: 'center',
+    },
+];
+
+export function buildDiscoveryCellRegistry({
+    dateFormatter,
+    durationFormatter,
+}: BuildDiscoveryCellsOpts): CellRegistry<DiscoveryResponseModel> {
+    return {
+        'property:DISCOVERY_NAME': (discovery) => <Link to={`./detail/${discovery.uuid}`}>{discovery.name}</Link>,
+        'property:DISCOVERY_CONNECTOR_NAME': (discovery) => (
+            <ConnectorLink uuid={discovery.connectorUuid} name={discovery.connectorName} fallback="Unassigned" />
+        ),
+        'property:DISCOVERY_KIND': (discovery) => (discovery.kind ? <Badge color="secondary">{discovery.kind}</Badge> : null),
+        'property:DISCOVERY_START_TIME': (discovery) =>
+            discovery.startTime ? <span className="whitespace-nowrap">{dateFormatter(discovery.startTime)}</span> : null,
+        'property:DISCOVERY_DURATION': (discovery) => (
+            <span className="whitespace-nowrap">{durationFormatter(discovery.startTime, discovery.endTime)}</span>
+        ),
+        'property:DISCOVERY_STATUS': (discovery) => <DiscoveryStatus status={discovery.status} />,
+        'property:DISCOVERY_TOTAL_CERT_DISCOVERED': (discovery) => discovery.totalCertificatesDiscovered?.toString() ?? '0',
+        // Beyond the default set: catalogued and renderable, so the picker offers it.
+        'property:DISCOVERY_END_TIME': (discovery) =>
+            discovery.endTime ? <span className="whitespace-nowrap">{dateFormatter(discovery.endTime)}</span> : null,
+    };
+}

--- a/src/components/_pages/discoveries/discoveryTableHelpers.tsx
+++ b/src/components/_pages/discoveries/discoveryTableHelpers.tsx
@@ -83,9 +83,12 @@ export function buildDiscoveryCellRegistry({
         'property:DISCOVERY_KIND': (discovery) => (discovery.kind ? <Badge color="secondary">{discovery.kind}</Badge> : null),
         'property:DISCOVERY_START_TIME': (discovery) =>
             discovery.startTime ? <span className="whitespace-nowrap">{dateFormatter(discovery.startTime)}</span> : null,
-        'property:DISCOVERY_DURATION': (discovery) => (
-            <span className="whitespace-nowrap">{durationFormatter(discovery.startTime, discovery.endTime)}</span>
-        ),
+        'property:DISCOVERY_DURATION': (discovery) => {
+            // The formatter yields nothing for a discovery that has not started, which is an empty cell rather than a
+            // zero duration.
+            const duration = durationFormatter(discovery.startTime, discovery.endTime);
+            return duration ? <span className="whitespace-nowrap">{duration}</span> : null;
+        },
         'property:DISCOVERY_STATUS': (discovery) => <DiscoveryStatus status={discovery.status} />,
         'property:DISCOVERY_TOTAL_CERT_DISCOVERED': (discovery) => discovery.totalCertificatesDiscovered?.toString() ?? '0',
         // Beyond the default set: catalogued and renderable, so the picker offers it.

--- a/src/components/_pages/discoveries/list/index.tsx
+++ b/src/components/_pages/discoveries/list/index.tsx
@@ -1,20 +1,17 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Link } from 'react-router';
-
-import Badge from 'components/Badge';
-import ConnectorLink from 'components/ConnectorLink';
 
 import { actions, selectors } from 'ducks/discoveries';
 import { EntityType } from 'ducks/filters';
 import { dateFormatter, durationFormatter } from 'utils/dateUtil';
 
 import type { ApiClients } from '../../../../api';
-import type { TableDataRow, TableHeader } from 'components/CustomTable';
 import PagedList from 'components/PagedList/PagedList';
 import type { SearchRequestModel } from 'types/certificate';
 import { LockWidgetNameEnum } from 'types/user-interface';
-import DiscoveryStatus from '../DiscoveryStatus';
+import { FilterFieldSource, Resource } from 'types/openapi';
+import type { DiscoveryResponseModel } from 'types/discoveries';
+import { buildDiscoveryCellRegistry, DISCOVERY_COLUMNS } from '../discoveryTableHelpers';
 import Dialog from 'components/Dialog';
 import DiscoveryForm from '../form';
 import type { WidgetButtonProps } from 'components/WidgetButtons';
@@ -31,89 +28,19 @@ function DiscoveryList() {
     const isBulkDeleting = useSelector(selectors.isBulkDeleting);
     const isBusy = isDeleting || isBulkDeleting;
 
-    const discoveriesRowHeaders: TableHeader[] = useMemo(
-        () => [
-            {
-                content: 'Name',
-                sortable: true,
-                sort: 'asc',
-                id: 'discoveryName',
-                width: 'auto',
-            },
-            {
-                content: 'Discovery Provider',
-                align: 'center',
-                sortable: true,
-                id: 'discoveryProvider',
-                width: '15%',
-            },
-            {
-                content: 'Kinds',
-                align: 'center',
-                sortable: true,
-                id: 'kinds',
-                width: '15%',
-            },
-            {
-                content: 'Start time',
-                align: 'center',
-                sortable: true,
-                id: 'startTime',
-                width: '10%',
-            },
-            {
-                content: 'Duration',
-                align: 'center',
-                sortable: true,
-                id: 'duration',
-                width: '5%',
-            },
-            {
-                content: 'Status',
-                align: 'center',
-                sortable: true,
-                id: 'status',
-                width: '10%',
-            },
-            {
-                content: 'Total Certificates',
-                align: 'center',
-                sortable: true,
-                sortType: 'numeric',
-                id: 'totalCertificates',
-                width: '10%',
-            },
-        ],
-        [],
-    );
+    const registry = useMemo(() => buildDiscoveryCellRegistry({ dateFormatter, durationFormatter }), []);
 
-    const discoveryList: TableDataRow[] = useMemo(
-        () =>
-            discoveries.map((discovery) => ({
-                id: discovery.uuid,
-                columns: [
-                    <Link key="name" to={`./detail/${discovery.uuid}`}>
-                        {discovery.name}
-                    </Link>,
-                    <ConnectorLink key="connector" uuid={discovery.connectorUuid} name={discovery.connectorName} fallback="Unassigned" />,
-                    <Badge key="kind" color="secondary">
-                        {discovery.kind}
-                    </Badge>,
-                    discovery.startTime ? (
-                        <span key="startTime" style={{ whiteSpace: 'nowrap' }}>
-                            {dateFormatter(discovery.startTime)}
-                        </span>
-                    ) : (
-                        ''
-                    ),
-                    <span key={`duration${discovery.uuid}`} style={{ whiteSpace: 'nowrap' }}>
-                        {durationFormatter(discovery.startTime, discovery.endTime)}
-                    </span>,
-                    <DiscoveryStatus key="status" status={discovery.status} />,
-                    discovery.totalCertificatesDiscovered?.toString() || '0',
-                ],
-            })),
-        [discoveries],
+    const configurableColumns = useMemo(
+        () => ({
+            resource: Resource.Discoveries,
+            standardColumns: DISCOVERY_COLUMNS,
+            rows: discoveries,
+            getRowId: (discovery: DiscoveryResponseModel) => discovery.uuid,
+            registry,
+            defaultSort: { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'DISCOVERY_NAME', direction: 'asc' as const },
+            resourceLabel: 'Discoveries',
+        }),
+        [discoveries, registry],
     );
 
     const onListCallback = useCallback((filters: SearchRequestModel) => dispatch(actions.listDiscoveries(filters)), [dispatch]);
@@ -157,8 +84,7 @@ function DiscoveryList() {
                 onListCallback={onListCallback}
                 onDeleteCallback={(uuids) => dispatch(actions.bulkDeleteDiscovery({ uuids }))}
                 getAvailableFiltersApi={useCallback((apiClients: ApiClients) => apiClients.discoveries.getDiscoverySearchableFields(), [])}
-                headers={discoveriesRowHeaders}
-                data={discoveryList}
+                configurableColumns={configurableColumns}
                 isBusy={isBusy}
                 title="Discovery Store"
                 entityNameSingular="a Discovery"

--- a/src/components/_pages/discoveries/list/index.tsx
+++ b/src/components/_pages/discoveries/list/index.tsx
@@ -2,7 +2,8 @@ import { useCallback, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { actions, selectors } from 'ducks/discoveries';
-import { EntityType } from 'ducks/filters';
+import { EntityType, actions as filterActions } from 'ducks/filters';
+import { actions as pagingActions } from 'ducks/paging';
 import { dateFormatter, durationFormatter } from 'utils/dateUtil';
 
 import type { ApiClients } from '../../../../api';
@@ -53,10 +54,16 @@ function DiscoveryList() {
         setIsAddModalOpen(false);
     }, []);
 
+    // Back to an unfiltered first page, so the discovery just created is on it. The refresh goes through
+    // the token rather than a request assembled here, which would carry no columns and no ordering.
+    const [refreshToken, setRefreshToken] = useState(0);
+
     const handleFormSuccess = useCallback(() => {
         handleCloseAddModal();
-        onListCallback({ itemsPerPage: 10, pageNumber: 1, filters: [] });
-    }, [handleCloseAddModal, onListCallback]);
+        dispatch(filterActions.setCurrentFilters({ entity: EntityType.DISCOVERY, currentFilters: [] }));
+        dispatch(pagingActions.resetPaging({ entity: EntityType.DISCOVERY }));
+        setRefreshToken((token) => token + 1);
+    }, [handleCloseAddModal, dispatch]);
 
     const handleCreateSuccess = useCallback(() => {
         if (!isAddModalOpen) return;
@@ -93,6 +100,7 @@ function DiscoveryList() {
                 pageWidgetLockName={LockWidgetNameEnum.DiscoveriesStore}
                 addHidden
                 additionalButtons={additionalButtons}
+                refreshToken={refreshToken}
             />
             <Dialog
                 isOpen={isAddModalOpen}

--- a/src/components/_pages/discoveries/list/index.tsx
+++ b/src/components/_pages/discoveries/list/index.tsx
@@ -9,9 +9,9 @@ import type { ApiClients } from '../../../../api';
 import PagedList from 'components/PagedList/PagedList';
 import type { SearchRequestModel } from 'types/certificate';
 import { LockWidgetNameEnum } from 'types/user-interface';
-import { FilterFieldSource, Resource } from 'types/openapi';
+import { Resource } from 'types/openapi';
 import type { DiscoveryResponseModel } from 'types/discoveries';
-import { buildDiscoveryCellRegistry, DISCOVERY_COLUMNS } from '../discoveryTableHelpers';
+import { buildDiscoveryCellRegistry, DISCOVERY_COLUMNS, DISCOVERY_DEFAULT_SORT } from '../discoveryTableHelpers';
 import Dialog from 'components/Dialog';
 import DiscoveryForm from '../form';
 import type { WidgetButtonProps } from 'components/WidgetButtons';
@@ -37,7 +37,7 @@ function DiscoveryList() {
             rows: discoveries,
             getRowId: (discovery: DiscoveryResponseModel) => discovery.uuid,
             registry,
-            defaultSort: { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'DISCOVERY_NAME', direction: 'asc' as const },
+            defaultSort: DISCOVERY_DEFAULT_SORT,
             resourceLabel: 'Discoveries',
         }),
         [discoveries, registry],

--- a/src/components/_pages/inventoryColumns.unit.spec.tsx
+++ b/src/components/_pages/inventoryColumns.unit.spec.tsx
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+
+import { FilterFieldSource, Resource, type SearchFieldDataByGroupDto } from 'types/openapi';
+import type { ColumnDefinition } from 'types/tableColumns';
+import { toCreateRequest, toStandardSlice } from 'utils/listViews';
+import { buildCbomCellRegistry, CBOM_COLUMNS } from './cboms/cbomTableHelpers';
+import { buildConnectorCellRegistry, buildConnectorColumns } from './connectors/connectorTableHelpers';
+import { buildDiscoveryCellRegistry, DISCOVERY_COLUMNS } from './discoveries/discoveryTableHelpers';
+import { buildSecretCellRegistry, SECRET_COLUMNS } from './secrets/secretTableHelpers';
+import { buildSigningRecordCellRegistry, SIGNING_RECORD_COLUMNS } from './signing-records/signingRecordTableHelpers';
+
+const noop = () => '';
+const enums = { getEnumLabel: noop, dateFormatter: noop, durationFormatter: noop };
+
+/**
+ * Each inventory's default column set beside the identifiers core's `FilterField` publishes for that resource, and the
+ * identifiers deliberately absent from it. A column outside both lists is the failure this guards: it would either
+ * render blank or make a saved view fail validation.
+ */
+const inventories = [
+    {
+        name: 'discoveries',
+        resource: Resource.Discoveries,
+        columns: DISCOVERY_COLUMNS,
+        registry: buildDiscoveryCellRegistry(enums),
+        catalogued: [
+            'DISCOVERY_NAME',
+            'DISCOVERY_START_TIME',
+            'DISCOVERY_END_TIME',
+            'DISCOVERY_STATUS',
+            'DISCOVERY_TOTAL_CERT_DISCOVERED',
+            'DISCOVERY_CONNECTOR_NAME',
+            'DISCOVERY_KIND',
+        ],
+        displayOnly: ['DISCOVERY_DURATION'],
+    },
+    {
+        name: 'connectors',
+        resource: Resource.Connectors,
+        columns: buildConnectorColumns(true),
+        registry: buildConnectorCellRegistry({
+            interfaceEnum: undefined,
+            featureEnum: undefined,
+            functionGroupEnum: undefined,
+            authTypeEnum: undefined,
+            getEnumLabel: noop,
+            onOverflowClick: () => undefined,
+        }),
+        catalogued: [
+            'CONNECTOR_NAME',
+            'CONNECTOR_VERSION',
+            'CONNECTOR_URL',
+            'CONNECTOR_AUTH_TYPE',
+            'CONNECTOR_STATUS',
+            'CONNECTOR_INTERFACE',
+            'CONNECTOR_FEATURES',
+            'CONNECTOR_FUNCTION_GROUP',
+        ],
+        displayOnly: ['CONNECTOR_PROXY'],
+    },
+    {
+        name: 'secrets',
+        resource: Resource.Secrets,
+        columns: SECRET_COLUMNS,
+        registry: buildSecretCellRegistry({
+            secretTypeEnum: undefined,
+            secretStateEnum: undefined,
+            getEnumLabel: noop,
+            vaultProfiles: [],
+        }),
+        catalogued: [
+            'SECRET_NAME',
+            'SECRET_TYPE',
+            'SECRET_STATE',
+            'SECRET_ENABLED',
+            'SECRET_GROUP_NAME',
+            'SECRET_OWNER',
+            'SECRET_COMPLIANCE_STATUS',
+            'SECRET_SOURCE_VAULT_PROFILE',
+            'SECRET_SYNC_VAULT_PROFILE',
+        ],
+        displayOnly: ['SECRET_VERSION'],
+    },
+    {
+        name: 'cboms',
+        resource: Resource.Cboms,
+        columns: CBOM_COLUMNS,
+        registry: buildCbomCellRegistry({
+            assetSyncStateEnum: undefined,
+            getEnumLabel: noop,
+            dateFormatter: noop,
+            renderActions: () => null,
+        }),
+        catalogued: [
+            'CBOM_SERIAL_NUMBER',
+            'CBOM_VERSION',
+            'CBOM_TIMESTAMP',
+            'CBOM_SOURCE',
+            'CBOM_ALGORITHMS_COUNT',
+            'CBOM_CERTIFICATES_COUNT',
+            'CBOM_PROTOCOLS_COUNT',
+            'CBOM_CRYPTO_MATERIAL_COUNT',
+            'CBOM_TOTAL_ASSETS_COUNT',
+            'CBOM_ASSET_SYNC_STATE',
+            'CBOM_ASSETS_SYNCED_AT',
+        ],
+        displayOnly: [],
+    },
+    {
+        name: 'signing records',
+        resource: Resource.SigningRecords,
+        columns: SIGNING_RECORD_COLUMNS,
+        registry: buildSigningRecordCellRegistry({ signingProtocolEnum: undefined, getEnumLabel: noop, dateFormatter: noop }),
+        catalogued: [
+            'SIGNING_RECORD_NAME',
+            'SIGNING_RECORD_SIGNING_PROFILE',
+            'SIGNING_RECORD_PROTOCOL',
+            'SIGNING_RECORD_SIGNING_PROFILE_VERSION',
+            'SIGNING_RECORD_SIGNING_TIME',
+            'SIGNING_RECORD_SIGNED_DOCUMENT_RETRIEVED_AT',
+            'SIGNING_RECORD_CREATED',
+        ],
+        displayOnly: [],
+    },
+];
+
+function catalogueOf(identifiers: readonly string[]): SearchFieldDataByGroupDto[] {
+    return [
+        {
+            filterFieldSource: FilterFieldSource.Property,
+            searchFieldData: identifiers.map((fieldIdentifier) => ({ fieldIdentifier, fieldLabel: fieldIdentifier, conditions: [] })),
+        },
+    ] as unknown as SearchFieldDataByGroupDto[];
+}
+
+function identifiersOf(columns: readonly ColumnDefinition[]): string[] {
+    return columns.map((column) => column.fieldIdentifier);
+}
+
+describe.each(inventories)('$name default columns', ({ resource, columns, registry, catalogued, displayOnly }) => {
+    it('renders every column it ships, so none of them is blank', () => {
+        const missing = columns.filter((column) => registry[`${column.fieldSource}:${column.fieldIdentifier}`] === undefined);
+
+        expect(identifiersOf(missing)).toEqual([]);
+    });
+
+    it('names only known display-only columns outside the catalogue', () => {
+        expect(identifiersOf(columns).filter((identifier) => !catalogued.includes(identifier))).toEqual(displayOnly);
+    });
+
+    it('saves as a view, dropping only the display-only columns', () => {
+        const request = toCreateRequest('Standard (copy)', resource, toStandardSlice(columns), catalogueOf(catalogued));
+
+        expect(request.columns.map((column) => column.fieldIdentifier)).toEqual(
+            identifiersOf(columns).filter((identifier) => !displayOnly.includes(identifier)),
+        );
+    });
+
+    it('registers no renderer for a field that exists nowhere, which would never be reached', () => {
+        const known = [...catalogued, ...displayOnly];
+        const stray = Object.keys(registry)
+            .map((key) => key.slice(key.indexOf(':') + 1))
+            .filter((identifier) => !known.includes(identifier));
+
+        expect(stray).toEqual([]);
+    });
+});

--- a/src/components/_pages/inventoryColumns.unit.spec.tsx
+++ b/src/components/_pages/inventoryColumns.unit.spec.tsx
@@ -1,6 +1,9 @@
+import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 
-import { FilterFieldSource, Resource, type SearchFieldDataByGroupDto } from 'types/openapi';
+import { renderCell } from 'components/CustomTable/columns';
+import type { ConnectorResponseModel } from 'types/connectors';
+import { ConnectorVersion, FilterFieldSource, Resource, type SearchFieldDataByGroupDto } from 'types/openapi';
 import type { ColumnDefinition } from 'types/tableColumns';
 import { toCreateRequest, toStandardSlice } from 'utils/listViews';
 import { buildCbomCellRegistry, CBOM_COLUMNS } from './cboms/cbomTableHelpers';
@@ -163,5 +166,35 @@ describe.each(inventories)('$name default columns', ({ resource, columns, regist
             .filter((identifier) => !known.includes(identifier));
 
         expect(stray).toEqual([]);
+    });
+});
+
+/**
+ * A cell that always returns an element renders blank rather than reaching the shared empty state, because
+ * `renderCell` only substitutes it for a renderer that returned nothing. The connector version is the one optional
+ * field in these inventories whose cell carries markup of its own.
+ */
+describe('optional connector version cell', () => {
+    const registry = buildConnectorCellRegistry({
+        interfaceEnum: undefined,
+        featureEnum: undefined,
+        functionGroupEnum: undefined,
+        authTypeEnum: undefined,
+        getEnumLabel: noop,
+        onOverflowClick: () => undefined,
+    });
+    const column = buildConnectorColumns(true).find((candidate) => candidate.fieldIdentifier === 'CONNECTOR_VERSION');
+
+    function render(connector: Partial<ConnectorResponseModel>): string {
+        if (!column) throw new Error('the connectors default set no longer ships a version column');
+        return renderToStaticMarkup(renderCell(connector as ConnectorResponseModel, column, registry));
+    }
+
+    it('reaches the shared empty state when the connector carries no version', () => {
+        expect(render({ uuid: 'connector-1' })).toContain('No value');
+    });
+
+    it('shows the version the connector carries', () => {
+        expect(render({ uuid: 'connector-1', version: ConnectorVersion.V2 })).toContain(ConnectorVersion.V2);
     });
 });

--- a/src/components/_pages/inventoryColumns.unit.spec.tsx
+++ b/src/components/_pages/inventoryColumns.unit.spec.tsx
@@ -1,10 +1,12 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 
-import { renderCell } from 'components/CustomTable/columns';
+import { type CellRegistry, renderCell } from 'components/CustomTable/columns';
 import type { ConnectorResponseModel } from 'types/connectors';
+import type { DiscoveryResponseModel } from 'types/discoveries';
 import { ConnectorVersion, FilterFieldSource, Resource, type SearchFieldDataByGroupDto } from 'types/openapi';
 import type { ColumnDefinition } from 'types/tableColumns';
+import { durationFormatter } from 'utils/dateUtil';
 import { toCreateRequest, toStandardSlice } from 'utils/listViews';
 import { buildCbomCellRegistry, CBOM_COLUMNS } from './cboms/cbomTableHelpers';
 import { buildConnectorCellRegistry, buildConnectorColumns } from './connectors/connectorTableHelpers';
@@ -171,11 +173,11 @@ describe.each(inventories)('$name default columns', ({ resource, columns, regist
 
 /**
  * A cell that always returns an element renders blank rather than reaching the shared empty state, because
- * `renderCell` only substitutes it for a renderer that returned nothing. The connector version is the one optional
- * field in these inventories whose cell carries markup of its own.
+ * `renderCell` only substitutes it for a renderer that returned nothing. These are the default columns whose value
+ * can be absent while the cell around it carries markup of its own.
  */
-describe('optional connector version cell', () => {
-    const registry = buildConnectorCellRegistry({
+describe('cells whose value can be absent', () => {
+    const connectorRegistry = buildConnectorCellRegistry({
         interfaceEnum: undefined,
         featureEnum: undefined,
         functionGroupEnum: undefined,
@@ -183,18 +185,40 @@ describe('optional connector version cell', () => {
         getEnumLabel: noop,
         onOverflowClick: () => undefined,
     });
-    const column = buildConnectorColumns(true).find((candidate) => candidate.fieldIdentifier === 'CONNECTOR_VERSION');
+    const discoveryRegistry = buildDiscoveryCellRegistry({ dateFormatter: () => 'a date', durationFormatter });
 
-    function render(connector: Partial<ConnectorResponseModel>): string {
-        if (!column) throw new Error('the connectors default set no longer ships a version column');
-        return renderToStaticMarkup(renderCell(connector as ConnectorResponseModel, column, registry));
+    function render<TRow extends object>(row: TRow, columns: ColumnDefinition[], registry: CellRegistry<TRow>, identifier: string) {
+        const column = columns.find((candidate) => candidate.fieldIdentifier === identifier);
+        if (!column) throw new Error(`the default set no longer ships ${identifier}`);
+        return renderToStaticMarkup(renderCell(row, column, registry));
     }
 
-    it('reaches the shared empty state when the connector carries no version', () => {
-        expect(render({ uuid: 'connector-1' })).toContain('No value');
+    const connectorColumns = buildConnectorColumns(true);
+
+    function connectorVersion(connector: Partial<ConnectorResponseModel>) {
+        return render(connector as ConnectorResponseModel, connectorColumns, connectorRegistry, 'CONNECTOR_VERSION');
+    }
+
+    function discoveryDuration(discovery: Partial<DiscoveryResponseModel>) {
+        return render(discovery as DiscoveryResponseModel, DISCOVERY_COLUMNS, discoveryRegistry, 'DISCOVERY_DURATION');
+    }
+
+    it('reaches the empty state for a connector carrying no version', () => {
+        expect(connectorVersion({ uuid: 'connector-1' })).toContain('No value');
     });
 
-    it('shows the version the connector carries', () => {
-        expect(render({ uuid: 'connector-1', version: ConnectorVersion.V2 })).toContain(ConnectorVersion.V2);
+    it('shows the version a connector carries', () => {
+        expect(connectorVersion({ uuid: 'connector-1', version: ConnectorVersion.V2 })).toContain(ConnectorVersion.V2);
+    });
+
+    it('reaches the empty state for a discovery that has not started', () => {
+        expect(discoveryDuration({ uuid: 'discovery-1' })).toContain('No value');
+    });
+
+    it('shows the duration a started discovery has run for', () => {
+        const markup = discoveryDuration({ uuid: 'discovery-1', startTime: '2026-01-01T00:00:00Z', endTime: '2026-01-01T00:00:05Z' });
+
+        expect(markup).not.toContain('No value');
+        expect(markup).toContain('05');
     });
 });

--- a/src/components/_pages/secrets/list/index.tsx
+++ b/src/components/_pages/secrets/list/index.tsx
@@ -1,9 +1,6 @@
-import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Link } from 'react-router';
 
-import type { TableDataRow, TableHeader } from 'components/CustomTable';
-import Badge from 'components/Badge';
 import PagedList from 'components/PagedList/PagedList';
 import Dialog from 'components/Dialog';
 import type { WidgetButtonProps } from 'components/WidgetButtons';
@@ -21,11 +18,10 @@ import { actions as vaultProfileActions, selectors as vaultProfileSelectors } fr
 
 import type { SearchRequestModel } from 'types/certificate';
 import { LockWidgetNameEnum } from 'types/user-interface';
-import { ComplianceStatus, PlatformEnum, Resource } from 'types/openapi';
+import { PlatformEnum, Resource, type SecretDto } from 'types/openapi';
+import { buildSecretCellRegistry, SECRET_COLUMNS } from '../secretTableHelpers';
 
 import SecretForm from '../form';
-import SecretStateBadge from '../SecretStateBadge';
-import CertificateStatus from 'components/_pages/certificates/CertificateStatus';
 
 export default function SecretsList() {
     const dispatch = useDispatch();
@@ -63,116 +59,30 @@ export default function SecretsList() {
         dispatch(vaultProfileActions.listVaultProfiles());
     }, [dispatch]);
 
-    const headers: TableHeader[] = useMemo(
-        () => [
-            {
-                id: 'name',
-                content: 'Name',
-                width: '25%',
-                sortable: true,
-            },
-            {
-                id: 'type',
-                content: 'Type',
-                info: <EnumColumnDescription platformEnum={PlatformEnum.SecretType} title="Type" />,
-                width: '10%',
-                sortable: true,
-            },
-            {
-                id: 'state',
-                content: 'State',
-                info: <EnumColumnDescription platformEnum={PlatformEnum.SecretState} title="State" />,
-                width: '10%',
-                align: 'center',
-                sortable: true,
-            },
-            {
-                id: 'compliance',
-                content: 'Compliance',
-                width: '10%',
-                align: 'center',
-                sortable: false,
-            },
-            {
-                id: 'vaultProfile',
-                content: 'Vault Profile',
-                width: '15%',
-                sortable: true,
-            },
-            {
-                id: 'version',
-                content: 'Version',
-                width: '5%',
-                align: 'center',
-                sortable: true,
-            },
-            {
-                id: 'owner',
-                content: 'Owner',
-                width: '15%',
-                sortable: true,
-            },
-            {
-                id: 'groups',
-                content: 'Groups',
-                width: '15%',
-                sortable: true,
-            },
-            {
-                id: 'status',
-                content: 'Status',
-                width: '5%',
-                align: 'center',
-                sortable: true,
-            },
-        ],
+    const registry = useMemo(
+        () => buildSecretCellRegistry({ secretTypeEnum, secretStateEnum, getEnumLabel, vaultProfiles }),
+        [secretTypeEnum, secretStateEnum, vaultProfiles],
+    );
+
+    const headerInfo = useMemo(
+        () => ({
+            'property:SECRET_TYPE': <EnumColumnDescription platformEnum={PlatformEnum.SecretType} title="Type" />,
+            'property:SECRET_STATE': <EnumColumnDescription platformEnum={PlatformEnum.SecretState} title="State" />,
+        }),
         [],
     );
 
-    const rows: TableDataRow[] = useMemo(
-        () =>
-            secrets.map((secret) => ({
-                id: secret.uuid,
-                columns: [
-                    <span key="name" style={{ whiteSpace: 'nowrap' }}>
-                        <Link to={`./detail/${secret.uuid}`}>{secret.name}</Link>
-                    </span>,
-                    getEnumLabel(secretTypeEnum, secret.type),
-                    <SecretStateBadge key="state" state={secret.state}>
-                        {getEnumLabel(secretStateEnum, secret.state)}
-                    </SecretStateBadge>,
-                    <CertificateStatus key="compliance" status={secret.complianceStatus || ComplianceStatus.Na} asIcon={true} />,
-                    secret.sourceVaultProfile
-                        ? (() => {
-                              const profile = vaultProfiles.find((p) => p.uuid === secret.sourceVaultProfile?.uuid);
-                              const vaultUuid = profile?.vaultInstance?.uuid;
-                              return vaultUuid ? (
-                                  <Link
-                                      to={`/${Resource.VaultProfiles.toLowerCase()}/detail/${vaultUuid}/${secret.sourceVaultProfile.uuid}`}
-                                  >
-                                      {secret.sourceVaultProfile.name}
-                                  </Link>
-                              ) : (
-                                  secret.sourceVaultProfile.name
-                              );
-                          })()
-                        : '',
-                    secret.version ? secret.version.toString() : '',
-                    secret.owner ? <Link to={`../users/detail/${secret.owner.uuid}`}>{secret.owner.name}</Link> : 'Unassigned',
-                    secret.groups && secret.groups.length > 0
-                        ? secret.groups.map((group, i) => (
-                              <Fragment key={group.uuid}>
-                                  <Link to={`../groups/detail/${group.uuid}`}>{group.name}</Link>
-                                  {secret.groups && i !== secret.groups.length - 1 ? ', ' : ''}
-                              </Fragment>
-                          ))
-                        : 'Unassigned',
-                    <Badge key="status" color={secret.enabled ? 'success' : 'danger'}>
-                        {secret.enabled ? 'Enabled' : 'Disabled'}
-                    </Badge>,
-                ],
-            })),
-        [secrets, secretTypeEnum, secretStateEnum, vaultProfiles],
+    const configurableColumns = useMemo(
+        () => ({
+            resource: Resource.Secrets,
+            standardColumns: SECRET_COLUMNS,
+            rows: secrets,
+            getRowId: (secret: SecretDto) => secret.uuid,
+            registry,
+            headerInfo,
+            resourceLabel: 'Secrets',
+        }),
+        [secrets, registry, headerInfo],
     );
 
     const onListCallback = useCallback((filters: SearchRequestModel) => dispatch(actions.listSecrets(filters)), [dispatch]);
@@ -311,8 +221,7 @@ export default function SecretsList() {
                 entity={EntityType.SECRET}
                 onListCallback={onListCallback}
                 onDeleteCallback={handleDeleteSecrets}
-                headers={headers}
-                data={rows}
+                configurableColumns={configurableColumns}
                 isBusy={isBusy}
                 title="List of Secrets"
                 entityNameSingular="Secret"

--- a/src/components/_pages/secrets/list/index.unit.spec.tsx
+++ b/src/components/_pages/secrets/list/index.unit.spec.tsx
@@ -34,14 +34,18 @@ vi.mock('components/_pages/certificates/CertificateStatus', () => ({
 }));
 
 vi.mock('components/PagedList/PagedList', () => ({
-    default: ({ headers, data, additionalButtons, onDeleteCallback }: any) => (
+    default: ({ configurableColumns, additionalButtons, onDeleteCallback }: any) => (
         <div>
-            <div data-testid="headers">{headers.map((h: any) => h.content).join('|')}</div>
+            <div data-testid="headers">
+                {(configurableColumns?.standardColumns || []).map((column: any) => column.catalogueLabel).join('|')}
+            </div>
             <div data-testid="rows">
-                {(data || []).map((row: any) => (
-                    <div key={row.id} data-testid={`row-${row.id}`}>
-                        {(row.columns || []).map((column: any, index: number) => (
-                            <span key={`${row.id}-col-${index}`}>{column}</span>
+                {(configurableColumns?.rows || []).map((row: any) => (
+                    <div key={configurableColumns.getRowId(row)} data-testid={`row-${configurableColumns.getRowId(row)}`}>
+                        {(configurableColumns.standardColumns || []).map((column: any) => (
+                            <span key={`${configurableColumns.getRowId(row)}-${column.fieldIdentifier}`}>
+                                {configurableColumns.registry?.[`${column.fieldSource}:${column.fieldIdentifier}`]?.(row)}
+                            </span>
                         ))}
                     </div>
                 ))}

--- a/src/components/_pages/secrets/secretTableHelpers.tsx
+++ b/src/components/_pages/secrets/secretTableHelpers.tsx
@@ -1,0 +1,115 @@
+import { Fragment } from 'react';
+import { Link } from 'react-router';
+import Badge from 'components/Badge';
+import type { CellRegistry } from 'components/CustomTable/columns';
+import CertificateStatus from 'components/_pages/certificates/CertificateStatus';
+import type { EnumItemModel } from 'types/enums';
+import { ComplianceStatus, FilterFieldSource, FilterFieldType, Resource, type SecretDto, type VaultProfileDto } from 'types/openapi';
+import type { ColumnDefinition } from 'types/tableColumns';
+import SecretStateBadge from './SecretStateBadge';
+
+type PlatformEnumMap = { [key: string]: EnumItemModel } | undefined;
+
+export interface BuildSecretCellsOpts {
+    secretTypeEnum: PlatformEnumMap;
+    secretStateEnum: PlatformEnumMap;
+    getEnumLabel: (enumMap: PlatformEnumMap, key: string) => string;
+    vaultProfiles: VaultProfileDto[];
+}
+
+/**
+ * The platform default column set for the secrets inventory.
+ *
+ * `SECRET_VERSION` is not in the filter-field catalogue, so it is display-only — shown here, not sortable, and dropped
+ * on write by `toStorableColumns`. It keeps a natural identifier so that cataloguing it is the only change needed.
+ */
+export const SECRET_COLUMNS: ColumnDefinition[] = [
+    { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'SECRET_NAME', catalogueLabel: 'Name', type: FilterFieldType.String },
+    { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'SECRET_TYPE', catalogueLabel: 'Type', type: FilterFieldType.List },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'SECRET_STATE',
+        catalogueLabel: 'State',
+        type: FilterFieldType.List,
+        align: 'center',
+    },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'SECRET_COMPLIANCE_STATUS',
+        catalogueLabel: 'Compliance Status',
+        label: 'Compliance',
+        type: FilterFieldType.List,
+        align: 'center',
+    },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'SECRET_SOURCE_VAULT_PROFILE',
+        catalogueLabel: 'Source Vault Profile',
+        label: 'Vault Profile',
+        type: FilterFieldType.List,
+    },
+    { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'SECRET_VERSION', catalogueLabel: 'Version', align: 'center' },
+    { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'SECRET_OWNER', catalogueLabel: 'Owner', type: FilterFieldType.List },
+    { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'SECRET_GROUP_NAME', catalogueLabel: 'Groups', type: FilterFieldType.List },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'SECRET_ENABLED',
+        catalogueLabel: 'Enabled',
+        label: 'Status',
+        type: FilterFieldType.Boolean,
+        align: 'center',
+    },
+];
+
+/**
+ * `SECRET_SYNC_VAULT_PROFILE` is catalogued but absent from `SecretDto`, so no renderer is registered and the picker
+ * does not offer it.
+ */
+export function buildSecretCellRegistry({
+    secretTypeEnum,
+    secretStateEnum,
+    getEnumLabel,
+    vaultProfiles,
+}: BuildSecretCellsOpts): CellRegistry<SecretDto> {
+    return {
+        'property:SECRET_NAME': (secret) => (
+            <span className="whitespace-nowrap">
+                <Link to={`./detail/${secret.uuid}`}>{secret.name}</Link>
+            </span>
+        ),
+        'property:SECRET_TYPE': (secret) => getEnumLabel(secretTypeEnum, secret.type),
+        'property:SECRET_STATE': (secret) => (
+            <SecretStateBadge state={secret.state}>{getEnumLabel(secretStateEnum, secret.state)}</SecretStateBadge>
+        ),
+        'property:SECRET_COMPLIANCE_STATUS': (secret) => (
+            <CertificateStatus status={secret.complianceStatus || ComplianceStatus.Na} asIcon={true} />
+        ),
+        'property:SECRET_SOURCE_VAULT_PROFILE': (secret) => {
+            if (!secret.sourceVaultProfile) return null;
+            // The link needs the vault instance the profile belongs to, which the listing does not carry.
+            const vaultUuid = vaultProfiles.find((profile) => profile.uuid === secret.sourceVaultProfile?.uuid)?.vaultInstance?.uuid;
+            return vaultUuid ? (
+                <Link to={`/${Resource.VaultProfiles.toLowerCase()}/detail/${vaultUuid}/${secret.sourceVaultProfile.uuid}`}>
+                    {secret.sourceVaultProfile.name}
+                </Link>
+            ) : (
+                secret.sourceVaultProfile.name
+            );
+        },
+        'property:SECRET_VERSION': (secret) => secret.version?.toString(),
+        'property:SECRET_OWNER': (secret) =>
+            secret.owner ? <Link to={`../users/detail/${secret.owner.uuid}`}>{secret.owner.name}</Link> : 'Unassigned',
+        'property:SECRET_GROUP_NAME': (secret) =>
+            secret.groups && secret.groups.length > 0
+                ? secret.groups.map((group, index) => (
+                      <Fragment key={group.uuid}>
+                          <Link to={`../groups/detail/${group.uuid}`}>{group.name}</Link>
+                          {index !== (secret.groups?.length ?? 0) - 1 ? ', ' : ''}
+                      </Fragment>
+                  ))
+                : 'Unassigned',
+        'property:SECRET_ENABLED': (secret) => (
+            <Badge color={secret.enabled ? 'success' : 'danger'}>{secret.enabled ? 'Enabled' : 'Disabled'}</Badge>
+        ),
+    };
+}

--- a/src/components/_pages/signing-records/list/index.tsx
+++ b/src/components/_pages/signing-records/list/index.tsx
@@ -1,18 +1,19 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Link } from 'react-router';
 import PagedList from 'components/PagedList/PagedList';
-import type { TableDataRow, TableHeader } from 'components/CustomTable';
 import Dialog from 'components/Dialog';
+import { EnumColumnDescription } from 'components/EnumDescription';
 import ForceDeleteErrorTable from 'components/ForceDeleteErrorTable';
 import { actions, selectors } from 'ducks/signing-records';
+import { selectors as enumSelectors, getEnumLabel } from 'ducks/enums';
 import { EntityType } from 'ducks/filters';
 import { selectors as pagingSelectors } from 'ducks/paging';
 import { LockWidgetNameEnum } from 'types/user-interface';
-import { Resource } from 'types/openapi';
+import { PlatformEnum, Resource, type SigningRecordListDto } from 'types/openapi';
 import type { SearchRequestModel } from 'types/certificate';
 import type { ApiClients } from 'src/api';
 import { dateFormatter } from 'utils/dateUtil';
+import { buildSigningRecordCellRegistry, SIGNING_RECORD_COLUMNS } from '../signingRecordTableHelpers';
 
 function SigningRecordsList() {
     const dispatch = useDispatch();
@@ -23,6 +24,7 @@ function SigningRecordsList() {
     const isBulkDeleting = useSelector(selectors.selectIsBulkDeleting);
     const bulkDeleteErrorMessages = useSelector(selectors.selectBulkDeleteErrorMessages);
     const checkedRows = useSelector(pagingSelectors.checkedRows(EntityType.SIGNING_RECORD));
+    const signingProtocolEnum = useSelector(enumSelectors.platformEnum(PlatformEnum.SigningProtocol));
 
     const [showDeleteErrors, setShowDeleteErrors] = useState(false);
 
@@ -39,36 +41,29 @@ function SigningRecordsList() {
         setShowDeleteErrors(false);
     }, [dispatch]);
 
-    const headers: TableHeader[] = useMemo(
-        () => [
-            { content: 'Name', sortable: true, id: 'name' },
-            { content: 'Signing Profile', sortable: true, id: 'signingProfile' },
-            { content: 'Signing Time', sortable: true, id: 'signingTime' },
-            { content: 'Created At', sortable: true, id: 'createdAt' },
-        ],
+    const registry = useMemo(
+        () => buildSigningRecordCellRegistry({ signingProtocolEnum, getEnumLabel, dateFormatter }),
+        [signingProtocolEnum],
+    );
+
+    const headerInfo = useMemo(
+        () => ({
+            'property:SIGNING_RECORD_PROTOCOL': <EnumColumnDescription platformEnum={PlatformEnum.SigningProtocol} title="Protocol" />,
+        }),
         [],
     );
 
-    const rows: TableDataRow[] = useMemo(
-        () =>
-            signingRecords.map((record) => ({
-                id: record.uuid,
-                columns: [
-                    <Link key="name" to={`./detail/${record.uuid}`}>
-                        {record.name}
-                    </Link>,
-                    record.signingProfile ? (
-                        <Link key="profile" to={`/${Resource.SigningProfiles.toLowerCase()}/detail/${record.signingProfile.uuid}`}>
-                            {record.signingProfile.name} (v{record.signingProfile.version})
-                        </Link>
-                    ) : (
-                        '-'
-                    ),
-                    record.signingTime ? dateFormatter(record.signingTime) : '-',
-                    record.createdAt ? dateFormatter(record.createdAt) : '-',
-                ],
-            })),
-        [signingRecords],
+    const configurableColumns = useMemo(
+        () => ({
+            resource: Resource.SigningRecords,
+            standardColumns: SIGNING_RECORD_COLUMNS,
+            rows: signingRecords,
+            getRowId: (record: SigningRecordListDto) => record.uuid,
+            registry,
+            headerInfo,
+            resourceLabel: 'Signing Records',
+        }),
+        [signingRecords, registry, headerInfo],
     );
 
     const onList = useCallback((filters: SearchRequestModel) => dispatch(actions.listSigningRecords(filters)), [dispatch]);
@@ -93,8 +88,7 @@ function SigningRecordsList() {
                     [],
                 )}
                 filterTitle="Signing Records Filter"
-                headers={headers}
-                data={rows}
+                configurableColumns={configurableColumns}
                 isBusy={isBusy}
                 title="Signing Records"
                 entityNameSingular="a Signing Record"

--- a/src/components/_pages/signing-records/list/index.tsx
+++ b/src/components/_pages/signing-records/list/index.tsx
@@ -68,6 +68,9 @@ function SigningRecordsList() {
 
     const onList = useCallback((filters: SearchRequestModel) => dispatch(actions.listSigningRecords(filters)), [dispatch]);
 
+    // A bulk delete re-reads through the host so the replayed request keeps the applied columns and ordering.
+    const refreshToken = useSelector(selectors.selectListRefreshToken);
+
     return (
         <>
             <PagedList
@@ -96,6 +99,7 @@ function SigningRecordsList() {
                 addHidden
                 hasCheckboxes={true}
                 pageWidgetLockName={LockWidgetNameEnum.ListOfSigningRecords}
+                refreshToken={refreshToken}
             />
 
             <Dialog

--- a/src/components/_pages/signing-records/signingRecordTableHelpers.tsx
+++ b/src/components/_pages/signing-records/signingRecordTableHelpers.tsx
@@ -1,0 +1,68 @@
+import { Link } from 'react-router';
+import type { CellRegistry } from 'components/CustomTable/columns';
+import type { EnumItemModel } from 'types/enums';
+import { FilterFieldSource, FilterFieldType, Resource, type SigningRecordListDto } from 'types/openapi';
+import type { ColumnDefinition } from 'types/tableColumns';
+
+type PlatformEnumMap = { [key: string]: EnumItemModel } | undefined;
+
+export interface BuildSigningRecordCellsOpts {
+    signingProtocolEnum: PlatformEnumMap;
+    getEnumLabel: (enumMap: PlatformEnumMap, key: string) => string;
+    dateFormatter: (date: string | Date) => string;
+}
+
+/** The platform default column set for the signing records inventory: what the page shipped before the picker. */
+export const SIGNING_RECORD_COLUMNS: ColumnDefinition[] = [
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'SIGNING_RECORD_NAME',
+        catalogueLabel: 'Name',
+        type: FilterFieldType.String,
+    },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'SIGNING_RECORD_SIGNING_PROFILE',
+        catalogueLabel: 'Signing Profile',
+        type: FilterFieldType.List,
+    },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'SIGNING_RECORD_SIGNING_TIME',
+        catalogueLabel: 'Signing Time',
+        type: FilterFieldType.Date,
+    },
+    {
+        fieldSource: FilterFieldSource.Property,
+        fieldIdentifier: 'SIGNING_RECORD_CREATED',
+        catalogueLabel: 'Created At',
+        type: FilterFieldType.Date,
+    },
+];
+
+/**
+ * `SIGNING_RECORD_SIGNED_DOCUMENT_RETRIEVED_AT` is catalogued but absent from `SigningRecordListDto`, so no renderer
+ * is registered for it and the picker does not offer it.
+ */
+export function buildSigningRecordCellRegistry({
+    signingProtocolEnum,
+    getEnumLabel,
+    dateFormatter,
+}: BuildSigningRecordCellsOpts): CellRegistry<SigningRecordListDto> {
+    return {
+        'property:SIGNING_RECORD_NAME': (record) => <Link to={`./detail/${record.uuid}`}>{record.name}</Link>,
+        'property:SIGNING_RECORD_SIGNING_PROFILE': (record) =>
+            record.signingProfile ? (
+                <Link to={`/${Resource.SigningProfiles.toLowerCase()}/detail/${record.signingProfile.uuid}`}>
+                    {record.signingProfile.name} (v{record.signingProfile.version})
+                </Link>
+            ) : null,
+        'property:SIGNING_RECORD_SIGNING_TIME': (record) =>
+            record.signingTime ? <span className="whitespace-nowrap">{dateFormatter(record.signingTime)}</span> : null,
+        'property:SIGNING_RECORD_CREATED': (record) =>
+            record.createdAt ? <span className="whitespace-nowrap">{dateFormatter(record.createdAt)}</span> : null,
+        // Beyond the default set: catalogued and renderable, so the picker offers them.
+        'property:SIGNING_RECORD_PROTOCOL': (record) => (record.protocol ? getEnumLabel(signingProtocolEnum, record.protocol) : null),
+        'property:SIGNING_RECORD_SIGNING_PROFILE_VERSION': (record) => record.signingProfile?.version?.toString(),
+    };
+}

--- a/src/ducks/cbom-epics.spec.ts
+++ b/src/ducks/cbom-epics.spec.ts
@@ -330,7 +330,7 @@ describe('cbom epics', () => {
         expect(emitted[1]).toEqual(alertsSlice.actions.error('Failed to delete CBOM. delete failed'));
     });
 
-    test('bulkDeleteCbom success (page unchanged) emits success, alert and a re-fetch without setPagination', async () => {
+    test('bulkDeleteCbom success emits success and alert, and re-reads through the host rather than listing here', async () => {
         const uuids = ['u1', 'u2'];
         const deps = createDeps({
             bulkDeleteCbom: ({ requestBody }) => {
@@ -357,11 +357,12 @@ describe('cbom epics', () => {
         } as any;
 
         const output$ = (cbomEpics[6] as any)(of(slice.actions.bulkDeleteCbom({ uuids })), state$, deps as any);
-        const emitted = await firstValueFrom(output$.pipe(take(3), toArray()));
+        const emitted = await firstValueFrom(output$.pipe(take(2), toArray()));
 
         expect(emitted[0]).toEqual(slice.actions.bulkDeleteCbomSuccess({ uuids }));
         expect(emitted[1].type).toBe(alertsSlice.actions.success.type);
-        expect(emitted[2]).toEqual(slice.actions.listCboms({ pageNumber: 1, itemsPerPage: 10, filters: [] }));
+        // The listing is the host's to issue: only its own request names the applied columns and ordering.
+        expect(emitted.some((a: any) => a.type === slice.actions.listCboms.type)).toBe(false);
         expect(emitted.some((a: any) => a.type === pagingActions.setPagination.type)).toBe(false);
     });
 
@@ -391,11 +392,11 @@ describe('cbom epics', () => {
             state$,
             deps as any,
         );
-        const emitted = await firstValueFrom(output$.pipe(take(4), toArray()));
+        const emitted = await firstValueFrom(output$.pipe(take(3), toArray()));
 
         expect(emitted[0]).toEqual(slice.actions.bulkDeleteCbomSuccess({ uuids: ['c1', 'c2', 'c3', 'c4', 'c5'] }));
         expect(emitted[2]).toEqual(pagingActions.setPagination({ entity: EntityType.CBOM, pageNumber: 1, pageSize: 5 }));
-        expect(emitted[3]).toEqual(slice.actions.listCboms({ pageNumber: 1, itemsPerPage: 5, filters: [] }));
+        expect(emitted.some((a: any) => a.type === slice.actions.listCboms.type)).toBe(false);
     });
 
     test('bulkDeleteCbom failure emits bulkDeleteCbomFailure and error alert', async () => {

--- a/src/ducks/cbom-epics.ts
+++ b/src/ducks/cbom-epics.ts
@@ -206,8 +206,10 @@ const bulkDeleteCbom: AppEpic = (action$, state, deps) => {
                     return of(
                         slice.actions.bulkDeleteCbomSuccess({ uuids: action.payload.uuids }),
                         alertsSlice.actions.success('Selected CBOMs successfully deleted.'),
-                        // Only re-align the paging slice when the deletion emptied the current page
-                        // and we had to step back; otherwise the re-fetch below is enough.
+                        // Only re-align the paging slice when the deletion emptied the current page and
+                        // we had to step back. The re-read itself rides on the refresh token that
+                        // `bulkDeleteCbomSuccess` bumps, so the host replays its own request — columns
+                        // and ordering included — instead of one assembled from paging and filters here.
                         ...(pageNumberChanged
                             ? [
                                   pagingActions.setPagination({
@@ -217,7 +219,6 @@ const bulkDeleteCbom: AppEpic = (action$, state, deps) => {
                                   }),
                               ]
                             : []),
-                        slice.actions.listCboms(listParams),
                     );
                 }),
                 catchError((err) =>

--- a/src/ducks/cbom.spec.ts
+++ b/src/ducks/cbom.spec.ts
@@ -182,9 +182,10 @@ describe('cbom slice', () => {
 
         next = reducer(next, actions.bulkDeleteCbomSuccess({ uuids: ['cbom-1', 'cbom-3'] }));
         expect(next.isBulkDeleting).toBe(false);
-        // Items are not spliced optimistically — the epic triggers a server re-fetch.
+        // Items are not spliced optimistically — the host re-reads on the bumped refresh token.
         expect(next.cbomsData!.items).toEqual([{ uuid: 'cbom-1' }, { uuid: 'cbom-2' }, { uuid: 'cbom-3' }]);
         expect(next.cbomsData!.totalItems).toBe(3);
+        expect(next.listRefreshToken).toBe(initialState.listRefreshToken + 1);
 
         next = reducer({ ...next, isBulkDeleting: true }, actions.bulkDeleteCbomFailure({ error: 'err' }));
         expect(next.isBulkDeleting).toBe(false);

--- a/src/ducks/cbom.ts
+++ b/src/ducks/cbom.ts
@@ -28,6 +28,9 @@ export type State = {
     isBulkDeleting: boolean;
     isSyncing: boolean;
     syncSucceeded: boolean;
+
+    /** Bumped whenever a mutation needs the listing re-read; the page forwards it as `refreshToken`. */
+    listRefreshToken: number;
 };
 
 export const initialState: State = {
@@ -44,6 +47,8 @@ export const initialState: State = {
     isBulkDeleting: false,
     isSyncing: false,
     syncSucceeded: false,
+
+    listRefreshToken: 0,
 };
 
 export const slice = createSlice({
@@ -174,8 +179,9 @@ export const slice = createSlice({
 
         bulkDeleteCbomSuccess: (state, action: PayloadAction<{ uuids: string[] }>) => {
             state.isBulkDeleting = false;
-            // On success the epic re-fetches the list from the server, so no optimistic
-            // list mutation is needed here.
+            // The host re-reads its own request rather than this slice pruning the rows: the request
+            // carries the applied columns and ordering, which a list action assembled elsewhere cannot.
+            state.listRefreshToken += 1;
         },
 
         bulkDeleteCbomFailure: (state, action: PayloadAction<{ error: string | undefined }>) => {
@@ -220,6 +226,7 @@ export const selectIsDeleting = createSelector(featureSelector, (state) => state
 export const selectIsBulkDeleting = createSelector(featureSelector, (state) => state.isBulkDeleting);
 export const selectIsSyncing = createSelector(featureSelector, (state) => state.isSyncing);
 export const selectSyncSucceeded = createSelector(featureSelector, (state) => state.syncSucceeded);
+export const selectListRefreshToken = createSelector(featureSelector, (state) => state.listRefreshToken);
 
 export const selectors = {
     selectCbomsData,
@@ -239,6 +246,7 @@ export const selectors = {
     selectIsBulkDeleting,
     selectIsSyncing,
     selectSyncSucceeded,
+    selectListRefreshToken,
 };
 
 export const { actions } = slice;

--- a/src/ducks/connectors-epic.spec.ts
+++ b/src/ducks/connectors-epic.spec.ts
@@ -668,7 +668,7 @@ describe('connectors epics', () => {
         expect(emitted[1]).toEqual(appRedirectActions.fetchError({ error: err, message: 'Failed to authorize connector' }));
     });
 
-    test('bulkAuthorizeConnectors success refreshes list preserving current pagination and filters', async () => {
+    test('bulkAuthorizeConnectors success re-reads through the host rather than listing here', async () => {
         const currentFilters = [{ fieldSource: 'property', fieldIdentifier: 'name' }] as any;
         const stateValue = {
             pagings: { pagings: [{ entity: EntityType.CONNECTOR, paging: { pageNumber: 2, pageSize: 25 } }] },
@@ -685,11 +685,12 @@ describe('connectors epics', () => {
                     },
                 } as any,
             },
-            2,
+            1,
             stateValue,
         );
         expect(emitted[0]).toEqual(slice.actions.bulkAuthorizeConnectorsSuccess({ uuids: ['c-1', 'c-2'] }));
-        expect(emitted[1]).toEqual(slice.actions.listConnectors({ itemsPerPage: 25, pageNumber: 2, filters: currentFilters }));
+        // The listing is the host's to issue: only its own request names the applied columns and ordering.
+        expect(emitted.some((action: any) => action.type === slice.actions.listConnectors.type)).toBe(false);
     });
 
     test('bulkAuthorizeConnectors failure emits bulkAuthorizeConnectorsFailure and fetchError', async () => {

--- a/src/ducks/connectors-epic.ts
+++ b/src/ducks/connectors-epic.ts
@@ -406,12 +406,10 @@ const bulkAuthorizeConnectors: AppEpic = (action$, state, deps) => {
         filter(slice.actions.bulkAuthorizeConnectors.match),
         switchMap((action) =>
             deps.apiClients.connectorsV2.bulkApproveV2({ requestBody: action.payload.uuids }).pipe(
-                mergeMap(() =>
-                    of(
-                        slice.actions.bulkAuthorizeConnectorsSuccess({ uuids: action.payload.uuids }),
-                        slice.actions.listConnectors(entityListParams(EntityType.CONNECTOR, state.value)),
-                    ),
-                ),
+                // The re-read rides on the refresh token that `bulkAuthorizeConnectorsSuccess` bumps, so
+                // the host replays its own request — columns and ordering included — rather than one
+                // assembled from paging and filters here.
+                mergeMap(() => of(slice.actions.bulkAuthorizeConnectorsSuccess({ uuids: action.payload.uuids }))),
 
                 catchError((error) =>
                     of(

--- a/src/ducks/connectors.spec.ts
+++ b/src/ducks/connectors.spec.ts
@@ -576,4 +576,12 @@ describe('connectors selectors', () => {
         expect(next.connectorAuthAttributes).toBeUndefined();
         expect(next.isFetchingAuthAttributes).toBe(false);
     });
+
+    test('bulkAuthorizeConnectorsSuccess asks the host to re-read its own listing request', () => {
+        const next = reducer({ ...initialState, isBulkAuthorizing: true }, actions.bulkAuthorizeConnectorsSuccess({ uuids: ['c-1'] }));
+
+        expect(next.isBulkAuthorizing).toBe(false);
+        expect(next.listRefreshToken).toBe(initialState.listRefreshToken + 1);
+        expect(selectors.listRefreshToken({ connectors: next } as any)).toBe(initialState.listRefreshToken + 1);
+    });
 });

--- a/src/ducks/connectors.ts
+++ b/src/ducks/connectors.ts
@@ -55,6 +55,9 @@ export type State = {
     isBulkAuthorizing: boolean;
     isRunningCallback: { [key: string]: boolean };
     callbackSeq: { [key: string]: number };
+
+    /** Bumped whenever a mutation needs the listing re-read; the page forwards it as `refreshToken`. */
+    listRefreshToken: number;
 };
 
 function removeConnectorsByUuids(state: State, uuids: string[]) {
@@ -103,6 +106,8 @@ export const initialState: State = {
     isBulkAuthorizing: false,
     isRunningCallback: {},
     callbackSeq: {},
+
+    listRefreshToken: 0,
 };
 
 export const slice = createSlice({
@@ -475,6 +480,9 @@ export const slice = createSlice({
 
         bulkAuthorizeConnectorsSuccess: (state, action: PayloadAction<{ uuids: string[] }>) => {
             state.isBulkAuthorizing = false;
+            // The host re-reads its own request rather than the epic listing here: the request carries
+            // the applied columns and ordering, which a list action assembled elsewhere cannot.
+            state.listRefreshToken += 1;
         },
 
         bulkAuthorizeConnectorsFailure: (state, action: PayloadAction<void>) => {
@@ -555,6 +563,7 @@ const isReconnecting = createSelector(state, (state) => state.isReconnecting);
 const isBulkReconnecting = createSelector(state, (state) => state.isBulkReconnecting);
 const isAuthorizing = createSelector(state, (state) => state.isAuthorizing);
 const isBulkAuthorizing = createSelector(state, (state) => state.isBulkAuthorizing);
+const listRefreshToken = createSelector(state, (state) => state.listRefreshToken);
 const isRunningCallback = createSelector(state, (state) => state.isRunningCallback);
 
 export const selectors = {
@@ -595,6 +604,7 @@ export const selectors = {
     isAuthorizing,
     isBulkAuthorizing,
     isRunningCallback,
+    listRefreshToken,
 };
 
 export const actions = slice.actions;

--- a/src/ducks/secrets-epics.spec.ts
+++ b/src/ducks/secrets-epics.spec.ts
@@ -149,7 +149,7 @@ describe('secrets epics', () => {
         expect(emitted[1]).toEqual(appRedirectActions.fetchError({ error: err, message: 'Failed to get Secret content' }));
     });
 
-    test('createSecret success emits createSecretSuccess, redirect and success alert', async () => {
+    test('createSecret success redirects to the inventory without listing it, leaving that to the host', async () => {
         const payload = {
             vaultUuid: 'v-1',
             vaultProfileUuid: 'vp-1',
@@ -160,12 +160,13 @@ describe('secrets epics', () => {
                 attributes: [],
             } as any,
         };
-        const emitted = await runEpic(SecretsEpicIndex.Create, secretsActions.createSecret(payload), {}, 4);
+        const emitted = await runEpic(SecretsEpicIndex.Create, secretsActions.createSecret(payload), {}, 3);
 
         expect(emitted[0].type).toBe(secretsActions.createSecretSuccess.type);
-        expect(emitted[1]).toEqual(secretsActions.listSecrets({ pageNumber: 1, itemsPerPage: 10, filters: [] }));
-        expect(emitted[2]).toEqual(appRedirectActions.redirect({ url: '/secrets' }));
-        expect(emitted[3]).toEqual(alertActions.success('Secret created successfully.'));
+        expect(emitted[1]).toEqual(appRedirectActions.redirect({ url: '/secrets' }));
+        expect(emitted[2]).toEqual(alertActions.success('Secret created successfully.'));
+        // The inventory lists under the columns and ordering it owns, which this request could not name.
+        expect(emitted.some((action: any) => action.type === secretsActions.listSecrets.type)).toBe(false);
     });
 
     test('deleteSecret success emits deleteSecretSuccess and info fetchError', async () => {

--- a/src/ducks/secrets-epics.ts
+++ b/src/ducks/secrets-epics.ts
@@ -372,10 +372,12 @@ const createSecret: AppEpic = (action$, state$, deps) => {
                     secretRequestDto: action.payload.request,
                 })
                 .pipe(
+                    // No listing is issued here: the redirect mounts the inventory, which lists under the
+                    // columns and ordering it owns. A request assembled here would carry neither, and
+                    // would race the host's own — leaving whichever landed last on screen.
                     mergeMap((secret) =>
                         of(
                             slice.actions.createSecretSuccess({ secret }),
-                            slice.actions.listSecrets({ pageNumber: 1, itemsPerPage: 10, filters: [] }),
                             appRedirectActions.redirect({ url: '/secrets' }),
                             alertActions.success('Secret created successfully.'),
                         ),

--- a/src/ducks/signing-records-epics.spec.ts
+++ b/src/ducks/signing-records-epics.spec.ts
@@ -156,7 +156,7 @@ describe('signingRecords epics', () => {
         expect(emitted[1].type).toBe(alertsSlice.actions.success.type);
     });
 
-    test('bulkDeleteSigningRecords success (no errors, page unchanged) emits success, alert and a re-fetch without setPagination', async () => {
+    test('bulkDeleteSigningRecords success emits success and alert, and re-reads through the host rather than listing here', async () => {
         const deps = createDeps({
             bulkDeleteSigningRecords: ({ requestBody }) => {
                 expect(requestBody).toEqual(['rec-1', 'rec-2']);
@@ -165,7 +165,7 @@ describe('signingRecords epics', () => {
         });
 
         // On page 1 with 5 items, deleting 2 still leaves page 1 populated, so the page does not
-        // shift and no setPagination is dispatched — only the re-fetch of the current page.
+        // shift and no setPagination is dispatched.
         const state$ = {
             value: {
                 pagings: {
@@ -187,11 +187,12 @@ describe('signingRecords epics', () => {
             state$,
             deps as any,
         );
-        const emitted = await firstValueFrom(output$.pipe(take(3), toArray()));
+        const emitted = await firstValueFrom(output$.pipe(take(2), toArray()));
 
         expect(emitted[0]).toEqual(slice.actions.bulkDeleteSigningRecordsSuccess({ uuids: ['rec-1', 'rec-2'], errors: [] }));
         expect(emitted[1].type).toBe(alertsSlice.actions.success.type);
-        expect(emitted[2]).toEqual(slice.actions.listSigningRecords({ pageNumber: 1, itemsPerPage: 10, filters: [] }));
+        // The listing is the host's to issue: only its own request names the applied columns and ordering.
+        expect(emitted.some((a: any) => a.type === slice.actions.listSigningRecords.type)).toBe(false);
         expect(emitted.some((a: any) => a.type === pagingActions.setPagination.type)).toBe(false);
     });
 
@@ -222,15 +223,15 @@ describe('signingRecords epics', () => {
             state$,
             deps as any,
         );
-        const emitted = await firstValueFrom(output$.pipe(take(4), toArray()));
+        const emitted = await firstValueFrom(output$.pipe(take(3), toArray()));
 
         expect(emitted[2]).toEqual(pagingActions.setPagination({ entity: EntityType.SIGNING_RECORD, pageNumber: 1, pageSize: 5 }));
-        expect(emitted[3]).toEqual(slice.actions.listSigningRecords({ pageNumber: 1, itemsPerPage: 5, filters: [] }));
+        expect(emitted.some((a: any) => a.type === slice.actions.listSigningRecords.type)).toBe(false);
     });
 
-    test('bulkDeleteSigningRecords with partial errors re-fetches the list without a success alert', async () => {
-        // rec-1 fails, rec-2 is deleted server-side. Since the reducers no longer splice locally,
-        // the deleted row must be removed by a re-fetch — but with no success alert.
+    test('bulkDeleteSigningRecords with partial errors reports the failures without a success alert', async () => {
+        // rec-1 fails, rec-2 is deleted server-side. The deleted row goes when the host re-reads on the
+        // refresh token the success reducer bumps — but there is no success alert.
         const errors = [{ uuid: 'rec-1', name: 'rec-1', message: 'In use' }] as any;
         const deps = createDeps({ bulkDeleteSigningRecords: () => of(errors) });
 
@@ -253,10 +254,10 @@ describe('signingRecords epics', () => {
             state$,
             deps as any,
         );
-        const emitted = await firstValueFrom(output$.pipe(take(4), toArray()));
+        const emitted = await firstValueFrom(output$.pipe(toArray()));
 
         expect(emitted[0]).toEqual(slice.actions.bulkDeleteSigningRecordsSuccess({ uuids: ['rec-1', 'rec-2'], errors }));
-        expect(emitted.some((a: any) => a.type === slice.actions.listSigningRecords.type)).toBe(true);
+        expect(emitted.some((a: any) => a.type === slice.actions.listSigningRecords.type)).toBe(false);
         expect(emitted.some((a: any) => a.type === alertsSlice.actions.success.type)).toBe(false);
         expect(emitted.some((a: any) => a.type === pagingActions.setPagination.type)).toBe(false);
     });

--- a/src/ducks/signing-records-epics.ts
+++ b/src/ducks/signing-records-epics.ts
@@ -151,8 +151,10 @@ const bulkDeleteSigningRecords: AppEpic = (action$, state, deps) => {
                         // Success alert only when every selected record was deleted; partial
                         // failures surface through bulkDeleteErrorMessages instead.
                         ...(errors.length === 0 ? [alertsSlice.actions.success('Selected Signing Records successfully deleted.')] : []),
-                        // Only re-align the paging slice when the deletion emptied the current page
-                        // and we had to step back; otherwise the re-fetch below is enough.
+                        // Only re-align the paging slice when the deletion emptied the current page and
+                        // we had to step back. The re-read itself rides on the refresh token that
+                        // `bulkDeleteSigningRecordsSuccess` bumps, so the host replays its own request —
+                        // columns and ordering included — rather than one assembled from paging here.
                         ...(pageNumberChanged
                             ? [
                                   pagingActions.setPagination({
@@ -162,7 +164,6 @@ const bulkDeleteSigningRecords: AppEpic = (action$, state, deps) => {
                                   }),
                               ]
                             : []),
-                        slice.actions.listSigningRecords(listParams),
                     );
                 }),
                 catchError((err) =>

--- a/src/ducks/signing-records.spec.ts
+++ b/src/ducks/signing-records.spec.ts
@@ -113,12 +113,13 @@ describe('signingRecords slice', () => {
         const next = reducer(state, actions.bulkDeleteSigningRecordsSuccess({ uuids: ['rec-1', 'rec-3'], errors: [] }));
 
         expect(next.isBulkDeleting).toBe(false);
-        // Bulk delete no longer touches the list or the deleted-uuid signal — the epic re-fetches
-        // from the server (deletedSigningRecordUuids is only used by the detail page's single delete).
+        // Bulk delete no longer touches the list or the deleted-uuid signal — the host re-reads on the
+        // bumped refresh token (deletedSigningRecordUuids is only used by the detail page's single delete).
         expect(next.deletedSigningRecordUuids).toEqual([]);
         expect(next.signingRecordsData?.items).toEqual([{ uuid: 'rec-1' }, { uuid: 'rec-2' }, { uuid: 'rec-3' }]);
         expect(next.signingRecordsData?.totalItems).toBe(3);
         expect(next.bulkDeleteErrorMessages).toEqual([]);
+        expect(next.listRefreshToken).toBe(initialState.listRefreshToken + 1);
     });
 
     test('bulkDeleteSigningRecords success with errors stores messages and keeps items', () => {
@@ -142,6 +143,20 @@ describe('signingRecords slice', () => {
         expect(next.deletedSigningRecordUuids).toEqual([]);
         expect(next.signingRecordsData?.items).toEqual([{ uuid: 'rec-1' }, { uuid: 'rec-2' }]);
         expect(next.signingRecordsData?.totalItems).toBe(2);
+        // rec-2 was deleted, so the listing still has to be re-read.
+        expect(next.listRefreshToken).toBe(initialState.listRefreshToken + 1);
+    });
+
+    test('bulk delete with every item failing asks for no re-read', () => {
+        const errors = [
+            { uuid: 'rec-1', name: 'rec-1', message: 'In use' },
+            { uuid: 'rec-2', name: 'rec-2', message: 'In use' },
+        ] as any;
+
+        const next = reducer(initialState, actions.bulkDeleteSigningRecordsSuccess({ uuids: ['rec-1', 'rec-2'], errors }));
+
+        expect(next.bulkDeleteErrorMessages).toEqual(errors);
+        expect(next.listRefreshToken).toBe(initialState.listRefreshToken);
     });
 
     test('clearDeleteErrorMessages resets bulk delete error messages', () => {

--- a/src/ducks/signing-records.ts
+++ b/src/ducks/signing-records.ts
@@ -23,6 +23,9 @@ export type State = {
     isFetchingSearchableFields: boolean;
     isDeleting: boolean;
     isBulkDeleting: boolean;
+
+    /** Bumped whenever a mutation needs the listing re-read; the page forwards it as `refreshToken`. */
+    listRefreshToken: number;
 };
 
 export const initialState: State = {
@@ -35,6 +38,8 @@ export const initialState: State = {
     isFetchingSearchableFields: false,
     isDeleting: false,
     isBulkDeleting: false,
+
+    listRefreshToken: 0,
 };
 
 export const slice = createSlice({
@@ -142,10 +147,16 @@ export const slice = createSlice({
         bulkDeleteSigningRecordsSuccess: (state, action: PayloadAction<{ uuids: string[]; errors: BulkActionMessageDto[] }>) => {
             state.isBulkDeleting = false;
 
-            // On success the epic re-fetches the list from the server, so no optimistic
-            // list mutation is needed here — we only surface any per-item failures.
-            if (action.payload.errors?.length > 0) {
-                state.bulkDeleteErrorMessages = action.payload.errors;
+            const errors = action.payload.errors ?? [];
+            if (errors.length > 0) {
+                state.bulkDeleteErrorMessages = errors;
+            }
+
+            // The host re-reads its own request rather than this slice pruning the rows: the request
+            // carries the applied columns and ordering, which a list action assembled elsewhere cannot.
+            // Nothing deleted means nothing to re-read — every uuid came back as a per-item failure.
+            if (action.payload.uuids.length > errors.length) {
+                state.listRefreshToken += 1;
             }
         },
 
@@ -178,6 +189,7 @@ export const selectIsFetchingDetail = createSelector(featureSelector, (state) =>
 export const selectIsFetchingSearchableFields = createSelector(featureSelector, (state) => state.isFetchingSearchableFields);
 export const selectIsDeleting = createSelector(featureSelector, (state) => state.isDeleting);
 export const selectIsBulkDeleting = createSelector(featureSelector, (state) => state.isBulkDeleting);
+export const selectListRefreshToken = createSelector(featureSelector, (state) => state.listRefreshToken);
 
 export const selectors = {
     selectSigningRecordsData,
@@ -193,6 +205,7 @@ export const selectors = {
     selectIsFetchingSearchableFields,
     selectIsDeleting,
     selectIsBulkDeleting,
+    selectListRefreshToken,
 };
 
 export const { actions } = slice;

--- a/src/utils/listViews.spec.ts
+++ b/src/utils/listViews.spec.ts
@@ -323,6 +323,18 @@ describe('toStandardSlice', () => {
     it('is the platform columns with no filters and no ordering of its own', () => {
         expect(toStandardSlice(standardColumns)).toEqual({ columns: standardColumns, filters: [], sort: undefined });
     });
+
+    it('carries the ordering the page declares as its default', () => {
+        const sort = { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME', direction: SortDirection.Asc };
+
+        expect(toStandardSlice(standardColumns, sort)).toEqual({ columns: standardColumns, filters: [], sort });
+    });
+
+    it('reads a page under its declared ordering as clean, so Standard is not born drifted', () => {
+        const sort = { fieldSource: FilterFieldSource.Property, fieldIdentifier: 'COMMON_NAME', direction: SortDirection.Asc };
+
+        expect(isSliceDirty(toStandardSlice(standardColumns, sort), { columns: standardColumns, filters: [], sort })).toBe(false);
+    });
 });
 
 describe('isSliceDirty', () => {

--- a/src/utils/listViews.ts
+++ b/src/utils/listViews.ts
@@ -290,9 +290,16 @@ export function toViewSlice(
     };
 }
 
-/** The Standard tab's own slice: the platform columns, no filters and no ordering of its own. */
-export function toStandardSlice(standardColumns: readonly ColumnDefinition[]): ViewSlice {
-    return { columns: [...standardColumns], filters: [], sort: undefined };
+/**
+ * The Standard tab's own slice: the platform columns, no filters, and the ordering the page declares
+ * as its default.
+ *
+ * The ordering belongs to Standard rather than being an opening value the first render happens to
+ * hold. Applying Standard is what a page load, a tab switch back and a reset all go through, so an
+ * ordering held anywhere else is cleared by the first of them and never comes back.
+ */
+export function toStandardSlice(standardColumns: readonly ColumnDefinition[], sort?: ColumnSort): ViewSlice {
+    return { columns: [...standardColumns], filters: [], sort };
 }
 
 /** A column list reduced to what a view actually stores, so two can be compared for equality. */


### PR DESCRIPTION
The certificate and key inventories proved the column pipeline in #2104. This takes it to the five that remain: discoveries, connectors, secrets, CBOMs and signing records.

Each page moves from a hardcoded header set and a positional row builder to a platform default column set plus a cell registry keyed by field identifier. Nothing new is designed — the picker, the view tabs, the render registry and the sortable headers already exist.

## Default column sets

Every default set is the columns that page already shipped, in the same order, so a user who never opens the picker sees no change.

Column headings are split across the two label fields the pipeline already has. `catalogueLabel` carries core's own wording, because `resolveColumns` refreshes it from the live catalogue; `label` carries the heading the page shipped, because that is the override the pipeline stores and preserves. Setting only `catalogueLabel` would have left the headings correct on the Standard tab and silently changed once a user duplicated it into a view.

Connectors build their set rather than declare it: the proxy column sits behind `featureFlags.isProxiesEnabled`, so a build with proxies off must not ship the column at all rather than ship it empty.

## What the registry decides

A catalogued field with no renderer is one the listing cannot supply, and the registry is what decides whether the picker offers a property column. Three fields across these inventories are catalogued but absent from their listing DTO — `SIGNING_RECORD_SIGNED_DOCUMENT_RETRIEVED_AT`, `SECRET_SYNC_VAULT_PROFILE` — so no renderer is registered and the picker does not offer them.

## Display-only columns

Three columns have no `FilterField` behind them: the discovery duration, computed from two timestamps; the secret version; and the connector proxy. Each is shown but not offered by the picker, and `toStorableColumns` drops it from a saved view on write.

The CBOM copy and download buttons are deliberately **not** one of these. An uncatalogued column is stripped from a saved view on write and the picker cannot offer it back, so a column of their own would leave every saved view on that inventory without any copy or download affordance. They ride in the serial-number cell instead, the way the certificate pending actions ride in the state cell.

## Default ordering

`ConfigurableColumns` gains an optional `defaultSort`. Connectors and discoveries both opened sorted by name, which `CustomTable` applied client-side; a column-driven table hands sorting to the server, so without naming the ordering both pages would have opened in API order with no sort arrow. The field is optional and additive — a page that does not set it behaves exactly as before.

Sortability comes from the filter-field catalogue, which arrives after the first render, and `toDisplayableSort` drops an ordering whose column is not marked sortable. So the declared ordering needs `withDeclaredSortability` to mark its column while the catalogue is unread, or the first listing request goes out in API order and a second one corrects it. A page naming a `defaultSort` asserts the API can order by that column, which is the same assertion its static column set already makes; `withCatalogueSortability` still overrules it once the catalogue is read.

The ordering is then carried by the Standard slice rather than held as an opening value, because applying Standard is what a page load, a switch back to the tab and a reset all go through — the tab strip applies that slice once its view list and the catalogue have settled, so an ordering held anywhere else is cleared a moment after the page appears. Drift and the reset action are measured against it too, so a page that opens sorted is not reported as changed. Only Standard carries it: a saved view storing no ordering still applies none, or an ordering could never be removed from a view.

## Refreshing after a mutation

A column-driven listing request carries the applied columns and ordering, so a post-mutation refetch cannot assemble its own from paging and filters — it would drop the ordering, and a column added through the picker resolves from projected attribute values that arrive only when the request names it.

Each refetch on these five inventories therefore goes through the host. A mutation the page owns bumps a local token, as the key inventory does: CBOM upload, CBOM sync and discovery create, each alongside the filter and paging reset that puts the new row on the listed page. A mutation an epic owns bumps a token in its slice for the page to forward, as the certificate inventory does: CBOM and signing-record bulk delete, and connector approve. The step back onto a page a deletion emptied is unchanged, and signing records bump only when something was actually deleted. Secret create stops listing altogether — it fired immediately before the redirect to the inventory, racing the request that inventory issues on mount.

## Tests

`inventoryColumns.unit.spec.tsx` table-drives all five inventories and pins four things: every shipped column has a renderer, only the known display-only identifiers sit outside the catalogue, the default set survives a save, and no renderer names a field that exists nowhere. `PagedList.unit.spec.tsx` covers the new default ordering reaching the listing request, both with the catalogue already read and before it has been, where it also pins that the catalogue read adds no second listing. `columnState.spec.ts` covers `withDeclaredSortability` on its own. `PagedListColumns.spec.tsx` covers the declared ordering surviving the Standard view opening over it, the reset returning to it, and a page under it reporting no drift. The duck and epic specs pin that each mutation bumps its refresh token and issues no listing of its own.

Closes #2067

